### PR TITLE
Add OpenBuildings Part Class

### DIFF
--- a/Domains/Building/BuildingDataGroupBase/BuildingDataGroupBase.ecschema.xml
+++ b/Domains/Building/BuildingDataGroupBase/BuildingDataGroupBase.ecschema.xml
@@ -1,20 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ==================================================================================
-|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-|  * See LICENSE.md in the project root for license terms and full copyright notice.
-======================================================================================= -->
-<ECSchema schemaName="BuildingDataGroupBase" alias="bdgb" version="01.00.00" description="ABD Static Schema" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
-    <ECSchemaReference name="BisCore" version="01.00.00" alias="bis"/>
-    <PropertyCategory typeName="BuildingPropertiesCategory" displayLabel="Properties" description="Properties for Building Components" priority="0"/>
+<ECSchema schemaName="BuildingDataGroupBase" alias="bdgb" version="01.00.01" description="ABD Static Schema" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <PropertyCategory typeName="BuildingPropertiesCategory" displayLabel="Part and Family" description="Properties for OpenBuildings Components" priority="0"/>
 
     <ECStructClass typeName="TriformaIdentity">
-        <ECProperty propertyName="PART" typeName="string" displayLabel="Part" category="BuildingPropertiesCategory" description="Open Buildings Designer part" >
-        </ECProperty>
-        <ECProperty propertyName="FAMILY" typeName="string" displayLabel="Family" description="Open Buildings Designer part family">
-        </ECProperty>
+        <ECProperty propertyName="PART"   typeName="string" displayLabel="Part"   category="BuildingPropertiesCategory" description="Open Buildings Designer Part" />
+        <ECProperty propertyName="FAMILY" typeName="string" displayLabel="Family" category="BuildingPropertiesCategory" description="Open Buildings Designer Part Family"/>
     </ECStructClass>
+
     <ECEntityClass typeName="TriformaPhysical">
         <BaseClass>bis:PhysicalElement</BaseClass>
         <ECStructProperty propertyName="identity" typeName="TriformaIdentity"/>
     </ECEntityClass>
+    
+    <ECEntityClass typeName="Part" description="Named set of properties that affect the display of OpenBuildingsDesigner elements in various contexts (placement, rendering, drawing).">
+        <BaseClass>bis:DefinitionElement</BaseClass>
+        <ECProperty propertyName="Name"                 typeName="string"  displayLabel="Part identifier"          description="Name of an OpenBuildings Part, unique within it's part Family." />
+        <ECProperty propertyName="FamilyName"           typeName="string"  displayLabel="Part Family identifier"   description="The Family of this part. Families group parts for easy navigation." />
+        <ECProperty propertyName="Description"          typeName="string"  displayLabel="Description"              description="Named set of properties that affect the display of OpenBuildingsDesigner elements in various contexts (placement, rendering, drawing)." />
+        <ECProperty propertyName="RenderPaletteName"    typeName="string"  displayLabel="Pallete Name Identifier"  description="Name of the palette containing the rendering material." />
+        <ECProperty propertyName="RenderMaterialName"   typeName="string"  displayLabel="Material Name Identifier" description="Name of the rendering material (unique within the pallete)." />
+        <ECProperty propertyName="RenderMaterialActive" typeName="boolean" displayLabel="Pallete Name Identifier"  description="Name of the palette containing the rendering material." />
+    </ECEntityClass> 
+    
 </ECSchema>

--- a/Domains/Building/BuildingDataGroupBase/BuildingDataGroupBase.ecschema.xml
+++ b/Domains/Building/BuildingDataGroupBase/BuildingDataGroupBase.ecschema.xml
@@ -20,7 +20,7 @@
         <ECProperty propertyName="Description"          typeName="string"  displayLabel="Description"              description="Named set of properties that affect the display of OpenBuildingsDesigner elements in various contexts (placement, rendering, drawing)." />
         <ECProperty propertyName="RenderPaletteName"    typeName="string"  displayLabel="Pallete Name Identifier"  description="Name of the palette containing the rendering material." />
         <ECProperty propertyName="RenderMaterialName"   typeName="string"  displayLabel="Material Name Identifier" description="Name of the rendering material (unique within the pallete)." />
-        <ECProperty propertyName="RenderMaterialActive" typeName="boolean" displayLabel="Pallete Name Identifier"  description="Name of the palette containing the rendering material." />
+        <ECProperty propertyName="RenderMaterialActive" typeName="boolean" displayLabel="Render Material Active"   description="Render Material is enabled for this Part." />
     </ECEntityClass> 
     
 </ECSchema>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -2289,7 +2289,7 @@
       "name": "BuildingDataGroupBase",
       "path": "Domains\\Building\\BuildingDataGroupBase\\BuildingDataGroupBase.ecschema.xml",
       "released": false,
-      "version": "01.00.00",
+      "version": "01.00.01",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",


### PR DESCRIPTION
OpenBuildings products refer to "Part" instances from every element. "Parts" define resymbolization behavior and are stored in the workspace. By Persisting the Parts in the itwin we can monitor changes and update resymbolization when needed.