### PR TITLE
Civil Connector 10.11 support additional fix

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
@@ -735,7 +735,7 @@
         </ECProperty>
         <ECProperty propertyName="MeshSurfaceEntity_Depth" typeName="double" displayLabel="Depth" category="MeshSurfaceEntity_Component_Layer" priority="299990" kindOfQuantity="cifu:LENGTH"/>
         <ECProperty propertyName="MeshSurfaceEntity_Description" typeName="string" displayLabel="Description" category="MeshSurfaceEntity_Component_Layer" priority="299980"/>
-        <ECProperty propertyName="MeshSurfaceEntity_StartStation" typeName="string" displayLabel="Start Station" category="MeshSurfaceEntity_Component_Layer" priority="299950">
+        <ECProperty propertyName="MeshSurfaceEntity_StartStation" typeName="string" displayLabel="Start Station [Deprecated]" category="MeshSurfaceEntity_Component_Layer" priority="299950">
             <ECCustomAttributes>
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
                     <Description>Replaced by the new MeshSurfaceEntity_StartStationNumeric property.</Description>
@@ -743,7 +743,7 @@
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="MeshSurfaceEntity_EndStation" typeName="string" displayLabel="End Station" category="MeshSurfaceEntity_Component_Layer" priority="299940">
+        <ECProperty propertyName="MeshSurfaceEntity_EndStation" typeName="string" displayLabel="End Station [Deprecated]" category="MeshSurfaceEntity_Component_Layer" priority="299940">
             <ECCustomAttributes>
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
                     <Description>Replaced by the new MeshSurfaceEntity_EndStationNumeric property.</Description>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
@@ -735,13 +735,29 @@
         </ECProperty>
         <ECProperty propertyName="MeshSurfaceEntity_Depth" typeName="double" displayLabel="Depth" category="MeshSurfaceEntity_Component_Layer" priority="299990" kindOfQuantity="cifu:LENGTH"/>
         <ECProperty propertyName="MeshSurfaceEntity_Description" typeName="string" displayLabel="Description" category="MeshSurfaceEntity_Component_Layer" priority="299980"/>
-        <ECProperty propertyName="MeshSurfaceEntity_StartStation" typeName="string" displayLabel="Start Station" category="MeshSurfaceEntity_Component_Layer" priority="299950"/>
-        <ECProperty propertyName="MeshSurfaceEntity_EndStation" typeName="string" displayLabel="End Station" category="MeshSurfaceEntity_Component_Layer" priority="299940"/>
+        <ECProperty propertyName="MeshSurfaceEntity_StartStation" typeName="string" displayLabel="Start Station" category="MeshSurfaceEntity_Component_Layer" priority="299950">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new MeshSurfaceEntity_StartStationNumeric property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="MeshSurfaceEntity_EndStation" typeName="string" displayLabel="End Station" category="MeshSurfaceEntity_Component_Layer" priority="299940">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new MeshSurfaceEntity_EndStationNumeric property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
         <ECProperty propertyName="MeshSurfaceEntity_MaterialSubtype" typeName="string" displayLabel="Material Subtype" category="MeshSurfaceEntity_Component_Layer" priority="299930"/>
         <ECProperty propertyName="MeshSurfaceEntity_SlopedArea" typeName="double" displayLabel="Top Sloped Area" category="MeshQuantities_Civil_Quantities" priority="299920" kindOfQuantity="cifu:AREA"/>
         <ECProperty propertyName="MeshSurfaceEntity_PlanarArea" typeName="double" displayLabel="Planar Area" category="MeshQuantities_Civil_Quantities" priority="299910" kindOfQuantity="cifu:AREA"/>
         <ECProperty propertyName="MeshSurfaceEntity_CivilVolume" typeName="double" displayLabel="Volume" category="MeshQuantities_Civil_Quantities" priority="299900" kindOfQuantity="cifu:VOLUME"/>
         <ECProperty propertyName="VolumeOption" typeName="MeshSurfaceEntityAspect_VolumeOption_Enum" displayLabel="Volume Option" category="MeshSurfaceEntity_Component_Layer" priority="299925"/>
+        <ECProperty propertyName="MeshSurfaceEntity_StartStationNumeric" typeName="double" displayLabel="Start Station" category="MeshSurfaceEntity_Component_Layer" priority="299950" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="MeshSurfaceEntity_EndStationNumeric" typeName="double" displayLabel="End Station" category="MeshSurfaceEntity_Component_Layer" priority="299940" kindOfQuantity="cifu:STATION"/>
     </ECEntityClass>
     <ECRelationshipClass typeName="ElementOwnsMeshSurfaceEntityAspect" modifier="None" strength="embedding">
         <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>


### PR DESCRIPTION
In the CifCommon schema, I deprecated and hid the MeshSurfaceEntity_StartStation and MeshSurfaceEntity_EndStation properties because they were defined as strings instead of doubles. I also added 2 new replacement properties with the correct (numeric) type and unit: MeshSurfaceEntity_StartStationNumeric and MeshSurfaceEntity_EndStationNumeric.