### PR TITLE
Moving 'Validate Docs' job to consume template from master branch of itwinjs-core

### DIFF
--- a/tools/MarkdownGeneration/generate-docs.yaml
+++ b/tools/MarkdownGeneration/generate-docs.yaml
@@ -22,7 +22,6 @@ resources:
   repositories:
     - repository: itwinjs-core
       type: github
-      #ref: 'refs/heads/io-fix-build-to-yaml'
       endpoint: iModelJs
       name: iTwin/itwinjs-core
 
@@ -146,7 +145,7 @@ jobs:
 - job: Validate_Docs
   dependsOn: Generate_Docs
   displayName: Validate Docs
-  #condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'))
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'))
   workspace:
     clean: all
   pool:

--- a/tools/MarkdownGeneration/generate-docs.yaml
+++ b/tools/MarkdownGeneration/generate-docs.yaml
@@ -22,7 +22,7 @@ resources:
   repositories:
     - repository: itwinjs-core
       type: github
-      ref: 'refs/heads/io-fix-build-to-yaml'
+      #ref: 'refs/heads/io-fix-build-to-yaml'
       endpoint: iModelJs
       name: iTwin/itwinjs-core
 
@@ -146,7 +146,7 @@ jobs:
 - job: Validate_Docs
   dependsOn: Generate_Docs
   displayName: Validate Docs
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'))
+  #condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'))
   workspace:
     clean: all
   pool:

--- a/tools/MarkdownGeneration/generate-docs.yaml
+++ b/tools/MarkdownGeneration/generate-docs.yaml
@@ -167,6 +167,8 @@ jobs:
         git config --local user.email $(user_email)
         git config --local user.name $(username)
       displayName: Setup git config
+
     - template: common/config/azure-pipelines/templates/docs-build.yaml@itwinjs-core
       parameters:
         downloadCurrentBuildArtifacts: 'true'
+        workingDir: $(Build.SourcesDirectory)/itwinjs-core

--- a/tools/MarkdownGeneration/generate-docs.yaml
+++ b/tools/MarkdownGeneration/generate-docs.yaml
@@ -171,4 +171,4 @@ jobs:
     - template: common/config/azure-pipelines/templates/docs-build.yaml@itwinjs-core
       parameters:
         downloadCurrentBuildArtifacts: 'true'
-        workingDir: $(Build.SourcesDirectory)/itwinjs-core
+        workingDir: $(Build.SourcesDirectory)


### PR DESCRIPTION
Right now, this validation part consumes the template from 'io-fix-build-to-yaml'.