### PR TITLE
Breaking Changes Fixed and Allow Executing Validation

### DIFF
--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -3724,7 +3724,8 @@
   "DocumentMetadata": [
     {
       "name": "DocumentMetadata",
-      "path": "Domains\\DocumentMetadata\\DocumentMetadata.ecschema.xml",
+      "path": "Domains\\1-Common\\DocumentMetadata\\DocumentMetadata.ecschema.xml",
+      "",
       "released": false,
       "version": "01.00.00",
       "comment": "Working Copy",

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -3725,7 +3725,6 @@
     {
       "name": "DocumentMetadata",
       "path": "Domains\\1-Common\\DocumentMetadata\\DocumentMetadata.ecschema.xml",
-      "",
       "released": false,
       "version": "01.00.00",
       "comment": "Working Copy",

--- a/tools/packages/packageSchema.yaml
+++ b/tools/packages/packageSchema.yaml
@@ -12,7 +12,7 @@ pr:
 
 stages:
 - stage: Build
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(succeeded())
   jobs:
   - job: build_packages
     displayName: Build Packages
@@ -56,4 +56,5 @@ stages:
       - publish: $(pkgOut)
         artifact: bis-schemas-packages
         displayName: 'Publish Pipeline Artifact'
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 

--- a/tools/packages/packageSchema.yaml
+++ b/tools/packages/packageSchema.yaml
@@ -12,7 +12,6 @@ pr:
 
 stages:
 - stage: Build
-  condition: and(succeeded())
   jobs:
   - job: build_packages
     displayName: Build Packages


### PR DESCRIPTION
Path of the schema is corrected to fix BIS-Schema-Packaging build.

The package generation task will now be executed with the PR build to validate this stuff but will not publish the packages as build artifacts until its executing on master branch.