### PR TITLE
Documentation upgrade with respect to iTwin.js

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,9 +18,9 @@ SchemaInventory.json                                          @iTwin/bis
 ignoreSchemaList.json                                         @naveedkhan8067 @ColinKerr @christophermlawson
 snapshotInformation.json                                      @naveedkhan8067 @ColinKerr @christophermlawson
 
-/docs/                                                        @christophermlawson @naveedkhan8067
-/cmaps/                                                       @ColinKerr @naveedkhan8067
-/test/                                                        @naveedkhan8067 @ColinKerr
+/docs/                                                        @christophermlawson @itwin/bis-admins
+/cmaps/                                                       @itwin/bis-admins
+/test/                                                        @naveedkhan8067 @ColinKerr @christophermlawson
 /tools/                                                       @iTwin/ec-reviewers
 
 /Domains/                                                     @iTwin/bis

--- a/Domains/Core/BisCore.remarks.md
+++ b/Domains/Core/BisCore.remarks.md
@@ -13,7 +13,7 @@ The core classes are decorated by ECCustomAttributes that effectively define the
 
 The classes of BisCore are used as base classes for all classes in other BIS Domain schemas.
 
-See [Base Infrastructure Schemas](https://imodeljs.github.io/iModelJs-docs-output//bis/)
+See [Base Infrastructure Schemas](https://www.itwinjs.org/bis/)
 
 ## Entity Classes
 
@@ -190,7 +190,7 @@ Categories should be standardized by domain groups where possible. They generall
 
 See [Categories Introduction](../intro/categories/).
 
-Also see the [ClassificationSystems](https://imodeljs.github.io/iModelJs-docs-output/bis/domains/classificationsystems.ecschema/) domain schema for another way of categorizing and classifying elements.
+Also see the [ClassificationSystems](https://www.itwinjs.org/bis/domains/classificationsystems.ecschema/) domain schema for another way of categorizing and classifying elements.
 
 > Behavior: The system handler (C++) for `Category` requires a valid `CodeValue` (name) for every instance.
 It will insert a *default* `SubCategory` for every `Category` that is inserted.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you just need json schemas of latest released versions:
 
 ### **BIS Rule Validation**
 
-BIS rule validation consists of checking all schemas in the bis-schemas repository against a set of [validation rules](https://imodeljs.github.io/iModelJs-docs-output/bis/intro/bis-schema-validation/). The npm script 'validateSchemas' uses the npm package `@bentley/schema-validator` to perform the validation.
+BIS rule validation consists of checking all schemas in the bis-schemas repository against a set of [validation rules](https://www.itwinjs.org/bis/intro/bis-schema-validation/). The npm script 'validateSchemas' uses the npm package `@bentley/schema-validator` to perform the validation.
 
 To run the 'validateSchemas' script follow these steps:
 
@@ -147,7 +147,7 @@ To run the 'compareSchemas' script, follow these steps:
 
 The iModel Schema Validation tool imports each individual schema in the bis-schema repository (along with schema references) into an local snapshot iModel. The schemas are then exported to a temp directory in order to perform the required validations. The following checks are performed:
 
-- **BIS-Rules Validation:** All schemas are validated against [BIS-Rules](https://www.imodeljs.org/bis/intro/bis-schema-validation/) using the `@bentley/schema-validator` package.
+- **BIS-Rules Validation:** All schemas are validated against [BIS-Rules](https://www.itwinjs.org/bis/intro/bis-schema-validation/) using the `@bentley/schema-validator` package.
 - **Comparison Validation:** All schemas are compared with their similar (exact version match) released schemas within bis-schemas using the `@bentley/schema-comparer` package.
 - **Sha1 Hash Validation:** Sha1 Hash is generated for each exported schema and compared against the set of hashes of released schemas present in [SchemaInventory](https://github.com/iTwin/bis-schemas/blob/master/SchemaInventory.json).
 - **Approval Validation:** Approval status of each schema is checked from [SchemaInventory](https://github.com/iTwin/bis-schemas/blob/master/SchemaInventory.json).  

--- a/docs/schema-cmap-class-style-guide.md
+++ b/docs/schema-cmap-class-style-guide.md
@@ -63,7 +63,7 @@ Class contents in order:
   - `name` - name of the property
   - `separator` - ":" if it's a regular property or " ->" if it's a navigation property
   - `type` - type of the property, this might be:
-    - `primitive` - ec primitive types ([full list](https://imodeljs.github.io/iModelJs-docs-output/bis/ec/primitive-types/)) e.g. string, double, point3d, IGeometry, etc.
+    - `primitive` - ec primitive types ([full list](https://www.itwinjs.org/bis/ec/primitive-types/)) e.g. string, double, point3d, IGeometry, etc.
     - `array` - double[], SomeStruct[], etc.
     - `enum` - name of the enum e.g. "SomeEnum"
     - `navigation` - name of the end point class e.g. "PhysicalElement"

--- a/docs/writing-schema-documentation.md
+++ b/docs/writing-schema-documentation.md
@@ -60,6 +60,10 @@ An example of a remarks file for a the [Fields.ecschema.xml](./remarks-example/F
 
 For more information visit the [Schema documentation style guide](./schema-documentation-style-guide.md).
 
+## Viewing the Schema Docs in a local iTwin.js build
+
+Check the wiki page in `BIS` section to get more information.
+
 ## Publishing Schema Documentation
 
 Markdown files are generated and published as an artifact for every released schema by default (see [Docs Generation Build](../tools/MarkdownGeneration/generate-docs.yaml)).  This artifact is published automatically as part of the iTwin.js doc build.  To make the schema visible in the iTwin.js docs you must add it to the domains index page (docs/bis/domains/index.md) in the itwinjs-core repo.

--- a/docs/writing-schema-documentation.md
+++ b/docs/writing-schema-documentation.md
@@ -13,7 +13,7 @@ More details on how this is happens in the [Writing Schema Docs Section](#writin
 - [Starting a new Remarks File](#starting-a-new-remarks-file)
 - [Writing Schema Remarks](#writing-schema-remarks)
   - [Schema Documentation Style Guide](./schema-documentation-style-guide.md)
-- [Viewing the Schema Docs in a local iModel.js build](#viewing-the-schema-docs-in-a-local-iModel.js-build)
+- [Viewing the Schema Docs in a local iTwin.js build](#viewing-the-schema-docs-in-a-local-iTwin.js-build)
 - [Publishing Schema Documentation](#publishing-schema-documentation)
 
 ## Starting a new Remarks File
@@ -35,7 +35,7 @@ remarksTarget: {SchemaName}.ecschema.md
 
 ## Writing Schema Remarks
 
-The schema remarks are used to enhance the descriptions and information that is available in the ECSchema.  This is done by using a separate file, a `*.remarks.md`.  The `remarks` file has a specific format to allow the tool that creates the iModel.js documentation to merge the ECSchema information with the contents of the remarks.
+The schema remarks are used to enhance the descriptions and information that is available in the ECSchema.  This is done by using a separate file, a `*.remarks.md`.  The `remarks` file has a specific format to allow the tool that creates the iTwin.js documentation to merge the ECSchema information with the contents of the remarks.
 
 The basic format for the `remarks.md` is,
 
@@ -62,8 +62,8 @@ For more information visit the [Schema documentation style guide](./schema-docum
 
 ## Publishing Schema Documentation
 
-Markdown files are generated and published as an artifact for every released schema by default (see [Docs Generation Build](../tools/MarkdownGeneration/generate-docs.yaml)).  This artifact is published automatically as part of the iModel.js doc build.  To make the schema visible in the iModel.js docs you must add it to the domains index page (docs/bis/domains/index.md) in the iModel.js repo
+Markdown files are generated and published as an artifact for every released schema by default (see [Docs Generation Build](../tools/MarkdownGeneration/generate-docs.yaml)).  This artifact is published automatically as part of the iTwin.js doc build.  To make the schema visible in the iTwin.js docs you must add it to the domains index page (docs/bis/domains/index.md) in the itwinjs-core repo.
 
-> WARNING:  When the documentation is added to the iModel.js docs it will be published publicly for anyone to see, so you will need to consider if that's what you want for your domain.
+> WARNING:  When the documentation is added to the itwinjs-core docs it will be published publicly for anyone to see, so you will need to consider if that's what you want for your domain.
 
-> NOTE: Currently there is no other published location for Schema documentation, only on the iModel.js site.
+> NOTE: Currently there is no other published location for Schema documentation, only on the iTwin.js site.

--- a/docs/writing-schema-documentation.md
+++ b/docs/writing-schema-documentation.md
@@ -13,7 +13,7 @@ More details on how this is happens in the [Writing Schema Docs Section](#writin
 - [Starting a new Remarks File](#starting-a-new-remarks-file)
 - [Writing Schema Remarks](#writing-schema-remarks)
   - [Schema Documentation Style Guide](./schema-documentation-style-guide.md)
-- [Viewing the Schema Docs in a local iTwin.js build](#viewing-the-schema-docs-in-a-local-iTwin.js-build)
+- [Viewing the Schema Docs in a local iTwin.js build](#viewing-the-schema-docs-in-a-local-iTwinjs-build)
 - [Publishing Schema Documentation](#publishing-schema-documentation)
 
 ## Starting a new Remarks File

--- a/tools/packages/README.md.template
+++ b/tools/packages/README.md.template
@@ -2,8 +2,8 @@
 
 Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md](./LICENSE.md) for license terms and full copyright notice.
 
-[iModel.js](http://imodeljs.org) is an open source platform for creating, querying, modifying, and displaying Infrastructure Digital Twins.
+[iTwin.js](http://itwinjs.org) is an open source platform for creating, querying, modifying, and displaying Infrastructure Digital Twins.
 
 ## BIS Schemas
 
-The acronym “BIS” stands for “Base Infrastructure Schemas”. BIS is an “open” and extensible family of schemas that is modularized into Domains. Please go to [iModeljs.org](https://www.imodeljs.org/bis/) for more information.
+The acronym “BIS” stands for “Base Infrastructure Schemas”. BIS is an “open” and extensible family of schemas that is modularized into Domains. Please go to [iTwinjs.org](https://www.itwinjs.org/bis/) for more information.

--- a/tools/packages/package.json.template
+++ b/tools/packages/package.json.template
@@ -2,7 +2,7 @@
   "name": "${PACKAGE_NAME}",
   "license": "MIT",
   "version": "${PACKAGE_VERSION}",
-  "homepage": "https://www.imodeljs.org/",
+  "homepage": "https://www.itwinjs.org/",
   "keywords": [
     "Bentley",
     "BIS",


### PR DESCRIPTION
The PR contains following updates:
- Links now point to itwinjs.org instead of imodeljs.org.
- Some repository and other keywords are also updated