### PR TITLE
Replace GeometryStream with GeometryMap.

### DIFF
--- a/Domains/Core/BisCore.ecschema.xml
+++ b/Domains/Core/BisCore.ecschema.xml
@@ -26,7 +26,6 @@
         <NoAdditionalLinkTables xmlns="ECDbSchemaPolicies.1.0"/>
         <SchemaHasBehavior/>
     </ECCustomAttributes>
-    
     <!-- Applied to an ECClass to reserve a list of properties that cannot be used by that class or its derived classes. -->
     <ECCustomAttributeClass typeName="ReservedPropertyNames" modifier="Sealed" appliesTo="EntityClass,RelationshipClass"
                             description="Declare a list of properties as reserved. The property name listed would be forbidden from use in the class and classes that inherit from it.">
@@ -566,14 +565,14 @@
 
     <ECEntityClass typeName="GeometryDetailRecord" modifier="Abstract" displayLabel="Geometry Detail Record" description="An abstract InformationRecordElement that holds geometry for use by the 'feature tree' stored in the `GeometricElement3d.GeometryOperations` property of its parent Element.">
         <BaseClass>InformationRecordElement</BaseClass>
-        <ECProperty propertyName="GeometryStream" typeName="binary" extendedTypeName="GeometryStream" displayLabel="Geometry Stream" description="Binary stream used to persist the geometry of this bis:Element.">
+        <ECProperty propertyName="GeometryMap" typeName="binary" extendedTypeName="GeometryMap" displayLabel="Geometry Map" description="Binary stream used to persist the geometries of this bis:Element.">
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.1.0"/>
                 <!-- WIP: can't have this CA without the class having a ClassHasHandler CA. Need a policy/strategy decision here...
                 <CustomHandledProperty/>
                 -->
             </ECCustomAttributes>
-        </ECProperty>        
+        </ECProperty>
     </ECEntityClass>
 
     <ECRelationshipClass typeName="GeometricElementOwnsGeometryDetailRecord" strength="embedding" modifier="None" displayLabel="GeometricElement Owns GeometryDetailRecord" description="Relates GeometryDetailRecords to their parent Element (of which they describe a geometry detail).">
@@ -2047,7 +2046,7 @@
         <ECEnumerator value="5" displayLabel="Elevation"/>
         <ECEnumerator value="6" displayLabel="Plan"/>
     </ECEnumeration>
-    
+
     <ECEntityClass typeName="SectionDrawingLocation" displayLabel="Section Drawing Location" description="The spatial location of a section drawing generated from a SpatialViewDefinition.">
         <BaseClass>SpatialLocationElement</BaseClass>
         <ECNavigationProperty propertyName="SectionView" relationshipName="SectionDrawingLocationRefersToSectionView" direction="forward" displayLabel="Section View" description="The section view generated from the SpatialViewDefinition."/>

--- a/Domains/Core/BisCore.remarks.md
+++ b/Domains/Core/BisCore.remarks.md
@@ -25,7 +25,7 @@ Other schemas should use domain handlers (written in TypeScript) and the `Schema
 
 ### ISubModeledElement
 
-Sub-modeling is also sometimes described as "breaking down", i.e. a sub-modeled Element can be "broken down into" a finer-grained (sub) Model.  
+Sub-modeling is also sometimes described as "breaking down", i.e. a sub-modeled Element can be "broken down into" a finer-grained (sub) Model.
 See also [IParentElement](#iparentelement).
 
 > Behavior: The system handler (C++) for `Element` only permits a sub-model to be inserted if the class of the *modeled element* implements the `ISubModeledElement` interface.
@@ -438,6 +438,24 @@ A `GeometryDetailRecord` should always be the child of a `GeometricElement3d` wh
 
 A `GeometryDetailRecord` models a geometric detail of the Entity modeled by its parent `GeometricElement3d`.
 
+The `GeometryMap` property of the `GeometryDetailRecord` holds an array of identifiable geometry streams serialized in flat buffer format, see [ElementGeometryDataEntry](https://www.itwinjs.org/reference/core-common/geometry/elementgeometrydataentry/):
+
+```text
+table GeometryMap {
+  entries: [GeometryMapEntry];
+}
+
+table GeometryMapEntry {
+  id: int;
+  entries: [ElementGeometryDataEntry];
+}
+
+table ElementGeometryDataEntry {
+  opcode: int;
+  data: [ubyte];
+}
+```
+
 The GeometryStream of the `GeometryDetailRecord` does not actually hold the geometry of the geometric detail, but rather holds information needed to *produce* the specific geometric detail in its parent `GeometricElement3d`'s GeometryStream. There may be two other geometries that a user will wish to see in conjunction with a `GeometryDetailRecord`:
 - The faces and edges produced in the parent's GeometryStream by the `GeometryDetailRecord`'s associated operation in the feature tree.
 - A representation of the geometric change caused by the associated operation in the "feature tree", e.g. a solid representing the material subtracted to create an opening or the material added to create a protrusion.
@@ -477,7 +495,7 @@ Other `InformationContentElement` instances can also be inserted into a `Definit
 
 ### RepositoryModel
 
-> Behavior: The singleton `RepositoryModel` behaves like a standard `InformationModel` and should have been a direct subclass of `InformationModel`. Unfortunately, it subclasses from `DefinitionModel` for legacy reasons that are no longer relevant. 
+> Behavior: The singleton `RepositoryModel` behaves like a standard `InformationModel` and should have been a direct subclass of `InformationModel`. Unfortunately, it subclasses from `DefinitionModel` for legacy reasons that are no longer relevant.
 However, the system handler (C++) for `RepositoryModel` makes it act like a direct subclass of `InformationModel`.
 Consistent with a standard `InformationModel`, all `InformationContentElement` instances except `DefinitionElement` subclasses may be inserted.
 For backwards compatibility reasons, the superclass of `RepositoryModel` cannot be corrected until a major schema version upgrade.


### PR DESCRIPTION
This PR suggests to change **GeometryStream** property of **GeometryDetailRecord** element to **GeometryMap**.
The main reason for the change is - possibility of huge number of elements and resulting performance issues.

There are some major complications when using **GeometryMap**, instead of i.e. using relationships to group related geometries.
1. Geometry of **GeometryMap** is not an Element. I.e. additional properties need to be serialized.
2. **GeometryMap** entry id's are not unique in the iModel - i.e. to reference a **geometry** in a **GeometryMap** one needs to provide _entry id_ of **GeometryMap** AND _element id_ of **GeometryDetailRecord**. Also managing such relationships.

Suggested FlatBuffer schema for **GeometryMap**:
```
table GeometryMap {
  entries: [GeometryMapEntry];
}

table GeometryMapEntry {
  id: int;
  entries: [ElementGeometryDataEntry];
}

table ElementGeometryDataEntry {
  opcode: int;
  data: [ubyte];
}
```
