### PR TITLE
Allow executing validation part for manual builds

### DIFF
--- a/tools/MarkdownGeneration/generate-docs.yaml
+++ b/tools/MarkdownGeneration/generate-docs.yaml
@@ -160,7 +160,7 @@ jobs:
 - job: Validate_Docs
   dependsOn: Generate_Docs
   displayName: Validate Docs
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'))
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest', 'Manual'))
   workspace:
     clean: all
   pool:


### PR DESCRIPTION
When artifacts are generated with manual builds, this change will help to also validate them.