### PR TITLE
Concept station segment assemblies

### DIFF
--- a/Domains/Civil/Connectors/ConceptStation/CSSegments.ecschema.xml
+++ b/Domains/Civil/Connectors/ConceptStation/CSSegments.ecschema.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CSSegments" alias="csseg" version="01.00.00" description="iModel Bridge schema for segment data from the ConceptStation application." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECSchemaReference name="Formats" version="01.00.00" alias="f"/>
+    <ECSchemaReference name="Units" version="01.00.05" alias="u"/>
+    <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU"/>
+
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+    </ECCustomAttributes>
+
+    <Format typeName="DefaultCurrency" displayLabel="real" type="decimal" precision="2" formatTraits="trailZeroes|zeroEmpty|keepDecimalPoint|showUnitLabel|prependUnitLabel|use1000Separator"/>
+
+    <KindOfQuantity typeName="STATION" displayLabel="Station" persistenceUnit="u:M" presentationUnits="f:StationZ_1000_3[u:M];f:StationZ_100_2[u:FT];f:StationZ_100_2[u:US_SURVEY_FT];f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>
+    <KindOfQuantity typeName="COST" displayLabel="Cost" persistenceUnit="u:US_DOLLAR" presentationUnits="DefaultCurrency[u:US_DOLLAR]" relativeError="0.001"/>
+    
+    <ECEntityClass typeName="SegmentAssembly" modifier="Abstract" displayLabel="Segment Assembly" description="Base class for groups of components, such as road segments, transition segments, intersections, etc.">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <BaseClass>bis:IParentElement</BaseClass>
+        <ECCustomAttributes>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.00"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="StartStation" displayLabel="Start Station" typeName="double" kindOfQuantity="STATION" description="The starting station of the assembly along the associated alignment."/>
+        <ECProperty propertyName="EndStation" displayLabel="End Station" typeName="double" kindOfQuantity="STATION" description="The ending station of the assembly along the associated alignment."/>
+    </ECEntityClass>
+    <ECEntityClass typeName="RoadSegment" modifier="Sealed" displayLabel="Road Segment" description="A physical stretch of roadway that groups all components across its width." >
+        <BaseClass>SegmentAssembly</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="TransitionSegment" modifier="Sealed" displayLabel="Transition Segment" description="A physical stretch of roadway whose composition of components changes from one end to the other." >
+        <BaseClass>SegmentAssembly</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Intersection" modifier="Sealed" displayLabel="Intersection" description="A physical stretch of roadway where two or more legs intersect." >
+        <BaseClass>SegmentAssembly</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BridgeSegment" modifier="Sealed" displayLabel="Bridge Segment" description="A physical stretch of bridge that groups all components across its width." >
+        <BaseClass>SegmentAssembly</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="TunnelSegment" modifier="Sealed" displayLabel="Tunnel Segment" description="A physical stretch of tunnel that groups all components across its width." >
+        <BaseClass>SegmentAssembly</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="HyperloopSegment" modifier="Sealed" displayLabel="Hyperloop Segment" description="A physical stretch of hyperloop that groups all components across its width." >
+        <BaseClass>SegmentAssembly</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Furniture" modifier="Sealed" displayLabel="Furniture" description="A physical piece of furniture.">
+        <BaseClass>SegmentAssembly</BaseClass>
+        <ECProperty propertyName="StartStation" typeName="double">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndStation" typeName="double">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="Culvert" modifier="Sealed" displayLabel="Culvert" description="A physical culvert structure.">
+        <BaseClass>SegmentAssembly</BaseClass>
+        <ECProperty propertyName="StartStation" typeName="double">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndStation" typeName="double">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="CADModeling" modifier="Sealed" displayLabel="CAD Modeling" description="A physical structure modeling with CAD shapes.">
+        <BaseClass>SegmentAssembly</BaseClass>
+        <ECProperty propertyName="StartStation" typeName="double">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndStation" typeName="double">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="PayItemQuantityAspect" displayLabel="Pay Item Quantity Aspect" description="A bis:ElementMultiAspect that stores common pay item data for segments.">
+        <BaseClass>bis:ElementMultiAspect</BaseClass>
+        <ECProperty propertyName="UnitCodeGroupLabel" displayLabel="Category" typeName="string" description="The label of the unit cost group."/>
+        <ECProperty propertyName="QuantityCode" displayLabel="Code" typeName="string" description="The code of the quantity."/>
+        <ECProperty propertyName="QuantityLabel" displayLabel="Item" typeName="string" description="The label of the quantity."/>
+        <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" description="The value of the quantity."/>
+        <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit."/>
+        <ECProperty propertyName="Cost" displayLabel="Cost" typeName="double" kindOfQuantity="COST" description="The cost of the quantity."/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemQuantityAspects" strength="embedding" modifier="None">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="SegmentAssembly"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="true">
+            <Class class="PayItemQuantityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PayItemLengthAspect" displayLabel="Pay Item Length Aspect" description="A bis:ElementMultiAspect that stores common pay item data in terms of lengths of segments.">
+        <BaseClass>PayItemQuantityAspect</BaseClass>
+        <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" kindOfQuantity="AECU:LENGTH" description="The length of the segment."/>
+        <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit length."/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemLengthAspects" strength="embedding" modifier="None">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="SegmentAssembly"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="true">
+            <Class class="PayItemLengthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PayItemAreaAspect" displayLabel="Pay Item Area Aspect" description="A bis:ElementMultiAspect that stores common pay item data in terms of areas of segments.">
+        <BaseClass>PayItemQuantityAspect</BaseClass>
+        <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" kindOfQuantity="AECU:AREA" description="The area of the segment."/>
+        <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit area."/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemAreaAspects" strength="embedding" modifier="None">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="SegmentAssembly"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="true">
+            <Class class="PayItemAreaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PayItemVolumeAspect" displayLabel="Pay Item Volume Aspect" description="A bis:ElementMultiAspect that stores common pay item data in terms of volumes of segments.">
+        <BaseClass>PayItemQuantityAspect</BaseClass>
+        <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" kindOfQuantity="AECU:VOLUME" description="The volume of the segment."/>
+        <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit volume."/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemVolumeAspects" strength="embedding" modifier="None">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="SegmentAssembly"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="true">
+            <Class class="PayItemVolumeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PayItemCountAspect" displayLabel="Pay Item Count Aspect" description="A bis:ElementMultiAspect that stores common pay item data in terms of counts for segments.">
+        <BaseClass>PayItemQuantityAspect</BaseClass>
+        <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" description="The count of the segment."/>
+        <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit count."/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemCountAspects" strength="embedding" modifier="None">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="SegmentAssembly"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="true">
+            <Class class="PayItemCountAspect"/>
+        </Target>
+    </ECRelationshipClass>
+
+</ECSchema>

--- a/Domains/Civil/Connectors/ConceptStation/CSSegments.ecschema.xml
+++ b/Domains/Civil/Connectors/ConceptStation/CSSegments.ecschema.xml
@@ -7,9 +7,8 @@
 
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
-    <ECSchemaReference name="Formats" version="01.00.00" alias="f"/>
-    <ECSchemaReference name="Units" version="01.00.05" alias="u"/>
     <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU"/>
+    <ECSchemaReference name="CSUnits" version="01.00.00" alias="csu"/>
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -17,19 +16,14 @@
         </ProductionStatus>
     </ECCustomAttributes>
 
-    <Unit typeName="MONETARY_UNIT" phenomenon="u:CURRENCY" unitSystem="u:SI" definition="MONETARY_UNIT" displayLabel="¤" description="For money of an unspecified denomination"/>
-
-    <KindOfQuantity typeName="STATION" displayLabel="Station" persistenceUnit="u:M" presentationUnits="f:StationZ_1000_3[u:M];f:StationZ_100_2[u:FT];f:StationZ_100_2[u:US_SURVEY_FT];f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>
-    <KindOfQuantity typeName="CURRENCY" displayLabel="ConceptStation Product Currency" persistenceUnit="MONETARY_UNIT" presentationUnits="f:DefaultRealU(2)[MONETARY_UNIT|$]" relativeError="0.0001"/>
-    
     <ECEntityClass typeName="SegmentAssembly" modifier="Abstract" displayLabel="Segment Assembly" description="Base class for groups of components, such as road segments, transition segments, intersections, etc.">
         <BaseClass>bis:PhysicalElement</BaseClass>
         <BaseClass>bis:IParentElement</BaseClass>
         <ECCustomAttributes>
             <HiddenClass xmlns="CoreCustomAttributes.01.00.00"/>
         </ECCustomAttributes>
-        <ECProperty propertyName="StartStation" displayLabel="Start Station" typeName="double" kindOfQuantity="STATION" description="The starting station of the assembly along the associated alignment."/>
-        <ECProperty propertyName="EndStation" displayLabel="End Station" typeName="double" kindOfQuantity="STATION" description="The ending station of the assembly along the associated alignment."/>
+        <ECProperty propertyName="StartStation" displayLabel="Start Station" typeName="double" kindOfQuantity="csu:STATION" description="The starting station of the assembly along the associated alignment."/>
+        <ECProperty propertyName="EndStation" displayLabel="End Station" typeName="double" kindOfQuantity="csu:STATION" description="The ending station of the assembly along the associated alignment."/>
     </ECEntityClass>
     <ECEntityClass typeName="RoadSegment" modifier="Sealed" displayLabel="Road Segment" description="A physical stretch of roadway that groups all components across its width." >
         <BaseClass>SegmentAssembly</BaseClass>
@@ -96,7 +90,7 @@
         <ECProperty propertyName="QuantityLabel" displayLabel="Item" typeName="string" description="The label of the quantity."/>
         <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" description="The value of the quantity."/>
         <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit."/>
-        <ECProperty propertyName="Cost" displayLabel="Cost" typeName="double" kindOfQuantity="CURRENCY" description="The cost of the quantity."/>
+        <ECProperty propertyName="Cost" displayLabel="Cost" typeName="double" kindOfQuantity="csu:CURRENCY" description="The cost of the quantity."/>
     </ECEntityClass>
     <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemQuantityAspects" strength="embedding" modifier="None">
         <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>

--- a/Domains/Civil/Connectors/ConceptStation/CSSegments.ecschema.xml
+++ b/Domains/Civil/Connectors/ConceptStation/CSSegments.ecschema.xml
@@ -17,10 +17,10 @@
         </ProductionStatus>
     </ECCustomAttributes>
 
-    <Format typeName="DefaultCurrency" displayLabel="real" type="decimal" precision="2" formatTraits="trailZeroes|zeroEmpty|keepDecimalPoint|showUnitLabel|prependUnitLabel|use1000Separator"/>
+    <Unit typeName="MONETARY_UNIT" phenomenon="u:CURRENCY" unitSystem="u:SI" definition="MONETARY_UNIT" displayLabel="¤" description="For money of an unspecified denomination"/>
 
     <KindOfQuantity typeName="STATION" displayLabel="Station" persistenceUnit="u:M" presentationUnits="f:StationZ_1000_3[u:M];f:StationZ_100_2[u:FT];f:StationZ_100_2[u:US_SURVEY_FT];f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>
-    <KindOfQuantity typeName="COST" displayLabel="Cost" persistenceUnit="u:US_DOLLAR" presentationUnits="DefaultCurrency[u:US_DOLLAR]" relativeError="0.001"/>
+    <KindOfQuantity typeName="CURRENCY" displayLabel="ConceptStation Product Currency" persistenceUnit="MONETARY_UNIT" presentationUnits="f:DefaultRealU(2)[MONETARY_UNIT|$]" relativeError="0.0001"/>
     
     <ECEntityClass typeName="SegmentAssembly" modifier="Abstract" displayLabel="Segment Assembly" description="Base class for groups of components, such as road segments, transition segments, intersections, etc.">
         <BaseClass>bis:PhysicalElement</BaseClass>
@@ -96,7 +96,7 @@
         <ECProperty propertyName="QuantityLabel" displayLabel="Item" typeName="string" description="The label of the quantity."/>
         <ECProperty propertyName="QuantityValue" displayLabel="Quantity" typeName="double" description="The value of the quantity."/>
         <ECProperty propertyName="Rate" displayLabel="Rate" typeName="double" description="The rate per unit."/>
-        <ECProperty propertyName="Cost" displayLabel="Cost" typeName="double" kindOfQuantity="COST" description="The cost of the quantity."/>
+        <ECProperty propertyName="Cost" displayLabel="Cost" typeName="double" kindOfQuantity="CURRENCY" description="The cost of the quantity."/>
     </ECEntityClass>
     <ECRelationshipClass typeName="SegmentAssemblyOwnsPayItemQuantityAspects" strength="embedding" modifier="None">
         <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>

--- a/Domains/Civil/Connectors/ConceptStation/CSSegments.remarks.md
+++ b/Domains/Civil/Connectors/ConceptStation/CSSegments.remarks.md
@@ -1,0 +1,9 @@
+---
+remarksTarget: CSSegments.ecschema.md
+---
+
+# CSSegments
+
+iModel Connector schema used by the ConceptStation iModel Connector while publishing datasets from the ConceptStation application. The classes contained within this schema aim to provide a similar user-experience with respect to properties in the source ConceptStation application, as well as make its data available for re-purposing. 
+
+This schema should not be considered the aligned BIS schema for any particular domain.

--- a/Domains/Civil/Connectors/ConceptStation/CSUnits.ecschema.xml
+++ b/Domains/Civil/Connectors/ConceptStation/CSUnits.ecschema.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CSUnits" alias="csu" version="01.00.00" description="Unit definitions that are used across ConceptStation (CS) iModel Connector schemas" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECSchemaReference name="Formats" version="01.00.00" alias="f"/>
+    <ECSchemaReference name="Units" version="01.00.05" alias="u"/>
+
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+    </ECCustomAttributes>
+
+    <Unit typeName="MONETARY_UNIT" phenomenon="u:CURRENCY" unitSystem="u:SI" definition="MONETARY_UNIT" displayLabel="¤" description="For money of an unspecified denomination"/>
+
+    <KindOfQuantity typeName="STATION" displayLabel="Station" persistenceUnit="u:M" presentationUnits="f:StationZ_1000_3[u:M];f:StationZ_100_2[u:FT];f:StationZ_100_2[u:US_SURVEY_FT];f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>
+    <KindOfQuantity typeName="CURRENCY" displayLabel="ConceptStation Product Currency" persistenceUnit="MONETARY_UNIT" presentationUnits="f:DefaultRealU(2)[MONETARY_UNIT|$]" relativeError="0.0001"/>
+
+</ECSchema>

--- a/Domains/Civil/Connectors/ConceptStation/CSUnits.remarks.md
+++ b/Domains/Civil/Connectors/ConceptStation/CSUnits.remarks.md
@@ -1,0 +1,9 @@
+---
+remarksTarget: CSUnits.ecschema.md
+---
+
+# CSUnits
+
+Contains the main Kind of Quantities used by the ConceptStation application. They aim to provide a similar user-experience with respect to the source application properties.
+
+This schema should not be considered the aligned BIS schema for any domain.

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -3412,5 +3412,19 @@
       "date": "Unknown",
       "dynamic": "No"
     }
+  ],
+  "CSUnits": [
+    {
+      "name": "CSUnits",
+      "path": "Domains\\Civil\\Connectors\\ConceptStation\\CSUnits.ecschema.xml",
+      "released": false,
+      "version": "01.00.00",
+      "comment": "Working Copy",
+      "sha1": "",
+      "author": "",
+      "approved": "No",
+      "date": "Unknown",
+      "dynamic": "No"
+    }
   ]
 }

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -3398,5 +3398,19 @@
       "date": "Unknown",
       "dynamic": "No"
     }
+  ],
+  "CSSegments": [
+    {
+      "name": "CSSegments",
+      "path": "Domains\\Civil\\Connectors\\ConceptStation\\CSSegments.ecschema.xml",
+      "released": false,
+      "version": "01.00.00",
+      "comment": "Working Copy",
+      "sha1": "",
+      "author": "",
+      "approved": "No",
+      "date": "Unknown",
+      "dynamic": "No"
+    }
   ]
 }


### PR DESCRIPTION
This PR introduces a new pair of application schemas for the ConceptStation Connector: CSSegments and CSUnits. CSUnits provides schema for application-specific units used by the ConceptStation Connector. CSSegments provides application-specific support for ConceptStation "segments" in the iModel, along with the application-specific ConceptStation pay item data.