### PR TITLE
Release of Civil Connector application schemas (existing schemas, but new versions)

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifBridge.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifBridge.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifBridge" alias="cifbrg" version="01.00.08" description="iModel Connector schema containing aspect classes with properties from OpenBridge Modeler." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifBridge" alias="cifbrg" version="01.00.09" description="iModel Connector schema containing aspect classes with properties from OpenBridge Modeler." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifCommon" alias="cifcmn" version="01.00.05" description="iModel Connector schema containing aspect classes with common properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifCommon" alias="cifcmn" version="01.00.06" description="iModel Connector schema containing aspect classes with common properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifUnits" version="01.00.01" alias="cifu"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifGeometricRules.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifGeometricRules.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifGeometricRules" alias="cifgr" version="01.00.03" description="iModel Connector schema containing aspect classes with common Geometric-rule properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifGeometricRules" alias="cifgr" version="01.00.04" description="iModel Connector schema containing aspect classes with common Geometric-rule properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.12" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.01" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifHydraulicAnalysis.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifHydraulicAnalysis.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifHydraulicAnalysis" alias="cifhydan" version="01.00.05" description="iModel Connector schema containing aspect classes with input properties from the Subsurface Utilities Design and Analysis module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifHydraulicAnalysis" alias="cifhydan" version="01.00.06" description="iModel Connector schema containing aspect classes with input properties from the Subsurface Utilities Design and Analysis module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifHydraulicResults.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifHydraulicResults.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifHydraulicResults" alias="cifhydrs" version="01.00.05" description="iModel Connector schema containing aspect classes with result properties from the Subsurface Utilities Design and Analysis module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifHydraulicResults" alias="cifhydrs" version="01.00.06" description="iModel Connector schema containing aspect classes with result properties from the Subsurface Utilities Design and Analysis module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifRail" alias="cifrl" version="01.00.04" description="iModel Connector schema containing aspect classes with properties from OpenRail Designer." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifRail" alias="cifrl" version="01.00.05" description="iModel Connector schema containing aspect classes with properties from OpenRail Designer." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifSubsurface.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifSubsurface.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifSubsurface" alias="cifssuf" version="01.00.05" description="iModel Connector schema containing aspect classes with properties from the Subsurface Utilities module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifSubsurface" alias="cifssuf" version="01.00.06" description="iModel Connector schema containing aspect classes with properties from the Subsurface Utilities module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifSubsurfaceConflictAnalysis.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifSubsurfaceConflictAnalysis.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifSubsurfaceConflictAnalysis" alias="cifsscfan" version="01.00.05" description="iModel Connector schema containing aspect classes with properties from the Subsurface Utilities Engineering module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifSubsurfaceConflictAnalysis" alias="cifsscfan" version="01.00.06" description="iModel Connector schema containing aspect classes with properties from the Subsurface Utilities Engineering module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifBridge.01.00.08.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifBridge.01.00.08.ecschema.xml
@@ -1,0 +1,3336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifBridge" alias="cifbrg" version="01.00.08" description="iModel Connector schema containing aspect classes with properties from OpenBridge Modeler." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.02" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECSchemaReference name="SchemaUpgradeCustomAttributes" version="01.00.00" alias="SchemaUpgradeCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="AbutmentAspect_Pier_AbutmentAnalyticalType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Regular" value="0" displayLabel="Regular"/>
+        <ECEnumerator name="Integral" value="1" displayLabel="Integral"/>
+        <ECEnumerator name="Semi_Integral" value="2" displayLabel="Semi-Integral"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ApproachRefLineRuleAspect_ApproachRefLineRule_DirectionInputMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Skew" value="0" displayLabel="Skew"/>
+        <ECEnumerator name="Direction" value="1" displayLabel="Direction"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ApproachSlabByTemplateRuleAspect_ApproachSlabByTemplateRule_TemplateOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BarrierAspect_Barrier_PayUnit_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Linear_Unit" value="0" displayLabel="Linear Unit"/>
+        <ECEnumerator name="Area_Unit" value="1" displayLabel="Area Unit"/>
+        <ECEnumerator name="Volume_Unit" value="2" displayLabel="Volume Unit"/>
+        <ECEnumerator name="Each" value="3" displayLabel="Each"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BarrierByTemplateRuleAspect_BarrierByTemplateRule_EndCutOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Follow_Skew" value="0" displayLabel="Follow Skew"/>
+        <ECEnumerator name="Normal_to_Path" value="1" displayLabel="Normal to Path"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BarrierByTemplateRuleAspect_BarrierByTemplateRule_StartCutOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Follow_Skew" value="0" displayLabel="Follow Skew"/>
+        <ECEnumerator name="Normal_to_Path" value="1" displayLabel="Normal to Path"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BarrierByTemplateRuleAspect_BarrierByTemplateRule_TemplateOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BeamGroupAspect_BeamGroup_EndCutOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BeamGroupAspect_BeamGroup_StartCutOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BeamSeatAspect_BeamSeatOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pier" value="0" displayLabel="Pier"/>
+        <ECEnumerator name="Girder" value="1" displayLabel="Girder"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BeamSeatAspect_BeamSeatThicknessDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="At_Center" value="0" displayLabel="At Center"/>
+        <ECEnumerator name="Min__Thickness" value="1" displayLabel="Min. Thickness"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BeamSegmentBaseAspect_BeamSegment_Type_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Undefined" value="0" displayLabel="Undefined"/>
+        <ECEnumerator name="Custom" value="1" displayLabel="Custom"/>
+        <ECEnumerator name="LEAP_Concrete" value="2" displayLabel="LEAP Concrete"/>
+        <ECEnumerator name="Rolled_Shapes" value="3" displayLabel="Rolled Shapes"/>
+        <ECEnumerator name="Top_Flange" value="4" displayLabel="Top Flange"/>
+        <ECEnumerator name="Bottom_Flange" value="5" displayLabel="Bottom Flange"/>
+        <ECEnumerator name="Web" value="6" displayLabel="Web"/>
+        <ECEnumerator name="Top_Plate" value="7" displayLabel="Top Plate"/>
+        <ECEnumerator name="Bottom_Plate" value="8" displayLabel="Bottom Plate"/>
+        <ECEnumerator name="Haunch" value="9" displayLabel="Haunch"/>
+        <ECEnumerator name="Top_Cover_Plate" value="10" displayLabel="Top Cover Plate"/>
+        <ECEnumerator name="Bottom_Cover_Plate" value="11" displayLabel="Bottom Cover Plate"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBaseAspect_BearingBearingOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pier" value="0" displayLabel="Pier"/>
+        <ECEnumerator name="Girder" value="1" displayLabel="Girder"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBaseAspect_BearingBearingType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Cube" value="0" displayLabel="Cube"/>
+        <ECEnumerator name="Cylinder" value="1" displayLabel="Cylinder"/>
+        <ECEnumerator name="Cell" value="2" displayLabel="Cell"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleBeamSeatOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pier" value="0" displayLabel="Pier"/>
+        <ECEnumerator name="Girder" value="1" displayLabel="Girder"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleBearingOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pier" value="0" displayLabel="Pier"/>
+        <ECEnumerator name="Girder" value="1" displayLabel="Girder"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleBearingType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Cube" value="0" displayLabel="Cube"/>
+        <ECEnumerator name="Cylinder" value="1" displayLabel="Cylinder"/>
+        <ECEnumerator name="Cell" value="2" displayLabel="Cell"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleGroutPadOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pier" value="0" displayLabel="Pier"/>
+        <ECEnumerator name="Girder" value="1" displayLabel="Girder"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleGroutPadThicknessDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="At_Center" value="0" displayLabel="At Center"/>
+        <ECEnumerator name="Min__Thickness" value="1" displayLabel="Min. Thickness"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BridgeUnitAspect_BridgeUnit_Type_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Beam_Slab_P_S_or_RC_Concrete_Girders" value="1" displayLabel="Beam Slab (P/S or RC Concrete Girders)"/>
+        <ECEnumerator name="Beam_Slab_Steel_Girders" value="2" displayLabel="Beam Slab (Steel Girders)"/>
+        <ECEnumerator name="RC_Slab" value="4" displayLabel="RC Slab"/>
+        <ECEnumerator name="CIP_Concrete_Box" value="3" displayLabel="CIP Concrete Box"/>
+        <ECEnumerator name="Segmental" value="5" displayLabel="Segmental"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossFrameComponentHolderBaseAspect_CrossFrameComponentHolder_ComponentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Undefined" value="0" displayLabel="Undefined"/>
+        <ECEnumerator name="Top_Strut_Down_Station" value="1" displayLabel="Top Strut Down Station"/>
+        <ECEnumerator name="Top_Strut_Up_Station" value="2" displayLabel="Top Strut Up Station"/>
+        <ECEnumerator name="Bottom_Strut_Down_Station" value="3" displayLabel="Bottom Strut Down Station"/>
+        <ECEnumerator name="Bottom_Strut_Up_Station" value="4" displayLabel="Bottom Strut Up Station"/>
+        <ECEnumerator name="Left_Diagnoal_Strut_Down_Station" value="5" displayLabel="Left Diagnoal Strut Down Station"/>
+        <ECEnumerator name="Left_Diagnoal_Strut_Up_Station" value="6" displayLabel="Left Diagnoal Strut Up Station"/>
+        <ECEnumerator name="Right_Diagnoal_Strut_Down_Station" value="7" displayLabel="Right Diagnoal Strut Down Station"/>
+        <ECEnumerator name="Right_Diagnoal_Strut_Up_Station" value="8" displayLabel="Right Diagnoal Strut Up Station"/>
+        <ECEnumerator name="Top_Left_Plate" value="9" displayLabel="Top Left Plate"/>
+        <ECEnumerator name="Top_Right_Plate" value="10" displayLabel="Top Right Plate"/>
+        <ECEnumerator name="Bottom_Left_Plate" value="11" displayLabel="Bottom Left Plate"/>
+        <ECEnumerator name="Bottom_Right_Plate" value="12" displayLabel="Bottom Right Plate"/>
+        <ECEnumerator name="Center_Plate" value="13" displayLabel="Center Plate"/>
+        <ECEnumerator name="Top_Construct_Line" value="14" displayLabel="Top Construct Line"/>
+        <ECEnumerator name="Bottom_Construct_Line" value="15" displayLabel="Bottom Construct Line"/>
+        <ECEnumerator name="Left_Diagnol_Construct_Line" value="16" displayLabel="Left Diagnol Construct Line"/>
+        <ECEnumerator name="Right_Diagnol_Construct_Line" value="17" displayLabel="Right Diagnol Construct Line"/>
+        <ECEnumerator name="Left_Construct_Line" value="18" displayLabel="Left Construct Line"/>
+        <ECEnumerator name="Right_Construct_Line" value="19" displayLabel="Right Construct Line"/>
+        <ECEnumerator name="Left_Connector_Angle" value="20" displayLabel="Left Connector Angle"/>
+        <ECEnumerator name="Right_Connector_Angle" value="21" displayLabel="Right Connector Angle"/>
+        <ECEnumerator name="Left_Connector_Down_Station" value="22" displayLabel="Left Connector Down Station"/>
+        <ECEnumerator name="Left_Connector_Up_Station" value="23" displayLabel="Left Connector Up Station"/>
+        <ECEnumerator name="Right_Connector_Down_Station" value="24" displayLabel="Right Connector Down Station"/>
+        <ECEnumerator name="Right_Connector_Up_Station" value="25" displayLabel="Right Connector Up Station"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossFrameG2Aspect_CrossFrameG2_CrossFrameType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Frame_X" value="0" displayLabel="Frame X"/>
+        <ECEnumerator name="Frame_V" value="1" displayLabel="Frame V"/>
+        <ECEnumerator name="Frame_Inverted_V" value="2" displayLabel="Frame Inverted V"/>
+        <ECEnumerator name="Diaphragm" value="3" displayLabel="Diaphragm"/>
+        <ECEnumerator name="Bent_Plate_Diaphragm" value="4" displayLabel="Bent Plate Diaphragm"/>
+        <ECEnumerator name="Bent_Plate___Concrete" value="5" displayLabel="Bent Plate - Concrete"/>
+        <ECEnumerator name="Frame_X___Concrete" value="6" displayLabel="Frame X - Concrete"/>
+        <ECEnumerator name="Frame_V___Concrete" value="7" displayLabel="Frame V - Concrete"/>
+        <ECEnumerator name="Frame_Inverted_V___Concrete" value="8" displayLabel="Frame Inverted V - Concrete"/>
+        <ECEnumerator name="Built_up_Diaphragm" value="9" displayLabel="Built-up Diaphragm"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossFrameHolderAspect_CrossFrameHolder_CrossFrameType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Frame_X" value="0" displayLabel="Frame X"/>
+        <ECEnumerator name="Frame_V" value="1" displayLabel="Frame V"/>
+        <ECEnumerator name="Frame_Inverted_V" value="2" displayLabel="Frame Inverted V"/>
+        <ECEnumerator name="Diaphragm" value="3" displayLabel="Diaphragm"/>
+        <ECEnumerator name="Bent_Plate_Diaphragm" value="4" displayLabel="Bent Plate Diaphragm"/>
+        <ECEnumerator name="Bent_Plate___Concrete" value="5" displayLabel="Bent Plate - Concrete"/>
+        <ECEnumerator name="Frame_X___Concrete" value="6" displayLabel="Frame X - Concrete"/>
+        <ECEnumerator name="Frame_V___Concrete" value="7" displayLabel="Frame V - Concrete"/>
+        <ECEnumerator name="Frame_Inverted_V___Concrete" value="8" displayLabel="Frame Inverted V - Concrete"/>
+        <ECEnumerator name="Built_up_Diaphragm" value="9" displayLabel="Built-up Diaphragm"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomAbutmentAnalyticalAspect_Pier_AbutmentAnalyticalType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Regular" value="0" displayLabel="Regular"/>
+        <ECEnumerator name="Integral" value="1" displayLabel="Integral"/>
+        <ECEnumerator name="Semi_Integral" value="2" displayLabel="Semi-Integral"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomAbutmentAspect_Pier_AbutmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pile_Cap" value="0" displayLabel="Pile Cap"/>
+        <ECEnumerator name="Stem_Wall" value="1" displayLabel="Stem Wall"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomAbutmentPileAspect_Pier_PileShape_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rectangle" value="0" displayLabel="Rectangle"/>
+        <ECEnumerator name="Circular_Pile" value="1" displayLabel="Circular Pile"/>
+        <ECEnumerator name="H_Pile" value="2" displayLabel="H Pile"/>
+        <ECEnumerator name="Circular_Drilled_Shaft" value="3" displayLabel="Circular Drilled Shaft"/>
+        <ECEnumerator name="Pipe_Pile" value="4" displayLabel="Pipe Pile"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomObjectByPathRuleAspect_CustomObjectByPathRuleAngleCalculation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Bridge_Alignment" value="0" displayLabel="Bridge Alignment"/>
+        <ECEnumerator name="Roadway_Alignment" value="1" displayLabel="Roadway Alignment"/>
+        <ECEnumerator name="Selected_Path" value="2" displayLabel="Selected Path"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomObjectByPathRuleAspect_CustomObjectByPathRuleFrequencyModeEnum_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Number" value="0" displayLabel="Number"/>
+        <ECEnumerator name="Distance" value="1" displayLabel="Distance"/>
+        <ECEnumerator name="Both" value="2" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomObjectByPathRuleAspect_CustomObjectByPathRuleVerticalOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomPierAnalyticalAspect_Pier_PierAnalyticalType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rectangle" value="0" displayLabel="Rectangle"/>
+        <ECEnumerator name="Tapered" value="1" displayLabel="Tapered"/>
+        <ECEnumerator name="InvertedT" value="2" displayLabel="InvertedT"/>
+        <ECEnumerator name="Variable" value="3" displayLabel="Variable"/>
+        <ECEnumerator name="Hammer_Head" value="4" displayLabel="Hammer Head"/>
+        <ECEnumerator name="Wall" value="5" displayLabel="Wall"/>
+        <ECEnumerator name="Pile_Bent" value="6" displayLabel="Pile Bent"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomPierBySupportLineRuleAspect_CustomPierBySupportLineRule_DeckLengthReference_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Top" value="0" displayLabel="Top"/>
+        <ECEnumerator name="Bottom" value="1" displayLabel="Bottom"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomPierBySupportLineRuleAspect_CustomPierBySupportLineRule_LengthAdjustment_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="By_Deck" value="1" displayLabel="Deck"/>
+        <ECEnumerator name="By_Skew" value="2" displayLabel="Skew"/>
+        <ECEnumerator name="Centered" value="3" displayLabel="Aligned"/>
+        <ECEnumerator name="Deck_And_Centered" value="4" displayLabel="Deck And Aligned"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomPierBySupportLineRuleAspect_CustomPierBySupportLineRule_TopSlopeMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Level" value="1" displayLabel="Level"/>
+        <ECEnumerator name="Parallel" value="0" displayLabel="Parallel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CustomPierPileAspect_Pier_PileShape_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rectangle" value="0" displayLabel="Rectangle"/>
+        <ECEnumerator name="Circular_Pile" value="1" displayLabel="Circular Pile"/>
+        <ECEnumerator name="H_Pile" value="2" displayLabel="H Pile"/>
+        <ECEnumerator name="Circular_Drilled_Shaft" value="3" displayLabel="Circular Drilled Shaft"/>
+        <ECEnumerator name="Pipe_Pile" value="4" displayLabel="Pipe Pile"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DeckByTemplateRuleAspect_DeckByTemplateRule_TemplateOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PierBySupportLineRuleAspect_PierBySupportLineRule_LengthAdjustment_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="By_Deck" value="1" displayLabel="Deck"/>
+        <ECEnumerator name="By_Skew" value="2" displayLabel="Skew"/>
+        <ECEnumerator name="Centered" value="3" displayLabel="Aligned"/>
+        <ECEnumerator name="Deck_And_Centered" value="4" displayLabel="Deck And Aligned"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PierBySupportLineRuleAspect_PierBySupportLineRule_SupportLineType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Start" value="0" displayLabel="Start"/>
+        <ECEnumerator name="End" value="2" displayLabel="End"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PierCapBaseAspect_PierCap_Type_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Tapered" value="0" displayLabel="Tapered"/>
+        <ECEnumerator name="Rectangle" value="1" displayLabel="Rectangle"/>
+        <ECEnumerator name="InvertedT" value="2" displayLabel="InvertedT"/>
+        <ECEnumerator name="Variable" value="8" displayLabel="Variable"/>
+        <ECEnumerator name="None" value="-1" displayLabel="None"/>
+        <ECEnumerator name="Stem_Wall" value="6" displayLabel="Stem Wall"/>
+        <ECEnumerator name="Pile_Cap" value="5" displayLabel="Pile Cap"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PierColumnBaseAspect_PierColumn_Type_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Circular" value="0" displayLabel="Circular"/>
+        <ECEnumerator name="Rectangle" value="1" displayLabel="Rectangle"/>
+        <ECEnumerator name="Rect_Fillet" value="2" displayLabel="Rect-Fillet"/>
+        <ECEnumerator name="Rect_Chamfer" value="3" displayLabel="Rect-Chamfer"/>
+        <ECEnumerator name="Rect_Bevel" value="4" displayLabel="Rect-Bevel"/>
+        <ECEnumerator name="None" value="-1" displayLabel="None"/>
+        <ECEnumerator name="Oval" value="6" displayLabel="Oval"/>
+        <ECEnumerator name="Variable" value="7" displayLabel="Variable"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PierFootingBaseAspect_Pierfooting_FootingType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rectangular_Isolated" value="0" displayLabel="Rectangular Isolated"/>
+        <ECEnumerator name="Rectangular_Combined" value="1" displayLabel="Rectangular Combined"/>
+        <ECEnumerator name="Rectangle_Drilled_Shaft" value="2" displayLabel="Rectangle Drilled Shaft"/>
+        <ECEnumerator name="Circular_Drilled_Shaft" value="3" displayLabel="Circular Drilled Shaft"/>
+        <ECEnumerator name="Rect__Combined_with_Crash_Wall" value="4" displayLabel="Rect. Combined with Crash Wall"/>
+        <ECEnumerator name="None" value="-1" displayLabel="None"/>
+        <ECEnumerator name="Custom" value="5" displayLabel="Custom"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PileBaseAspect_Pile_Type_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rectangle" value="0" displayLabel="Rectangle"/>
+        <ECEnumerator name="Circular_Pile" value="1" displayLabel="Circular Pile"/>
+        <ECEnumerator name="H_Pile" value="2" displayLabel="H Pile"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SegmentalBalanceRuleAspect_SegmentalBalanceRule_TemplateOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SegmentalSpanBetweenSupportLinesRuleAspect_SegmentalSpanBetweenSupportLinesRuleTemplateOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SegmentalSpanRuleAspect_SegmentalSpanRuleTemplateOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ShearConnectorsHolderAspect_ShearConnectorsHolder_ConnectorType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Stud" value="0" displayLabel="Stud"/>
+        <ECEnumerator name="Channel" value="1" displayLabel="Channel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SleeperSlabByApproachRuleAspect_SleeperSlabByApproachRule_LengthAdjustment_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Approach_Slab" value="1" displayLabel="Approach Slab"/>
+        <ECEnumerator name="Skew" value="2" displayLabel="Skew"/>
+        <ECEnumerator name="Centered" value="3" displayLabel="Aligned"/>
+        <ECEnumerator name="Approach_Slab_and_Centered" value="4" displayLabel="Approach Slab and Aligned"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SleeperSlabByApproachRuleAspect_SleeperSlabByApproachRuleLocation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Start" value="0" displayLabel="Start"/>
+        <ECEnumerator name="End" value="1" displayLabel="End"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SupportLineBtMidPointRuleAspect_SupportLineBtMidPointRule_DirectionInputMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Skew" value="0" displayLabel="Skew"/>
+        <ECEnumerator name="Direction" value="1" displayLabel="Direction"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TubGirderGroupByBeamCorridorRuleAspect_TubGirderGroupByBeamCorridorRuleEndCutOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical" value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Normal" value="1" displayLabel="Normal"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TubGirderSegmentAspect_TubGirderSegment_Type_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Haunch_Left" value="0" displayLabel="Haunch Left"/>
+        <ECEnumerator name="Haunch_Right" value="1" displayLabel="Haunch Right"/>
+        <ECEnumerator name="Flange_Top_Left" value="2" displayLabel="Flange Top Left"/>
+        <ECEnumerator name="Flange_Top_Right" value="3" displayLabel="Flange Top Right"/>
+        <ECEnumerator name="Web_Left" value="4" displayLabel="Web Left"/>
+        <ECEnumerator name="Web_Right" value="5" displayLabel="Web Right"/>
+        <ECEnumerator name="Flange_Bottom" value="6" displayLabel="Flange Bottom"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WingWallByAbutmentRuleAspect_WingWallByAbutmentRuleOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Normal_Skewed" value="0" displayLabel="Normal/Skewed"/>
+        <ECEnumerator name="Inline_Skewed" value="1" displayLabel="Inline/Skewed"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="AbutmentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Abutment" priority="299950"/>
+        <ECProperty propertyName="Pier_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Abutment" priority="299949"/>
+        <ECProperty propertyName="Pier_TemplateName" typeName="string" displayLabel="Template Name" category="BridgeModelerAttributes_Abutment" priority="299948"/>
+        <ECProperty propertyName="Pier_PierCapMaterial" typeName="string" displayLabel="Cap Material" category="BridgeModelerAttributes_Material_Material" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnMaterial" typeName="string" displayLabel="Column Material" category="BridgeModelerAttributes_Material_Material" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingMaterial" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299948"/>
+        <ECProperty propertyName="Pier_PileMaterial" typeName="string" displayLabel="Pile Material" category="BridgeModelerAttributes_Material_Material" priority="299946"/>
+        <ECProperty propertyName="Pier_PierCapBuildOrder" typeName="int" displayLabel="Pier Cap Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnBuildOrder" typeName="int" displayLabel="Column Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingBuildOrder" typeName="int" displayLabel="Footing Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299948"/>
+        <ECProperty propertyName="Pier_PileBuildOrder" typeName="int" displayLabel="Pile Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299946"/>
+        <ECProperty propertyName="Pier_AbutmentAnalyticalType" typeName="AbutmentAspect_Pier_AbutmentAnalyticalType_Enum" displayLabel="Abutment Type" category="AnalyticalProperties_Analytical" priority="299950"/>
+        <ECProperty propertyName="Pier_ConcretePadMaterial" typeName="string" displayLabel="Concrete Pad Material" category="BridgeModelerAttributes_Material_Material" priority="299947"/>
+        <ECProperty propertyName="Pier_ConcretePadBuildOrder" typeName="int" displayLabel="Concrete Pad Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299947"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AbutmentWingComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AbutmentWingComponent_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AbutmentWingWallAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AbutmentWingWallName" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Abutment_Wingwall" priority="299999"/>
+        <ECProperty propertyName="AbutmentWingWallFeatureName" typeName="string" displayLabel="Feature Name" category="BridgeModelerAttributes_Abutment_Wingwall" priority="299998"/>
+        <ECProperty propertyName="AbutmentWingWallMaterial_WingWall" typeName="string" displayLabel="Wingwall Material" category="BridgeModelerAttributes_Material_Material" priority="299997"/>
+        <ECProperty propertyName="AbutmentWingWallMaterial_Footing" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299996"/>
+        <ECProperty propertyName="AbutmentWingWallMaterial_Pile" typeName="string" displayLabel="Pile Material" category="BridgeModelerAttributes_Material_Material" priority="299995"/>
+        <ECProperty propertyName="AbutmentWingWallBuildOrder_WingWall" typeName="int" displayLabel="Wingwall Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299994"/>
+        <ECProperty propertyName="AbutmentWingWallBuildOrder_Footing" typeName="int" displayLabel="Footing Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299993"/>
+        <ECProperty propertyName="AbutmentWingWallBuildOrder_Pile" typeName="int" displayLabel="Pile Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299992"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AccessoryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Accessory_Name" typeName="string" displayLabel="Name" category="AccessoryProperties_Accessory" priority="400000"/>
+        <ECProperty propertyName="Accessory_Description" typeName="string" displayLabel="Description" category="AccessoryProperties_Accessory" priority="399999"/>
+        <ECProperty propertyName="Accessory_MaterialMain" typeName="string" displayLabel="Main" category="BridgeModelerAttributes_Material_Material" priority="399998"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AccessoryComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AccessoryComponent_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ApproachRefLineAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ApproachRefLine_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Approach_Reference_Line" priority="299950"/>
+        <ECProperty propertyName="ApproachRefLine_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Approach_Reference_Line" priority="299940"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ApproachRefLineRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ApproachRefLineRule_Length" typeName="double" displayLabel="Length" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachRefLineRule_DirectionInputMode" typeName="ApproachRefLineRuleAspect_ApproachRefLineRule_DirectionInputMode_Enum" displayLabel="Direction Mode" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299997"/>
+        <ECProperty propertyName="ApproachRefLineRule_Direction" typeName="double" displayLabel="Direction" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299996" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="ApproachRefLineRule_Offset" typeName="double" displayLabel="Offset From SupportLine" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299993" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ApproachRefLineRule_Skew" typeName="double" displayLabel="Skew" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299995" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ApproachRefLineRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachRefLineRule_Station" typeName="string" displayLabel="Station" category="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" priority="299998"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ApproachSlabAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ApproachSlab_Name" typeName="string" displayLabel="Name" category="ApproachSlabProperties_Approach_Slab" priority="400000"/>
+        <ECProperty propertyName="ApproachSlab_Description" typeName="string" displayLabel="Description" category="ApproachSlabProperties_Approach_Slab" priority="399999"/>
+        <ECProperty propertyName="ApproachSlab_TemplateName" typeName="string" displayLabel="Template Name" category="ApproachSlabProperties_Approach_Slab" priority="399998"/>
+        <ECProperty propertyName="ApproachSlab_MainMaterial" typeName="string" displayLabel="Approach Slab Material Name" category="BridgeModelerAttributes_Material_Material" priority="399997"/>
+        <ECProperty propertyName="ApproachSlab_MainBuildOrder" typeName="int" displayLabel="Approach Slab Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399996"/>
+        <ECProperty propertyName="ApproachSlab_TopSurfaceArea" typeName="double" displayLabel="Top Surface Area" category="ApproachSlabProperties_Approach_Slab" priority="200000" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ApproachSlabByTemplateRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_IsSyncDeck" typeName="boolean" displayLabel="Sync With Deck" category="ApproachSlabProperties_Approach_Slab" priority="300000"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_StartOffset" typeName="double" displayLabel="Start Station Offset" category="ApproachSlabProperties_Approach_Slab" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_EndOffset" typeName="double" displayLabel="End Station Offset" category="ApproachSlabProperties_Approach_Slab" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_TemplateOrientation" typeName="ApproachSlabByTemplateRuleAspect_ApproachSlabByTemplateRule_TemplateOrientation_Enum" displayLabel="Template Orientation" category="ApproachSlabProperties_Approach_Slab" priority="299997">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="ApproachSlabProperties_Approach_Slab" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_StartVerticalOffset" typeName="double" displayLabel="Start Vertical Offset" category="ApproachSlabProperties_Approach_Slab" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_EndVerticalOffset" typeName="double" displayLabel="End Vertical Offset" category="ApproachSlabProperties_Approach_Slab" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_Template" typeName="string" displayLabel="Template" category="ApproachSlabProperties_Approach_Slab" priority="299993"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="ApproachSlabProperties_Approach_Slab" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="ApproachSlabProperties_Approach_Slab" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="ApproachSlabProperties_Approach_Slab" priority="299990"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_PointControl" typeName="string" displayLabel="Point Control" category="ApproachSlabProperties_Approach_Slab" priority="299989"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_LeftStartBreakbackDistance" typeName="double" displayLabel="Left Start Breakback Distance" category="ApproachSlabBreakbackProperties_Approach_Slab_Breakbacks" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_RightStartBreakbackDistance" typeName="double" displayLabel="Right Start Breakback Distance" category="ApproachSlabBreakbackProperties_Approach_Slab_Breakbacks" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_LeftEndBreakbackDistance" typeName="double" displayLabel="Left End Breakback Distance" category="ApproachSlabBreakbackProperties_Approach_Slab_Breakbacks" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ApproachSlabByTemplateRule_RightEndBreakbackDistance" typeName="double" displayLabel="Right End Breakback Distance" category="ApproachSlabBreakbackProperties_Approach_Slab_Breakbacks" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AppurtenanceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Appurtenance_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Auxiliary" priority="299950"/>
+        <ECProperty propertyName="Appurtenance_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Auxiliary" priority="299940"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AppurtenanceComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AppurtenanceComponent_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AuxObjectAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AuxObject_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AuxObjectRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AuxObjectRuleActiveAngle" typeName="double" displayLabel="Active Angle" category="AuxObjectRuleAttributes_Rule_Property" priority="299999" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AuxObjectRuleHorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="AuxObjectRuleAttributes_Rule_Property" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AuxObjectRuleVerticalOffset" typeName="double" displayLabel="Vertical Offset" category="AuxObjectRuleAttributes_Rule_Property" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AuxObjectByDataPointRuleAspect">
+        <BaseClass>AuxObjectRuleAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BarrierAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Barrier_Name" typeName="string" displayLabel="Name" category="BarrierProperties_Barrier" priority="399950"/>
+        <ECProperty propertyName="Barrier_Description" typeName="string" displayLabel="Description" category="BarrierProperties_Barrier" priority="399940"/>
+        <ECProperty propertyName="Barrier_TemplateName" typeName="string" displayLabel="Template Name" category="BarrierProperties_Barrier" priority="399930"/>
+        <ECProperty propertyName="Barrier_MainMaterial" typeName="string" displayLabel="Barrier Material" category="BridgeModelerAttributes_Material_Material" priority="399920"/>
+        <ECProperty propertyName="Barrier_MainBuildOrder" typeName="int" displayLabel="Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399910"/>
+        <ECProperty propertyName="Barrier_Length" typeName="double" displayLabel="Length" category="BarrierProperties_Barrier" priority="-100" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Barrier_PayUnit" typeName="BarrierAspect_Barrier_PayUnit_Enum" displayLabel="Pay Unit" category="BarrierProperties_Barrier" priority="-90"/>
+        <ECProperty propertyName="Barrier_PayUnitText" typeName="string" displayLabel="Pay Unit Text" category="BarrierProperties_Barrier" priority="-95"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="SolidByTemplateRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SolidByTemplateRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SolidByTemplateRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SolidByTemplateRule_Template" typeName="string" displayLabel="Template" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299988"/>
+        <ECProperty propertyName="SolidByTemplateRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SolidByTemplateRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SolidByTemplateRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299985">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SolidByTemplateRule_PointControl" typeName="string" displayLabel="Point Control" category="SolidByTemplateRuleAttributes_Rule_Property" priority="299984">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="BarrierByTemplateRuleAspect">
+        <BaseClass>SolidByTemplateRuleAspect</BaseClass>
+        <ECProperty propertyName="BarrierByTemplateRule_StartOffset" typeName="double" displayLabel="Start Station Offset" category="BarrierProperties_Barrier" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BarrierByTemplateRule_EndOffset" typeName="double" displayLabel="End Station Offset" category="BarrierProperties_Barrier" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BarrierByTemplateRule_TemplateOrientation" typeName="BarrierByTemplateRuleAspect_BarrierByTemplateRule_TemplateOrientation_Enum" displayLabel="Template Orientation" category="BarrierProperties_Barrier" priority="299997"/>
+        <ECProperty propertyName="BarrierByTemplateRule_PointControlPath" typeName="string" displayLabel="Point Control Path" category="BarrierProperties_Barrier" priority="299974"/>
+        <ECProperty propertyName="BarrierByTemplateRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="BarrierProperties_Barrier" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BarrierByTemplateRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="BarrierProperties_Barrier" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BarrierByTemplateRule_Template" typeName="string" displayLabel="Template" category="BarrierProperties_Barrier" priority="299988"/>
+        <ECProperty propertyName="BarrierByTemplateRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="BarrierProperties_Barrier" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BarrierByTemplateRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="BarrierProperties_Barrier" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BarrierByTemplateRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="BarrierProperties_Barrier" priority="299985"/>
+        <ECProperty propertyName="BarrierByTemplateRule_PointControl" typeName="string" displayLabel="Point Control" category="BarrierProperties_Barrier" priority="299984"/>
+        <ECProperty propertyName="BarrierByTemplateRule_EndCutOrientation" typeName="BarrierByTemplateRuleAspect_BarrierByTemplateRule_EndCutOrientation_Enum" displayLabel="End Cut Orientation" category="BarrierProperties_Barrier" priority="299995"/>
+        <ECProperty propertyName="BarrierByTemplateRule_StartCutOrientation" typeName="BarrierByTemplateRuleAspect_BarrierByTemplateRule_StartCutOrientation_Enum" displayLabel="Start Cut Orientation" category="BarrierProperties_Barrier" priority="299996"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamCorridorAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BeamCorridor_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Beam_Layout" priority="299950"/>
+        <ECProperty propertyName="BeamCorridor_Pattern" typeName="string" displayLabel="Pattern" category="BridgeModelerAttributes_Beam_Layout" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BeamGroup_UseBeamRotation" typeName="boolean" displayLabel="Use Beam Rotation" category="BeamGroupProperties_Beam_Group_Properties" priority="299998"/>
+        <ECProperty propertyName="BeamGroup_FollowLeftDeckEdge" typeName="boolean" displayLabel="Follow Left Deck Edge" category="BeamGroupProperties_Beam_Group_Properties" priority="299995"/>
+        <ECProperty propertyName="BeamGroup_FollowRightDeckEdge" typeName="boolean" displayLabel="Follow Right Deck Edge" category="BeamGroupProperties_Beam_Group_Properties" priority="299994"/>
+        <ECProperty propertyName="BeamGroup_ConstructWetJoints" typeName="boolean" displayLabel="Construct Wet Joints" category="BeamGroupProperties_Beam_Group_Properties" priority="299993"/>
+        <ECProperty propertyName="BeamGroup_WetJointEndsNormal" typeName="boolean" displayLabel="Wet Joint Ends Normal" category="BeamGroupProperties_Beam_Group_Properties" priority="299992"/>
+        <ECProperty propertyName="BeamGroup_MaterialWetJoints" typeName="string" displayLabel="Wet Joint Material" category="BeamGroupProperties_Beam_Group_Properties" priority="299991"/>
+        <ECProperty propertyName="BeamGroup_BeamDefinition" typeName="string" displayLabel="Beam Definition" category="BeamGroupProperties_Beam_Group_Properties" priority="299950">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamGroup_BuildOrder" typeName="int" displayLabel="Beam Group Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="-90"/>
+        <ECProperty propertyName="BeamGroup_StartCutOrientation" typeName="BeamGroupAspect_BeamGroup_StartCutOrientation_Enum" displayLabel="Start Cut Orientation" category="BeamGroupProperties_Beam_Group_Properties" priority="299997"/>
+        <ECProperty propertyName="BeamGroup_EndCutOrientation" typeName="BeamGroupAspect_BeamGroup_EndCutOrientation_Enum" displayLabel="End Cut Orientation" category="BeamGroupProperties_Beam_Group_Properties" priority="299996"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSeatAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BeamSeatBearingGroupName" typeName="string" displayLabel="Bearing Group" category="BridgeModelerAttributes_General" priority="299999"/>
+        <ECProperty propertyName="BeamSeatBearingName" typeName="string" displayLabel="Bearing" category="BridgeModelerAttributes_General" priority="299998"/>
+        <ECProperty propertyName="BeamSeatOrientation" typeName="BeamSeatAspect_BeamSeatOrientation_Enum" displayLabel="Orientation" category="BridgeModelerAttributes_General" priority="299997"/>
+        <ECProperty propertyName="BeamSeatD1" typeName="double" displayLabel="D1" category="BridgeModelerAttributes_General" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatD2" typeName="double" displayLabel="D2" category="BridgeModelerAttributes_General" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatW1" typeName="double" displayLabel="W1" category="BridgeModelerAttributes_General" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatW2" typeName="double" displayLabel="W2" category="BridgeModelerAttributes_General" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatMinThickness" typeName="double" displayLabel="Min. Thickness" category="BridgeModelerAttributes_General" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatThicknessAtCenter" typeName="double" displayLabel="Thickness at Center" category="BridgeModelerAttributes_General" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatDepthAtD1W1" typeName="double" displayLabel="Depth at D1W1" category="BridgeModelerAttributes_General" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatDepthAtD1W2" typeName="double" displayLabel="Depth at D1W2" category="BridgeModelerAttributes_General" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatDepthAtD2W1" typeName="double" displayLabel="Depth at D2W1" category="BridgeModelerAttributes_General" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatDepthAtD2W2" typeName="double" displayLabel="Depth at D2W2" category="BridgeModelerAttributes_General" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSeatThicknessDefinitionMethod" typeName="BeamSeatAspect_BeamSeatThicknessDefinitionMethod_Enum" displayLabel="Thickness Definition" category="BridgeModelerAttributes_General" priority="299992"/>
+        <ECProperty propertyName="BeamSeatTopElevation" typeName="double" displayLabel="Top Elevation" category="BridgeModelerAttributes_General" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSegmentBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BeamSegment_Type" typeName="BeamSegmentBaseAspect_BeamSegment_Type_Enum" displayLabel="Type" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299999"/>
+        <ECProperty propertyName="BeamSegment_BeamName" typeName="string" displayLabel="Beam Name" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299975"/>
+        <ECProperty propertyName="BeamSegment_SpanName" typeName="string" displayLabel="Span Name" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299974"/>
+        <ECProperty propertyName="BeamSegment_TypeText" typeName="string" displayLabel="Type Text" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299998"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSegmentCollectionBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BeamSegmentCollection_BeamDefinition" typeName="string" displayLabel="Beam Definition" category="BridgeModelerAttributes_Beam" priority="299999"/>
+        <ECProperty propertyName="BeamSegmentCollection_Direction" typeName="double" displayLabel="Direction" category="BridgeModelerAttributes_Beam" priority="299998" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BeamSegmentCollection_Rotation" typeName="double" displayLabel="Rotation" category="BridgeModelerAttributes_Beam" priority="299997" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BeamSegmentCollection_TrueLength" typeName="double" displayLabel="True Length" category="BridgeModelerAttributes_Beam" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegmentCollection_ProjectedLength" typeName="double" displayLabel="Projected Length" category="BridgeModelerAttributes_Beam" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegmentCollection_SpanName" typeName="string" displayLabel="Span Name" category="BridgeModelerAttributes_Beam" priority="299991"/>
+        <ECProperty propertyName="BeamSegmentCollection_Grade" typeName="double" displayLabel="Grade" category="BridgeModelerAttributes_Beam" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="BeamSegmentCollection_BridgeStructureNumber" typeName="string" displayLabel="Bridge Structure #" category="BridgeModelerAttributes_Beam" priority="299990"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSegmentCollectionAspect">
+        <BaseClass>BeamSegmentCollectionBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSegmentCollectionWithIDsAspect">
+        <BaseClass>BeamSegmentCollectionBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegmentCollection_NBIID" typeName="string" displayLabel="NBI Element Number" category="BridgeModelerAttributes_Beam" priority="299993"/>
+        <ECProperty propertyName="BeamSegmentCollection_StateID" typeName="string" displayLabel="State Element Number" category="BridgeModelerAttributes_Beam" priority="299992"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSegmentCommonBaseAspect" modifier="Abstract">
+        <BaseClass>BeamSegmentBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegment_Length" typeName="double" displayLabel="Length" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegment_Material" typeName="string" displayLabel="Material" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299987"/>
+        <ECProperty propertyName="BeamSegment_Material_UnitPrice" typeName="double" displayLabel="Material Unit Price" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299986" kindOfQuantity="cifu:UNITLESS_PRICE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:COEFFICIENT</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_UnitWeight" typeName="double" displayLabel="Unit Wt" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299985" kindOfQuantity="cifu:DENSITY">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:KG_PER_CUB_M</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_CTE" typeName="double" displayLabel="CTE" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299984" kindOfQuantity="cifu:THERMAL_COEFFICIENT">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:STRAIN_PER_KELVIN</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_E" typeName="double" displayLabel="E" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299983" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_Poisson" typeName="double" displayLabel="Poisson" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299982" kindOfQuantity="cifu:COEFFICIENT">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:COEFFICIENT</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="BeamSegmentWidthAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BeamSegment_Width" typeName="double" displayLabel="Width" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Bearing_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299999"/>
+        <ECProperty propertyName="BearingBearingGroup" typeName="string" displayLabel="Bearing Group" category="BridgeModelerAttributes_General" priority="299998"/>
+        <ECProperty propertyName="BearingSupportedBeamGrade" typeName="double" displayLabel="Beam Grade (%)" category="BridgeModelerAttributes_General" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingActiveAngle" typeName="double" displayLabel="Active Angle" category="BridgeModelerAttributes_General" priority="299988" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BearingXScale" typeName="double" displayLabel="X-Scale" category="BridgeModelerAttributes_General" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingYScale" typeName="double" displayLabel="Y-Scale" category="BridgeModelerAttributes_General" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingZScale" typeName="double" displayLabel="Z-Scale" category="BridgeModelerAttributes_General" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBearingType" typeName="BearingBaseAspect_BearingBearingType_Enum" displayLabel="Bearing Type" category="BridgeModelerAttributes_General" priority="299997"/>
+        <ECProperty propertyName="BearingBearingOrientation" typeName="BearingBaseAspect_BearingBearingOrientation_Enum" displayLabel="Bearing Orientation" category="BridgeModelerAttributes_General" priority="299996"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBySupportLineAndBeamsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BearingBySupportLineAndBeamsRuleModelAsSteppedCap" typeName="boolean" displayLabel="Model Stepped Cap" category="BearingRuleAttributes_Rule_Property" priority="400000"/>
+        <ECProperty propertyName="BearingBySupportLineAndBeamsRuleModelAsSlopedBearingSeats" typeName="boolean" displayLabel="Model As Sloped Bearing Seats" category="BearingRuleAttributes_Rule_Property" priority="399999"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBySupportLineAndDecksRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BearingBySupportLineAndDecksRuleTransverseOffsetsString" typeName="string" displayLabel="Trans. Offsets (L1; L2; ...)" category="BearingRuleAttributes_Rule_Property" priority="300000"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBySupportLineRuleBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BearingBySupportLineRuleBackOffset" typeName="double" displayLabel="Back Offset" category="BearingRuleAttributes_Rule_Property" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleAheadOffset" typeName="double" displayLabel="Ahead Offset" category="BearingRuleAttributes_Rule_Property" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleActiveAngle" typeName="double" displayLabel="Active Angle" category="BearingRuleAttributes_Rule_Property" priority="299994" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BearingBySupportLineRuleXScale" typeName="double" displayLabel="X-Scale" category="BearingRuleAttributes_Rule_Property" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleYScale" typeName="double" displayLabel="Y-Scale" category="BearingRuleAttributes_Rule_Property" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleZScale" typeName="double" displayLabel="Z-Scale" category="BearingRuleAttributes_Rule_Property" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleHasBeamSeats" typeName="boolean" displayLabel="Has Bearing Seats" category="BearingRuleAttributes_Rule_Property" priority="299985"/>
+        <ECProperty propertyName="BearingBySupportLineRuleMinBtmThickness" typeName="double" displayLabel="Seat Min Thickness" category="BearingRuleAttributes_Rule_Property" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBottomD1" typeName="double" displayLabel="Seat D1" category="BearingRuleAttributes_Rule_Property" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBottomD2" typeName="double" displayLabel="Seat D2" category="BearingRuleAttributes_Rule_Property" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBottomW1" typeName="double" displayLabel="Seat W1" category="BearingRuleAttributes_Rule_Property" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBottomW2" typeName="double" displayLabel="Seat W2" category="BearingRuleAttributes_Rule_Property" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleHasGroutPads" typeName="boolean" displayLabel="Has Pad or Plate" category="BearingRuleAttributes_Rule_Property" priority="299978"/>
+        <ECProperty propertyName="BearingBySupportLineRuleGroutPadThicknessAtCenter" typeName="double" displayLabel="Pad Center Thickness" category="BearingRuleAttributes_Rule_Property" priority="299976" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleTopD1" typeName="double" displayLabel="Pad D1" category="BearingRuleAttributes_Rule_Property" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleTopD2" typeName="double" displayLabel="Pad D2" category="BearingRuleAttributes_Rule_Property" priority="299973" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleTopW1" typeName="double" displayLabel="Pad W1" category="BearingRuleAttributes_Rule_Property" priority="299972" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleTopW2" typeName="double" displayLabel="Pad W2" category="BearingRuleAttributes_Rule_Property" priority="299971" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBearingOrientation" typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleBearingOrientation_Enum" displayLabel="Bearing Orientation" category="BearingRuleAttributes_Rule_Property" priority="299997"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBearingType" typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleBearingType_Enum" displayLabel="Bearing Type" category="BearingRuleAttributes_Rule_Property" priority="299996"/>
+        <ECProperty propertyName="BearingBySupportLineRuleBeamSeatOrientation" typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleBeamSeatOrientation_Enum" displayLabel="Seat Orientation" category="BearingRuleAttributes_Rule_Property" priority="299979"/>
+        <ECProperty propertyName="BearingBySupportLineRuleGroutPadOrientation" typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleGroutPadOrientation_Enum" displayLabel="Grout Pad Orientation" category="BearingRuleAttributes_Rule_Property" priority="299970"/>
+        <ECProperty propertyName="BearingBySupportLineRuleMinTopThickness" typeName="double" displayLabel="Pad Min Thickness" category="BearingRuleAttributes_Rule_Property" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleGroutPadThicknessDefinitionMethod" typeName="BearingBySupportLineRuleBaseAspect_BearingBySupportLineRuleGroutPadThicknessDefinitionMethod_Enum" displayLabel="Pad Thickness Definition" category="BearingRuleAttributes_Rule_Property" priority="299977"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBySupportLineRuleCellAspect">
+        <BaseClass>BearingBySupportLineRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BearingBySupportLineRuleCellName" typeName="string" displayLabel="Cell" category="BearingRuleAttributes_Rule_Property" priority="299995"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBySupportLineRuleCubeAspect">
+        <BaseClass>BearingBySupportLineRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BearingBySupportLineRuleCubeWidth" typeName="double" displayLabel="Cube Width, W" category="BearingRuleAttributes_Rule_Property" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleCubeDepth" typeName="double" displayLabel="Cube Depth, D" category="BearingRuleAttributes_Rule_Property" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleCubeHeight" typeName="double" displayLabel="Cube Height" category="BearingRuleAttributes_Rule_Property" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingBySupportLineRuleCylinderAspect">
+        <BaseClass>BearingBySupportLineRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BearingBySupportLineRuleCylinderRadius" typeName="double" displayLabel="Cylinder Radius" category="BearingRuleAttributes_Rule_Property" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingBySupportLineRuleCylinderHeight" typeName="double" displayLabel="Cylinder Height" category="BearingRuleAttributes_Rule_Property" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingCellAspect">
+        <BaseClass>BearingBaseAspect</BaseClass>
+        <ECProperty propertyName="BearingCellName" typeName="string" displayLabel="Cell" category="BridgeModelerAttributes_General" priority="299989"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BearingComponent_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingCubeAspect">
+        <BaseClass>BearingBaseAspect</BaseClass>
+        <ECProperty propertyName="BearingCubeHeight" typeName="double" displayLabel="Cube Height" category="BridgeModelerAttributes_General" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingCubeWidth" typeName="double" displayLabel="Cube Width, W" category="BridgeModelerAttributes_General" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingCubeDepth" typeName="double" displayLabel="Cube Depth, D" category="BridgeModelerAttributes_General" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingCylinderAspect">
+        <BaseClass>BearingBaseAspect</BaseClass>
+        <ECProperty propertyName="BearingCylinderHeight" typeName="double" displayLabel="Cylinder Height" category="BridgeModelerAttributes_General" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BearingCylinderRadius" typeName="double" displayLabel="Cylinder Radius" category="BridgeModelerAttributes_General" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BearingGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BearingGroup_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Bearing_Group" priority="0"/>
+        <ECProperty propertyName="BearingGroup_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Bearing_Group" priority="-1"/>
+        <ECProperty propertyName="BearingGroup_MaterialGrout" typeName="string" displayLabel="Pad or Plate Material" category="BridgeModelerAttributes_Material_Material" priority="-2"/>
+        <ECProperty propertyName="BearingGroup_MaterialBearing" typeName="string" displayLabel="Bearing Material" category="BridgeModelerAttributes_Material_Material" priority="-3"/>
+        <ECProperty propertyName="BearingGroup_MaterialBeam" typeName="string" displayLabel="Bearing Seat Material" category="BridgeModelerAttributes_Material_Material" priority="-4"/>
+        <ECProperty propertyName="BearingGroup_BuildOrderGrout" typeName="int" displayLabel="Pad or Plate Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="-5"/>
+        <ECProperty propertyName="BearingGroup_BuildOrderBearing" typeName="int" displayLabel="Bearing Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="-6"/>
+        <ECProperty propertyName="BearingGroup_BuildOrderBeam" typeName="int" displayLabel="Beam Seat Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="-7"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="SteelBeamSegmentBaseAspect" modifier="Abstract">
+        <BaseClass>BeamSegmentCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegment_Thickness" typeName="double" displayLabel="Thickness" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="SteelSPCBeamSegmentBaseAspect" modifier="Abstract">
+        <BaseClass>SteelBeamSegmentBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegment_Material_Steel_FU" typeName="double" displayLabel="Fu" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299981" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_Steel_Fy" typeName="double" displayLabel="Fy" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299980" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_Steel_G" typeName="double" displayLabel="G" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299979" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="BottomCoverPlateBeamSegmentAspect">
+        <BaseClass>SteelSPCBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="SteelFlangeBeamSegmentBaseAspect" modifier="Abstract">
+        <BaseClass>SteelBeamSegmentBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegment_StartValue" typeName="double" displayLabel="Start Value" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegment_EndValue" typeName="double" displayLabel="End Value" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegment_StartWidth" typeName="double" displayLabel="Start Width" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegment_StartHeight" typeName="double" displayLabel="Start Height" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegment_EndWidth" typeName="double" displayLabel="End Width" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BeamSegment_EndHeight" typeName="double" displayLabel="End Height" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BottomFlangeBeamSegmentAspect">
+        <BaseClass>SteelFlangeBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BottomPlateBeamSegmentAspect">
+        <BaseClass>SteelBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BridgeAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Bridge_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Bridge" priority="299950"/>
+        <ECProperty propertyName="Bridge_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Bridge" priority="299949"/>
+        <ECProperty propertyName="Bridge_UseRoadwayAlignmentStationing" typeName="boolean" displayLabel="Use Road Alignment For Stationing " category="BridgeModelerAttributes_Bridge" priority="299940"/>
+        <ECProperty propertyName="Bridge_StructureNumber" typeName="string" displayLabel="Structure Number" category="BridgeModelerAttributes_Bridge" priority="299945"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BridgeUnitAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BridgeUnit_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Unit" priority="299950"/>
+        <ECProperty propertyName="BridgeUnit_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Unit" priority="299940"/>
+        <ECProperty propertyName="BridgeUnit_Type" typeName="BridgeUnitAspect_BridgeUnit_Type_Enum" displayLabel="Type" category="BridgeModelerAttributes_Unit" priority="299930"/>
+        <ECProperty propertyName="BridgeUnit_NumberOfSeg" typeName="int" displayLabel="Number Of Segments" category="SegmentProperties_Segment_Properties" priority="299920"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PierFootingBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pierfooting_FootingType" typeName="PierFootingBaseAspect_Pierfooting_FootingType_Enum" displayLabel="Footing Type" category="FootingProperties_Footing" priority="0"/>
+        <ECProperty propertyName="Pierfooting_Material" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PierFootingCommonBaseAspect" modifier="Abstract">
+        <BaseClass>PierFootingBaseAspect</BaseClass>
+        <ECProperty propertyName="PierFooting_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierFooting_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="Pierfooting_AssociationType" typeName="string" displayLabel="Footing Association" category="FootingProperties_Footing" priority="-1"/>
+        <ECProperty propertyName="Pierfooting_AssociatedColumn" typeName="string" displayLabel="Assoc. Column ID" category="FootingProperties_Footing" priority="-2"/>
+        <ECProperty propertyName="Pierfooting_TopElevation" typeName="double" displayLabel="Top Elevation" category="FootingProperties_Footing" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pierfooting_BottomElevation" typeName="double" displayLabel="Bottom Elevation" category="FootingProperties_Footing" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CircularDrilledShaftPierFootingAspect">
+        <BaseClass>PierFootingCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="Pierfooting_DrillShaftHeight" typeName="double" displayLabel="Drilled Shaft Height" category="FootingProperties_Footing" priority="-15" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pierfooting_DrillShaftDiameter" typeName="double" displayLabel="Drilled Shaft Diameter" category="FootingProperties_Footing" priority="-16" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PierColumnBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierColumn_Type" typeName="PierColumnBaseAspect_PierColumn_Type_Enum" displayLabel="Column Type" category="ColumnProperties_Column" priority="0"/>
+        <ECProperty propertyName="PierColumn_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PierColumnCommonBaseAspect" modifier="Abstract">
+        <BaseClass>PierColumnBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierColumn_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierColumn_Length" typeName="double" displayLabel="Length" category="ColumnProperties_Column" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_TopElevation" typeName="double" displayLabel="Top Elevation" category="ColumnProperties_Column" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_OverhangType" typeName="string" displayLabel="Overhang Type" category="ColumnProperties_Column" priority="-12"/>
+        <ECProperty propertyName="PierColumn_Overhang" typeName="double" displayLabel="Overhang" category="ColumnProperties_Column" priority="-13" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CircularPierColumnAspect">
+        <BaseClass>PierColumnCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_Diameter" typeName="double" displayLabel="Diameter" category="ColumnProperties_Column" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PileBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pile_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="Pile_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="Pile_Type" typeName="PileBaseAspect_Pile_Type_Enum" displayLabel="Pile Shape" category="BridgeModelerAttributes_Pier" priority="0"/>
+        <ECProperty propertyName="Pile_PileLength" typeName="double" displayLabel="Pile Length" category="BridgeModelerAttributes_Pier" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_TopMargin" typeName="double" displayLabel="Top Margin" category="BridgeModelerAttributes_Pier" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_BottomMargin" typeName="double" displayLabel="Bottom Margin" category="BridgeModelerAttributes_Pier" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_LeftMargin" typeName="double" displayLabel="Left Margin" category="BridgeModelerAttributes_Pier" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_RightMargin" typeName="double" displayLabel="Right Margin" category="BridgeModelerAttributes_Pier" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_TopElevation" typeName="double" displayLabel="Top Elevation" category="BridgeModelerAttributes_Pier" priority="-6" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_BottomElevation" typeName="double" displayLabel="Bottom Elevation" category="BridgeModelerAttributes_Pier" priority="-7" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_BottomAngleXAdjustment" typeName="double" displayLabel="Longitudinal Angle" category="BridgeModelerAttributes_Pier" priority="-8" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Pile_BottomAngleYAdjustment" typeName="double" displayLabel="Transverse Angle" category="BridgeModelerAttributes_Pier" priority="-9" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Pile_EmbedDepth" typeName="double" displayLabel="Embed Length" category="BridgeModelerAttributes_Pier" priority="-13" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_TopX" typeName="double" displayLabel="Top X" category="BridgeModelerAttributes_Pier" priority="-20" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_TopY" typeName="double" displayLabel="Top Y" category="BridgeModelerAttributes_Pier" priority="-21" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierPile_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+        <ECProperty propertyName="PierPile_PileTypeText" typeName="string" displayLabel="Pile Shape Text" category="PileProperties_Pile" priority="-1"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CircularPileAspect">
+        <BaseClass>PileBaseAspect</BaseClass>
+        <ECProperty propertyName="Pile_PileDiameter" typeName="double" displayLabel="Pile Diameter" category="BridgeModelerAttributes_Pier" priority="-12" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConcreteBeamSegmentBaseAspect" modifier="Abstract">
+        <BaseClass>BeamSegmentCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegment_Template" typeName="string" displayLabel="Template" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299997"/>
+        <ECProperty propertyName="BeamSegment_Material_Concrete_FC" typeName="double" displayLabel="f’c" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299978" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_Concrete_FCi" typeName="double" displayLabel="f’ci" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299977" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeamSegment_Material_Concrete_MR" typeName="double" displayLabel="MR" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299976" kindOfQuantity="cifu:PRESSURE_LARGE">
+            <ECCustomAttributes>
+                <AllowUnitChange xmlns="SchemaUpgradeCustomAttributes.01.00.00">
+                    <From>u:M</From>
+                    <To>u:PA</To>
+                </AllowUnitChange>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConcreteDiaphragmAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ConcreteDiaphragmLayout" typeName="string" displayLabel="Concrete Diaphragm Definition" category="ConcreteDiaphragmProperties_Concrete_Diaphragm" priority="299930"/>
+        <ECProperty propertyName="ConcreteDiaphragm_Name" typeName="string" displayLabel="Name" category="ConcreteDiaphragmProperties_Concrete_Diaphragm" priority="299999"/>
+        <ECProperty propertyName="ConcreteDiaphragmThickness" typeName="double" displayLabel="Thickness" category="ConcreteDiaphragmProperties_Concrete_Diaphragm" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ConcreteDiaphragmVolume" typeName="double" displayLabel="Volume" category="ConcreteDiaphragmProperties_Concrete_Diaphragm" priority="299997" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="ConcreteDiaphragmMaterial" typeName="string" displayLabel="Material" category="ConcreteDiaphragmProperties_Concrete_Diaphragm" priority="299996"/>
+        <ECProperty propertyName="ConcreteDiaphragm_MainBuildOrder" typeName="int" displayLabel="Concrete Diaphragm Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299995"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConcreteDiaphragmGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ConcreteDiaphragmGroup_Name" typeName="string" displayLabel="Name" category="ConcreteDiaphragmGroupProperties_Concrete_Diaphragm_Collection" priority="299950"/>
+        <ECProperty propertyName="ConcreteDiaphragmGroup_Description" typeName="string" displayLabel="Description" category="ConcreteDiaphragmGroupProperties_Concrete_Diaphragm_Collection" priority="299949"/>
+        <ECProperty propertyName="ConcreteDiaphragmGroup_LayoutDefinition" typeName="string" displayLabel="Concrete Diaphragm Definition" category="ConcreteDiaphragmGroupProperties_Concrete_Diaphragm_Collection" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameComponentHolderBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossFrameComponentHolder_Name" typeName="string" displayLabel="Name" category="ComponentProperties_Component_Properties" priority="299999"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_CrossFrameName" typeName="string" displayLabel="Cross-Frame" category="ComponentProperties_Component_Properties" priority="299998"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_CrossFrameGroupName" typeName="string" displayLabel="Cross-Frame Group" category="ComponentProperties_Component_Properties" priority="299997"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Material" typeName="string" displayLabel="Material" category="ComponentProperties_Component_Properties" priority="299995"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Volume" typeName="double" displayLabel="Volume" category="ComponentProperties_Component_Properties" priority="299977" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Weight" typeName="double" displayLabel="Weight" category="ComponentProperties_Component_Properties" priority="299976" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_ComponentType" typeName="CrossFrameComponentHolderBaseAspect_CrossFrameComponentHolder_ComponentType_Enum" displayLabel="Type" category="ComponentProperties_Component_Properties" priority="299975"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_ComponentTypeText" typeName="string" displayLabel="Type Text" category="ComponentProperties_Component_Properties" priority="299974"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameComponentHolderAngleAspect">
+        <BaseClass>CrossFrameComponentHolderBaseAspect</BaseClass>
+        <ECProperty propertyName="CrossFrameComponentHolder_AngleDepth" typeName="double" displayLabel="Angle Depth" category="ComponentProperties_Component_Properties" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_AngleWidth" typeName="double" displayLabel="Angle Width" category="ComponentProperties_Component_Properties" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_AngleHeight" typeName="double" displayLabel="Angle Height" category="ComponentProperties_Component_Properties" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_PlateThickness" typeName="double" displayLabel="Plate Thickness" category="ComponentProperties_Component_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_PlateCornerRadius" typeName="double" displayLabel="Corner Radius" category="ComponentProperties_Component_Properties" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameComponentHolderAspect">
+        <BaseClass>CrossFrameComponentHolderBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameComponentHolderPlateAspect">
+        <BaseClass>CrossFrameComponentHolderBaseAspect</BaseClass>
+        <ECProperty propertyName="CrossFrameComponentHolder_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="ComponentProperties_Component_Properties" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="ComponentProperties_Component_Properties" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Height" typeName="double" displayLabel="Height" category="ComponentProperties_Component_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Width" typeName="double" displayLabel="Width" category="ComponentProperties_Component_Properties" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Thickness" typeName="double" displayLabel="Thickness" category="ComponentProperties_Component_Properties" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameComponentHolderStrutAspect">
+        <BaseClass>CrossFrameComponentHolderBaseAspect</BaseClass>
+        <ECProperty propertyName="CrossFrameComponentHolder_AxialOffsetLeft" typeName="double" displayLabel="Axial Offset Left" category="ComponentProperties_Component_Properties" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_AxialOffsetRight" typeName="double" displayLabel="Axial Offset Right" category="ComponentProperties_Component_Properties" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_VerticalOffsetLeft" typeName="double" displayLabel="Vertical Offset Left" category="ComponentProperties_Component_Properties" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_VerticalOffsetRight" typeName="double" displayLabel="Vertical Offset Right" category="ComponentProperties_Component_Properties" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Length" typeName="double" displayLabel="Length" category="ComponentProperties_Component_Properties" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_Section" typeName="string" displayLabel="Section" category="ComponentProperties_Component_Properties" priority="299996"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameComponentHolderStrutPlateDimensionsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossFrameComponentHolder_PlateThickness" typeName="double" displayLabel="Plate Thickness" category="ComponentProperties_Component_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_PlateCornerRadius" typeName="double" displayLabel="Corner Radius" category="ComponentProperties_Component_Properties" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_PlateDepth" typeName="double" displayLabel="Depth" category="ComponentProperties_Component_Properties" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameComponentHolder_FlangeWidth" typeName="double" displayLabel="Flange Width" category="ComponentProperties_Component_Properties" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameG2Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossFrameG2_Name" typeName="string" displayLabel="Name" category="CrossFrameProperties_Cross_Frame_Properties" priority="299999"/>
+        <ECProperty propertyName="CrossFrameG2_TotalWeight" typeName="double" displayLabel="Total Components Weight" category="CrossFrameProperties_Cross_Frame_Properties" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameG2_TemplateName" typeName="string" displayLabel="Template Name" category="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" priority="299997"/>
+        <ECProperty propertyName="CrossFrameG2_CrossFrameType" typeName="CrossFrameG2Aspect_CrossFrameG2_CrossFrameType_Enum" displayLabel="Cross-Frame Type" category="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" priority="299996"/>
+        <ECProperty propertyName="CrossFrameG2_LayoutDefinition" typeName="string" displayLabel="Cross-Frame Placement" category="CrossFrameProperties_Cross_Frame_Properties" priority="299995"/>
+        <ECProperty propertyName="CrossFrameG2_MainBuildOrder" typeName="int" displayLabel="Crossframe Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299994"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameG2GroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossFrameG2Group_Name" typeName="string" displayLabel="Name" category="CrossFrameGroupProperties_Cross_Frame_Group_Properties" priority="299950"/>
+        <ECProperty propertyName="CrossFrameG2Group_Description" typeName="string" displayLabel="Description" category="CrossFrameGroupProperties_Cross_Frame_Group_Properties" priority="299950"/>
+        <ECProperty propertyName="CrossFrameG2Group_LayoutDefinition" typeName="string" displayLabel="Cross-Frame Placement" category="CrossFrameGroupProperties_Cross_Frame_Group_Properties" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossFrameGroup_Name" typeName="string" displayLabel="Name" category="CrossFrameGroupProperties_Cross_Frame_Group_Properties" priority="299950"/>
+        <ECProperty propertyName="CrossFrameGroup_Description" typeName="string" displayLabel="Description" category="CrossFrameGroupProperties_Cross_Frame_Group_Properties" priority="299950"/>
+        <ECProperty propertyName="CrossFrameGroup_LayoutDefinition" typeName="string" displayLabel="Cross-Frame Placement" category="CrossFrameGroupProperties_Cross_Frame_Group_Properties" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossFrameHolderAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossFrameHolder_Name" typeName="string" displayLabel="Name" category="CrossFrameProperties_Cross_Frame_Properties" priority="299999"/>
+        <ECProperty propertyName="CrossFrameHolder_TotalWeight" typeName="double" displayLabel="Total Components Weight" category="CrossFrameProperties_Cross_Frame_Properties" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossFrameHolder_Template" typeName="string" displayLabel="Template" category="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" priority="299997"/>
+        <ECProperty propertyName="CrossFrameHolder_CrossFrameType" typeName="CrossFrameHolderAspect_CrossFrameHolder_CrossFrameType_Enum" displayLabel="Cross-Frame Type" category="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" priority="299996"/>
+        <ECProperty propertyName="CrossFrameHolder_LayoutDefinition" typeName="string" displayLabel="Cross-Frame Placement" category="CrossFrameProperties_Cross_Frame_Properties" priority="299994"/>
+        <ECProperty propertyName="CrossFrameHolder_MainBuildOrder" typeName="int" displayLabel="Crossframe Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299993"/>
+        <ECProperty propertyName="CrossFrameHolder_TemplateName" typeName="string" displayLabel="Template Name" category="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" priority="299997"/>
+        <ECProperty propertyName="CrossFrameHolder_CrossFrameTypeText" typeName="string" displayLabel="Cross-Frame Type Text" category="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" priority="299995"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomAbutmentAnalyticalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_AnalyticalLongOffset" typeName="double" displayLabel="Longitudinal Offset" category="AnalyticalProperties_Analytical" priority="299948" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_AnalyticalTransvOffset" typeName="double" displayLabel="Transverse Offset" category="AnalyticalProperties_Analytical" priority="299947" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_AbutmentAnalyticalType" typeName="CustomAbutmentAnalyticalAspect_Pier_AbutmentAnalyticalType_Enum" displayLabel="Abutment Type" category="AnalyticalProperties_Analytical" priority="299949"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomAbutmentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Custom_Abutment" priority="299950"/>
+        <ECProperty propertyName="Pier_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Custom_Abutment" priority="299949"/>
+        <ECProperty propertyName="Pier_TemplateName" typeName="string" displayLabel="Cell Name" category="BridgeModelerAttributes_Custom_Abutment" priority="299948"/>
+        <ECProperty propertyName="Pier_PierCapMaterial" typeName="string" displayLabel="Cap Material" category="BridgeModelerAttributes_Material_Material" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnMaterial" typeName="string" displayLabel="Column Material" category="BridgeModelerAttributes_Material_Material" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingMaterial" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299948"/>
+        <ECProperty propertyName="Pier_PileMaterial" typeName="string" displayLabel="Pile Material" category="BridgeModelerAttributes_Material_Material" priority="299946"/>
+        <ECProperty propertyName="Pier_PierCapBuildOrder" typeName="int" displayLabel="Pier Cap Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnBuildOrder" typeName="int" displayLabel="Column Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingBuildOrder" typeName="int" displayLabel="Footing Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299948"/>
+        <ECProperty propertyName="Pier_PileBuildOrder" typeName="int" displayLabel="Pile Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299946"/>
+        <ECProperty propertyName="Pier_AbutmentType" typeName="CustomAbutmentAspect_Pier_AbutmentType_Enum" displayLabel="Abutment Type" category="AnalyticalProperties_Analytical" priority="299950"/>
+        <ECProperty propertyName="Pier_BackWallDepth" typeName="double" displayLabel="Back Wall Depth" category="AnalyticalProperties_Analytical" priority="299942" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_BackWallWidth" typeName="double" displayLabel="Back Wall Width" category="AnalyticalProperties_Analytical" priority="299941" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_BackWallOffset" typeName="double" displayLabel="Back Wall Horizontal Offset" category="AnalyticalProperties_Analytical" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_ConcretePadMaterial" typeName="string" displayLabel="Concrete Pad Material" category="BridgeModelerAttributes_Material_Material" priority="299947"/>
+        <ECProperty propertyName="Pier_ConcretePadBuildOrder" typeName="int" displayLabel="Concrete Pad Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299947"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomAbutmentCapAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_CapLength" typeName="double" displayLabel="Abutment Length" category="AnalyticalProperties_Analytical" priority="299945" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_CapHeight" typeName="double" displayLabel="Cap Height" category="AnalyticalProperties_Analytical" priority="299944" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_CapWidth" typeName="double" displayLabel="Cap Width" category="AnalyticalProperties_Analytical" priority="299943" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomAbutmentFootingAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_FootingLength" typeName="double" displayLabel="Footing Length" category="AnalyticalProperties_Analytical" priority="299938" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_FootingHeight" typeName="double" displayLabel="Footing Height" category="AnalyticalProperties_Analytical" priority="299937" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_FootingWidth" typeName="double" displayLabel="Footing Width" category="AnalyticalProperties_Analytical" priority="299936" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_FtgWidthOffset" typeName="double" displayLabel="Footing Width Offset" category="AnalyticalProperties_Analytical" priority="299935" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_FtgLengthOffset" typeName="double" displayLabel="Footing Length Offset" category="AnalyticalProperties_Analytical" priority="299934" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomAbutmentPileAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_PileNumber" typeName="int" displayLabel="Pile Number" category="AnalyticalProperties_Analytical" priority="299932"/>
+        <ECProperty propertyName="Pier_PileHeight" typeName="double" displayLabel="Pile Height" category="AnalyticalProperties_Analytical" priority="299931" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PileDiameter" typeName="double" displayLabel="Pile Size" category="AnalyticalProperties_Analytical" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PilePattern" typeName="string" displayLabel="Pile Pattern" category="AnalyticalProperties_Analytical" priority="299928"/>
+        <ECProperty propertyName="Pier_PileEdgeDistance" typeName="double" displayLabel="Pile Edge Distance" category="AnalyticalProperties_Analytical" priority="299927" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PileShape" typeName="CustomAbutmentPileAspect_Pier_PileShape_Enum" displayLabel="Pile Shape" category="AnalyticalProperties_Analytical" priority="299929"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomConcreteBeamSegmentAspect">
+        <BaseClass>ConcreteBeamSegmentBaseAspect</BaseClass>
+        <ECProperty propertyName="BeamSegment_IsDualTemplate" typeName="boolean" displayLabel="Is Dual Template" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299996"/>
+        <ECProperty propertyName="BeamSegment_EndTemplate" typeName="string" displayLabel="End Template" category="BeamSegmentProperties_Beam_Segment_Properties" priority="299995"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomObjectAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CustomObject_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomObjectRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CustomObjectRuleCellName" typeName="string" displayLabel="Cell" category="CustomObjectRuleAttributes_Rule_Property" priority="299999"/>
+        <ECProperty propertyName="CustomObjectRuleActiveAngle" typeName="double" displayLabel="Active Angle" category="CustomObjectRuleAttributes_Rule_Property" priority="299998" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="CustomObjectRuleXScale" typeName="double" displayLabel="X-Scale" category="CustomObjectRuleAttributes_Rule_Property" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomObjectRuleYScale" typeName="double" displayLabel="Y-Scale" category="CustomObjectRuleAttributes_Rule_Property" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomObjectRuleZScale" typeName="double" displayLabel="Z-Scale" category="CustomObjectRuleAttributes_Rule_Property" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomObjectRuleHorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="CustomObjectRuleAttributes_Rule_Property" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomObjectRuleVerticalOffset" typeName="double" displayLabel="Vertical Offset" category="CustomObjectRuleAttributes_Rule_Property" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomObjectByDataPointRuleAspect">
+        <BaseClass>CustomObjectRuleAspect</BaseClass>
+        <ECProperty propertyName="CustomObjectByDataPointRule_CellName" typeName="string" displayLabel="Cell" category="AccessoryProperties_Accessory" priority="300000">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectRuleCellName' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByDataPointRule_ActiveAngle" typeName="double" displayLabel="Active Angle" category="AccessoryProperties_Accessory" priority="299999" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="CustomObjectByDataPointRule_XScale" typeName="double" displayLabel="X-Scale" category="AccessoryProperties_Accessory" priority="299998" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectRuleXScale' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByDataPointRule_YScale" typeName="double" displayLabel="Y-Scale" category="AccessoryProperties_Accessory" priority="299997" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectRuleYScale' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByDataPointRule_ZScale" typeName="double" displayLabel="Z-Scale" category="AccessoryProperties_Accessory" priority="299996" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectRuleZScale' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByDataPointRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="AccessoryProperties_Accessory" priority="299995" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectRuleHorizontalOffset' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByDataPointRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="AccessoryProperties_Accessory" priority="299994" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectRuleVerticalOffset' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByDataPointRule_Number" typeName="int" displayLabel="Number" category="AccessoryProperties_Accessory" priority="200000"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomObjectByPathRuleAspect">
+        <BaseClass>CustomObjectRuleAspect</BaseClass>
+        <ECProperty propertyName="CustomObjectByPathRuleStartStation" typeName="double" displayLabel="Start Station" category="CustomObjectRuleAttributes_Rule_Property" priority="299989" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CustomObjectByPathRuleStartStation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectByPathRuleStartStation' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByPathRuleEndStation" typeName="double" displayLabel="End Station" category="CustomObjectRuleAttributes_Rule_Property" priority="299988" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CustomObjectByPathRuleEndStation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'CustomObjectByPathRuleEndStation' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByPathRuleDistance" typeName="double" displayLabel="Distance" category="CustomObjectRuleAttributes_Rule_Property" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomObjectByPathRuleNumber" typeName="int" displayLabel="Number" category="CustomObjectRuleAttributes_Rule_Property" priority="299986"/>
+        <ECProperty propertyName="CustomObjectByPathRuleFrequencyMode" typeName="string" displayLabel="-- deprecated --" category="CustomObjectRuleAttributes_Rule_Property" priority="299985">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new CustomObjectByPathRuleFrequencyModeEnum property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CustomObjectByPathRuleAngleCalculation" typeName="CustomObjectByPathRuleAspect_CustomObjectByPathRuleAngleCalculation_Enum" displayLabel="Angle Calculation" category="CustomObjectRuleAttributes_Rule_Property" priority="299984"/>
+        <ECProperty propertyName="CustomObjectByPathRuleFrequencyModeEnum" typeName="CustomObjectByPathRuleAspect_CustomObjectByPathRuleFrequencyModeEnum_Enum" displayLabel="Mode" category="CustomObjectRuleAttributes_Rule_Property" priority="299985"/>
+        <ECProperty propertyName="CustomObjectByPathRuleVerticalOrientation" typeName="CustomObjectByPathRuleAspect_CustomObjectByPathRuleVerticalOrientation_Enum" displayLabel="Vertical Orientation" category="CustomObjectRuleAttributes_Rule_Property" priority="299983"/>
+        <ECProperty propertyName="CustomObjectByPathRule_ActiveAngle" typeName="double" displayLabel="Active Angle" category="AccessoryProperties_Accessory" priority="299999" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierAnalyticalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_AnalyticalTransvOffset" typeName="double" displayLabel="Transverse Offset" category="AnalyticalProperties_Analytical" priority="299949" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PierAnalyticalType" typeName="CustomPierAnalyticalAspect_Pier_PierAnalyticalType_Enum" displayLabel="Pier Type" category="AnalyticalProperties_Analytical" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Custom_Pier" priority="299950"/>
+        <ECProperty propertyName="Pier_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Custom_Pier" priority="299949"/>
+        <ECProperty propertyName="Pier_TemplateName" typeName="string" displayLabel="Cell Name" category="BridgeModelerAttributes_Custom_Pier" priority="299948"/>
+        <ECProperty propertyName="Pier_PierCapMaterial" typeName="string" displayLabel="Cap Material" category="BridgeModelerAttributes_Material_Material" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnMaterial" typeName="string" displayLabel="Column Material" category="BridgeModelerAttributes_Material_Material" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingMaterial" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299948"/>
+        <ECProperty propertyName="Pier_PileMaterial" typeName="string" displayLabel="Pile Material" category="BridgeModelerAttributes_Material_Material" priority="299946"/>
+        <ECProperty propertyName="Pier_PierCapBuildOrder" typeName="int" displayLabel="Pier Cap Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnBuildOrder" typeName="int" displayLabel="Column Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingBuildOrder" typeName="int" displayLabel="Footing Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299948"/>
+        <ECProperty propertyName="Pier_PileBuildOrder" typeName="int" displayLabel="Pile Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299946"/>
+        <ECProperty propertyName="Pier_ConcretePadMaterial" typeName="string" displayLabel="Concrete Pad Material" category="BridgeModelerAttributes_Material_Material" priority="299947"/>
+        <ECProperty propertyName="Pier_ConcretePadBuildOrder" typeName="int" displayLabel="Concrete Pad Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299947"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierBySupportLineRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CustomPierBySupportLineRuleCellName" typeName="string" displayLabel="Cell" category="CustomPierRuleAttributes_Rule_Property" priority="299999"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleCellType" typeName="string" displayLabel="Type" category="CustomPierRuleAttributes_Rule_Property" priority="299998"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleActiveAngle" typeName="double" displayLabel="Active Angle" category="CustomPierRuleAttributes_Rule_Property" priority="299997" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleXScale" typeName="double" displayLabel="X-Scale" category="CustomPierRuleAttributes_Rule_Property" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleYScale" typeName="double" displayLabel="Y-Scale" category="CustomPierRuleAttributes_Rule_Property" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleZScale" typeName="double" displayLabel="Z-Scale" category="CustomPierRuleAttributes_Rule_Property" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleHorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="CustomPierRuleAttributes_Rule_Property" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleVerticalOffset" typeName="double" displayLabel="Vertical Offset" category="CustomPierRuleAttributes_Rule_Property" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleSupportLineOffset" typeName="double" displayLabel="SupportLine Offset" category="CustomPierRuleAttributes_Rule_Property" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CustomPierBySupportLineRule_LengthAdjustment" typeName="CustomPierBySupportLineRuleAspect_CustomPierBySupportLineRule_LengthAdjustment_Enum" displayLabel="Cap Length Adjustment" category="CustomPierRuleAttributes_Rule_Property" priority="299989"/>
+        <ECProperty propertyName="CustomPierBySupportLineRule_DeckLengthReference" typeName="CustomPierBySupportLineRuleAspect_CustomPierBySupportLineRule_DeckLengthReference_Enum" displayLabel="Deck Length Side" category="CustomPierRuleAttributes_Rule_Property" priority="299988"/>
+        <ECProperty propertyName="CustomPierBySupportLineRule_TopSlopeMode" typeName="CustomPierBySupportLineRuleAspect_CustomPierBySupportLineRule_TopSlopeMode_Enum" displayLabel="Top Slope" category="CustomPierRuleAttributes_Rule_Property" priority="299990"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleIgnoreSupportLinewSkew" typeName="boolean" displayLabel="Ignore Support Line Skew" category="CustomPierRuleAttributes_Rule_Property" priority="299987"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleMappedPlacementAngle" typeName="string" displayLabel="Placement Angle" category="GenCompMappedAttributes_Gen_Comp_Mapped" priority="299986"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleMappedCapLength" typeName="string" displayLabel="Cap Length" category="GenCompMappedAttributes_Gen_Comp_Mapped" priority="299986"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleMappedHorizontalOffset" typeName="string" displayLabel="Horizontal Offset" category="GenCompMappedAttributes_Gen_Comp_Mapped" priority="299984"/>
+        <ECProperty propertyName="CustomPierBySupportLineRuleMappedVerticalOffset" typeName="string" displayLabel="Vertical Offset" category="GenCompMappedAttributes_Gen_Comp_Mapped" priority="299983"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierCapAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_CapLength" typeName="double" displayLabel="Cap Length" category="AnalyticalProperties_Analytical" priority="299947" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_CapHeight" typeName="double" displayLabel="Cap Height" category="AnalyticalProperties_Analytical" priority="299946" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_CapWidth" typeName="double" displayLabel="Cap Width" category="AnalyticalProperties_Analytical" priority="299945" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierColumnAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_ColumnNumber" typeName="int" displayLabel="Column Number" category="AnalyticalProperties_Analytical" priority="299943"/>
+        <ECProperty propertyName="Pier_ColumnHeight" typeName="double" displayLabel="Column Height" category="AnalyticalProperties_Analytical" priority="299942" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_ColumnDiameter" typeName="double" displayLabel="Column Diameter" category="AnalyticalProperties_Analytical" priority="299941" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierFootingAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_FootingLength" typeName="double" displayLabel="Footing Length" category="AnalyticalProperties_Analytical" priority="299939" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_FootingHeight" typeName="double" displayLabel="Footing Height" category="AnalyticalProperties_Analytical" priority="299938" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_FootingWidth" typeName="double" displayLabel="Footing Width" category="AnalyticalProperties_Analytical" priority="299937" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CustomPierPileAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_PileNumber" typeName="int" displayLabel="Pile Number" category="AnalyticalProperties_Analytical" priority="299935"/>
+        <ECProperty propertyName="Pier_PileHeight" typeName="double" displayLabel="Pile Height" category="AnalyticalProperties_Analytical" priority="299934" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PileDiameter" typeName="double" displayLabel="Pile Diameter" category="AnalyticalProperties_Analytical" priority="299933" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PilePattern" typeName="string" displayLabel="Pile Pattern" category="AnalyticalProperties_Analytical" priority="299931"/>
+        <ECProperty propertyName="Pier_PileEdgeDistance" typeName="double" displayLabel="Pile Edge Distance" category="AnalyticalProperties_Analytical" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pier_PileShape" typeName="CustomPierPileAspect_Pier_PileShape_Enum" displayLabel="Pile Shape" category="AnalyticalProperties_Analytical" priority="299932"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DeckByMultiTemplateRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeckByMultiTemplateRule_StartOffset" typeName="double" displayLabel="Start Station Offset" category="DeckProperties_Deck" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByMultiTemplateRule_EndOffset" typeName="double" displayLabel="End Station Offset" category="DeckProperties_Deck" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByMultiTemplateRule_HorizOffset" typeName="double" displayLabel="Horizontal Offset" category="DeckProperties_Deck" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByMultiTemplateRule_VertOffset" typeName="double" displayLabel="Vertical Offset" category="DeckProperties_Deck" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByMultiTemplateRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="DeckProperties_Deck" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByMultiTemplateRule_MaxDistBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="DeckProperties_Deck" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByMultiTemplateRule_OpenIntervalsXmlFragment" typeName="string" displayLabel="Deck Definition" category="DeckProperties_Deck" priority="299993">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="DeckByTemplateRuleAspect">
+        <BaseClass>SolidByTemplateRuleAspect</BaseClass>
+        <ECProperty propertyName="DeckByTemplateRule_StartOffset" typeName="double" displayLabel="Start Station Offset" category="DeckProperties_Deck" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_EndOffset" typeName="double" displayLabel="End Station Offset" category="DeckProperties_Deck" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_TemplateOrientation" typeName="DeckByTemplateRuleAspect_DeckByTemplateRule_TemplateOrientation_Enum" displayLabel="Template Orientation" category="DeckProperties_Deck" priority="299993"/>
+        <ECProperty propertyName="DeckByTemplateRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="DeckProperties_Deck" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="DeckProperties_Deck" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_Template" typeName="string" displayLabel="Template" category="DeckProperties_Deck" priority="299988"/>
+        <ECProperty propertyName="DeckByTemplateRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="DeckProperties_Deck" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="DeckProperties_Deck" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="DeckProperties_Deck" priority="299985"/>
+        <ECProperty propertyName="DeckByTemplateRule_PointControl" typeName="string" displayLabel="Point Control" category="DeckProperties_Deck" priority="299984"/>
+        <ECProperty propertyName="DeckByTemplateRule_LeftStartBreakbackDistance" typeName="double" displayLabel="Left Start Breakback Distance" category="DeckBreakbackProperties_Deck_Breakbacks" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_RightStartBreakbackDistance" typeName="double" displayLabel="Right Start Breakback Distance" category="DeckBreakbackProperties_Deck_Breakbacks" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_LeftEndBreakbackDistance" typeName="double" displayLabel="Left End Breakback Distance" category="DeckBreakbackProperties_Deck_Breakbacks" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeckByTemplateRule_RightEndBreakbackDistance" typeName="double" displayLabel="Right End Breakback Distance" category="DeckBreakbackProperties_Deck_Breakbacks" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DeckPropertiesAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeckProperties_Name" typeName="string" displayLabel="Name" category="DeckProperties_Deck" priority="399950"/>
+        <ECProperty propertyName="DeckProperties_Description" typeName="string" displayLabel="Description" category="DeckProperties_Deck" priority="399940"/>
+        <ECProperty propertyName="DeckProperties_TemplateName" typeName="string" displayLabel="Template Name" category="DeckProperties_Deck" priority="399930"/>
+        <ECProperty propertyName="DeckProperties_IsAnalytical" typeName="boolean" displayLabel="Analytical Deck" category="DeckProperties_Deck" priority="399920"/>
+        <ECProperty propertyName="DeckProperties_TopSurfaceArea" typeName="double" displayLabel="Top Surface Area" category="DeckProperties_Deck" priority="200000" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="DeckProperties_MainMaterial" typeName="string" displayLabel="Deck Material" category="BridgeModelerAttributes_Material_Material" priority="399920"/>
+        <ECProperty propertyName="DeckProperties_MainBuildOrder" typeName="int" displayLabel="Deck Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399910"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsAbutmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AbutmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAbutmentWingComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AbutmentWingComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAbutmentWingWallAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AbutmentWingWallAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAccessoryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AccessoryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAccessoryComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AccessoryComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsApproachRefLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ApproachRefLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsApproachRefLineRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ApproachRefLineRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsApproachSlabAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ApproachSlabAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsApproachSlabByTemplateRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ApproachSlabByTemplateRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAppurtenanceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AppurtenanceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAppurtenanceComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AppurtenanceComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAuxObjectAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AuxObjectAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAuxObjectByDataPointRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AuxObjectByDataPointRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAuxObjectRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AuxObjectRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBarrierAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BarrierAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBarrierByTemplateRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BarrierByTemplateRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBeamCorridorAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BeamCorridorAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBeamGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BeamGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBeamSeatAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BeamSeatAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBeamSegmentCollectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BeamSegmentCollectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBeamSegmentCollectionWithIDsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BeamSegmentCollectionWithIDsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBeamSegmentWidthAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BeamSegmentWidthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingBySupportLineAndBeamsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingBySupportLineAndBeamsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingBySupportLineAndDecksRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingBySupportLineAndDecksRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingBySupportLineRuleCellAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingBySupportLineRuleCellAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingBySupportLineRuleCubeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingBySupportLineRuleCubeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingBySupportLineRuleCylinderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingBySupportLineRuleCylinderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingCellAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingCellAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingCubeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingCubeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingCylinderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingCylinderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBearingGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BearingGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBottomCoverPlateBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BottomCoverPlateBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBottomFlangeBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BottomFlangeBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBottomPlateBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BottomPlateBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBridgeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BridgeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBridgeUnitAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BridgeUnitAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCircularDrilledShaftPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CircularDrilledShaftPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCircularPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CircularPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCircularPileAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="true">
+            <Class class="CircularPileAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConcreteDiaphragmAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConcreteDiaphragmAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConcreteDiaphragmGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConcreteDiaphragmGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameComponentHolderAngleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameComponentHolderAngleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameComponentHolderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameComponentHolderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameComponentHolderPlateAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameComponentHolderPlateAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameComponentHolderStrutAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameComponentHolderStrutAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameComponentHolderStrutPlateDimensionsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameComponentHolderStrutPlateDimensionsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameG2Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameG2Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameG2GroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameG2GroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossFrameHolderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossFrameHolderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomAbutmentAnalyticalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomAbutmentAnalyticalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomAbutmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomAbutmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomAbutmentCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomAbutmentCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomAbutmentFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomAbutmentFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomAbutmentPileAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomAbutmentPileAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomConcreteBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomConcreteBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomObjectAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomObjectAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomObjectByDataPointRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomObjectByDataPointRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomObjectByPathRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomObjectByPathRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomObjectRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomObjectRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierAnalyticalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierAnalyticalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierBySupportLineRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierBySupportLineRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCustomPierPileAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CustomPierPileAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDeckByMultiTemplateRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DeckByMultiTemplateRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDeckByTemplateRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DeckByTemplateRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDeckPropertiesAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DeckPropertiesAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ExcavationAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Excavation_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Excavation_Properties" priority="299999"/>
+        <ECProperty propertyName="Excavation_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Excavation_Properties" priority="299998"/>
+        <ECProperty propertyName="Excavation_Volume" typeName="double" displayLabel="Volume" category="BridgeModelerAttributes_Excavation_Properties" priority="299997" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Excavation_MaterialMain" typeName="string" displayLabel="Cut Material" category="BridgeModelerAttributes_Material_Material" priority="299996"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsExcavationAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ExcavationAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ExcavationRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ExcavationRule_TerrainModel" typeName="string" displayLabel="Terrain Model" category="ExcavationRuleAttributes_Excavation_Rule" priority="299999"/>
+        <ECProperty propertyName="ExcavationRule_WpOffset" typeName="double" displayLabel="Horizontal Offset" category="ExcavationRuleAttributes_Excavation_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ExcavationRule_VerticalSheeting" typeName="boolean" displayLabel="Vertical Sheeting" category="ExcavationRuleAttributes_Excavation_Rule" priority="299997"/>
+        <ECProperty propertyName="ExcavationRule_SweepAngle" typeName="double" displayLabel="Corner Sweep Angle" category="ExcavationRuleAttributes_Excavation_Rule" priority="299996" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ExcavationRule_SideSlope" typeName="string" displayLabel="Side Slope" category="ExcavationRuleAttributes_Excavation_Rule" priority="299995"/>
+        <ECProperty propertyName="ExcavationRule_VerticalOffset" typeName="double" displayLabel="Bottom Vertical Offset" category="ExcavationRuleAttributes_Excavation_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ExcavationRule_BottomOffset" typeName="double" displayLabel="Bottom Horiz. Offset" category="ExcavationRuleAttributes_Excavation_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ExcavationRule_BottomSlope" typeName="string" displayLabel="Bottom Slope" category="ExcavationRuleAttributes_Excavation_Rule" priority="299992"/>
+        <ECProperty propertyName="ExcavationRule_Combined" typeName="boolean" displayLabel="Combined Excavation" category="ExcavationRuleAttributes_Excavation_Rule" priority="299991"/>
+        <ECProperty propertyName="ExcavationRule_AllowOverlap" typeName="boolean" displayLabel="Allow Overlaping" category="ExcavationRuleAttributes_Excavation_Rule" priority="299990"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsExcavationRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ExcavationRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FieldSpliceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FieldSplice_Name" typeName="string" displayLabel="Name" category="FieldSpliceProperties_Field_Splice_Properties" priority="300000"/>
+        <ECProperty propertyName="FieldSplice_BoltDiameter" typeName="double" displayLabel="Bolt Diameter" category="FieldSpliceProperties_Field_Splice_Properties" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_TotalNumberOfBolts" typeName="int" displayLabel="Total Number Of Bolts" category="FieldSpliceProperties_Field_Splice_Properties" priority="299998"/>
+        <ECProperty propertyName="FieldSplice_TopFlangePlateLength" typeName="double" displayLabel="TF Plate Length" category="TopFlangePlatesProperties_Top_Flange_Plates_Properties" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_TopFlangeOutsidePlateWidth" typeName="double" displayLabel="TF Outside Plate Width" category="TopFlangePlatesProperties_Top_Flange_Plates_Properties" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_TopFlangeOutsidePlateTickness" typeName="double" displayLabel="TF Outside Plate Thickness" category="TopFlangePlatesProperties_Top_Flange_Plates_Properties" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_TopFlangeInsidePlateWidth" typeName="double" displayLabel="TF Inside Plate Width" category="TopFlangePlatesProperties_Top_Flange_Plates_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_TopFlangeInsidePlateThickness" typeName="double" displayLabel="TF Inside Plate Thickness" category="TopFlangePlatesProperties_Top_Flange_Plates_Properties" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_TopFlangeBolts" typeName="int" displayLabel="TF Bolts" category="TopFlangePlatesProperties_Top_Flange_Plates_Properties" priority="299992"/>
+        <ECProperty propertyName="FieldSplice_BottomFlangePlateLength" typeName="double" displayLabel="BF Plate Length" category="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_BottomFlangeOutsidePlateWidth" typeName="double" displayLabel="BF Outside Plate Width" category="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_BottomFlangeOutsidePlateTickness" typeName="double" displayLabel="BF Outside Plate Thickness" category="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_BottomFlangeInsidePlateWidth" typeName="double" displayLabel="BF Inside Plate Width" category="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_BottomFlangeInsidePlateThickness" typeName="double" displayLabel="BF Inside Plate Thickness" category="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_BottomFlangeBolts" typeName="int" displayLabel="BF Bolts" category="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" priority="299986"/>
+        <ECProperty propertyName="FieldSplice_WebPlateLength" typeName="double" displayLabel="Web Plate Length" category="WebPlatesbProperties_Web_Plates_Properties" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_WebOutsidePlateHeight" typeName="double" displayLabel="Web Plate Height" category="WebPlatesbProperties_Web_Plates_Properties" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_WebOutsidePlateTickness" typeName="double" displayLabel="Web Plate Thickness" category="WebPlatesbProperties_Web_Plates_Properties" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FieldSplice_WebBolts" typeName="int" displayLabel="Web Bolts" category="WebPlatesbProperties_Web_Plates_Properties" priority="299982"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFieldSpliceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FieldSpliceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FieldSpliceComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FieldSpliceComponent_Name" typeName="string" displayLabel="Name" category="FieldSpliceComponentProperties_Field_Splice_Component_Properties" priority="299950"/>
+        <ECProperty propertyName="FieldSpliceComponent_Type" typeName="string" displayLabel="Type" category="FieldSpliceComponentProperties_Field_Splice_Component_Properties" priority="299949"/>
+        <ECProperty propertyName="FieldSpliceComponent_Material" typeName="string" displayLabel="Material" category="FieldSpliceComponentProperties_Field_Splice_Component_Properties" priority="299948"/>
+        <ECProperty propertyName="FieldSpliceComponent_Volume" typeName="double" displayLabel="Volume" category="FieldSpliceComponentProperties_Field_Splice_Component_Properties" priority="299946" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="FieldSpliceComponent_Count" typeName="int" displayLabel="Count" category="FieldSpliceComponentProperties_Field_Splice_Component_Properties" priority="299944"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFieldSpliceComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FieldSpliceComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FieldSpliceGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FieldSpliceGroup_Name" typeName="string" displayLabel="Name" category="FieldSpliceGroupProperties_Field_Splice_Group" priority="299950"/>
+        <ECProperty propertyName="FieldSpliceGroup_Description" typeName="string" displayLabel="Description" category="FieldSpliceGroupProperties_Field_Splice_Group" priority="299949"/>
+        <ECProperty propertyName="FieldSpliceGroup_LayoutDefinition" typeName="string" displayLabel="Field Splice Placement" category="FieldSpliceGroupProperties_Field_Splice_Group" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFieldSpliceGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FieldSpliceGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="HaunchBeamSegmentAspect">
+        <BaseClass>BeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHaunchBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="HaunchBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularPileBaseAspect" modifier="Abstract">
+        <BaseClass>PileBaseAspect</BaseClass>
+        <ECProperty propertyName="Pile_PileWidth" typeName="double" displayLabel="Pile Width" category="BridgeModelerAttributes_Pier" priority="-10" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_PileDepth" typeName="double" displayLabel="Pile Depth" category="BridgeModelerAttributes_Pier" priority="-11" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="HPileAspect">
+        <BaseClass>RectangularPileBaseAspect</BaseClass>
+        <ECProperty propertyName="Pile_ThicknessOutside" typeName="double" displayLabel="Flange Thickness" category="BridgeModelerAttributes_Pier" priority="-14" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_ThicknessInside" typeName="double" displayLabel="Web Thickness" category="BridgeModelerAttributes_Pier" priority="-15" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_RotationAngle" typeName="double" displayLabel="Rotation" category="BridgeModelerAttributes_Pier" priority="-16" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Pile_Template" typeName="string" displayLabel="Template" category="BridgeModelerAttributes_Pier" priority="-17"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHPileAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="true">
+            <Class class="HPileAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierCapBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierCap_Type" typeName="PierCapBaseAspect_PierCap_Type_Enum" displayLabel="Cap Type" category="CapProperties_Cap" priority="0"/>
+        <ECProperty propertyName="PierCap_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PierCapCommonBaseAspect" modifier="Abstract">
+        <BaseClass>PierCapBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierCap_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="RegularPierCapBaseAspect" modifier="Abstract">
+        <BaseClass>PierCapCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_Length" typeName="double" displayLabel="Length" category="CapProperties_Cap" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_Width" typeName="double" displayLabel="Width" category="CapProperties_Cap" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_Height" typeName="double" displayLabel="Height" category="CapProperties_Cap" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_ElevationLeft" typeName="double" displayLabel="Elevation Left" category="CapProperties_Cap" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_ElevationRight" typeName="double" displayLabel="Elevation Right" category="CapProperties_Cap" priority="-6" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="InvertedTPierCapAspect">
+        <BaseClass>RegularPierCapBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_LedgeWidth" typeName="double" displayLabel="Ledge Width" category="CapProperties_Cap" priority="-9" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_LedgeDepth" typeName="double" displayLabel="Ledge Depth" category="CapProperties_Cap" priority="-10" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsInvertedTPierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="InvertedTPierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LEAPConcreteBeamSegmentAspect">
+        <BaseClass>ConcreteBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLEAPConcreteBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LEAPConcreteBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NonePierCapAspect">
+        <BaseClass>PierCapBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNonePierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NonePierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NonePierColumnAspect">
+        <BaseClass>PierColumnBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNonePierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NonePierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NonePierFootingAspect">
+        <BaseClass>PierFootingBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNonePierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NonePierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="OvalPierColumnAspect">
+        <BaseClass>PierColumnBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_DiameterX" typeName="double" displayLabel="Diameter X" category="ColumnProperties_Column" priority="-6" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_DiameterY" typeName="double" displayLabel="Diameter Y" category="ColumnProperties_Column" priority="-7" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierColumn_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierColumn_Length" typeName="double" displayLabel="Length" category="ColumnProperties_Column" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_TopElevation" typeName="double" displayLabel="Top Elevation" category="ColumnProperties_Column" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_OverhangType" typeName="string" displayLabel="Overhang Type" category="ColumnProperties_Column" priority="-12"/>
+        <ECProperty propertyName="PierColumn_Overhang" typeName="double" displayLabel="Overhang" category="ColumnProperties_Column" priority="-13" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOvalPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="OvalPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pier_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_Pier" priority="299950"/>
+        <ECProperty propertyName="Pier_Description" typeName="string" displayLabel="Description" category="BridgeModelerAttributes_Pier" priority="299949"/>
+        <ECProperty propertyName="Pier_TemplateName" typeName="string" displayLabel="Template Name" category="BridgeModelerAttributes_Pier" priority="299948"/>
+        <ECProperty propertyName="Pier_PierCapMaterial" typeName="string" displayLabel="Cap Material" category="BridgeModelerAttributes_Material_Material" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnMaterial" typeName="string" displayLabel="Column Material" category="BridgeModelerAttributes_Material_Material" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingMaterial" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299948"/>
+        <ECProperty propertyName="Pier_PileMaterial" typeName="string" displayLabel="Pile Material" category="BridgeModelerAttributes_Material_Material" priority="299946"/>
+        <ECProperty propertyName="Pier_PierCapBuildOrder" typeName="int" displayLabel="Pier Cap Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299950"/>
+        <ECProperty propertyName="Pier_ColumnBuildOrder" typeName="int" displayLabel="Column Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299949"/>
+        <ECProperty propertyName="Pier_FootingBuildOrder" typeName="int" displayLabel="Footing Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299948"/>
+        <ECProperty propertyName="Pier_PileBuildOrder" typeName="int" displayLabel="Pile Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299946"/>
+        <ECProperty propertyName="Pier_ConcretePadMaterial" typeName="string" displayLabel="Concrete Pad Material" category="BridgeModelerAttributes_Material_Material" priority="299947"/>
+        <ECProperty propertyName="Pier_ConcretePadBuildOrder" typeName="int" displayLabel="Concrete Pad Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299947"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierBellAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierBell_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierBell_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierBell_TopDiameter" typeName="double" displayLabel="Bell Top Diameter" category="BellProperties_Bell" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBell_BottomDiameter" typeName="double" displayLabel="Bell Bottom Diameter" category="BellProperties_Bell" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBell_SlopedHeight" typeName="double" displayLabel="Bell Sloped Height" category="BellProperties_Bell" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBell_StraightHeight" typeName="double" displayLabel="Bell Straight Height" category="BellProperties_Bell" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBell_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierBellAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierBellAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierBySupportLineRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierBySupportLineRule_ElevationConstraints" typeName="string" displayLabel="Elevation Constraints" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299999"/>
+        <ECProperty propertyName="PierBySupportLineRule_PierTemplate" typeName="string" displayLabel="Substructure Template" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299998"/>
+        <ECProperty propertyName="PierBySupportLineRule_ApplySkewToSolids" typeName="boolean" displayLabel="Apply Skew To Solids" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299997"/>
+        <ECProperty propertyName="PierBySupportLineRuleConformBackWallWithDeckTop" typeName="boolean" displayLabel="Conform BackWall With Deck Top" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299996"/>
+        <ECProperty propertyName="PierBySupportLineRuleBackWallVerticalOffsetFromDeckTop" typeName="double" displayLabel="BackWall Vertical Offset From Deck Top" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBySupportLineRule_IsIntegral" typeName="boolean" displayLabel="Integral" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299994"/>
+        <ECProperty propertyName="PierBySupportLineRule_WpOffset" typeName="double" displayLabel="Horizontal Offset" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBySupportLineRule_LongitudinalOffset" typeName="double" displayLabel="Longitudinal Offset" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBySupportLineRule_LengthAdjustment" typeName="PierBySupportLineRuleAspect_PierBySupportLineRule_LengthAdjustment_Enum" displayLabel="Cap Length Adjustment" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299991"/>
+        <ECProperty propertyName="PierBySupportLineRule_SupportLineType" typeName="PierBySupportLineRuleAspect_PierBySupportLineRule_SupportLineType_Enum" displayLabel="Orientation" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299990"/>
+        <ECProperty propertyName="PierBySupportLineRuleConformCorbelWithApproachBot" typeName="boolean" displayLabel="Conform Corbel With Approach Slab Bottom" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299989"/>
+        <ECProperty propertyName="PierBySupportLineRuleConformCorbelBotWithApproach" typeName="boolean" displayLabel="Conform Corbel Bottom With Approach Slab" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299988"/>
+        <ECProperty propertyName="PierBySupportLineRuleCorbelVerticalOffsetFromApproachBot" typeName="double" displayLabel="Corbel Vertical Offset from Approach Slab" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierBySupportLineRuleConformNotchWithApproach" typeName="boolean" displayLabel="Conform Notch With Approach Slab" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299986"/>
+        <ECProperty propertyName="PierBySupportLineRuleNotchVerticalOffsetFromApproach" typeName="double" displayLabel="Notch Vertical Offset from Approach Slab" category="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierBySupportLineRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierBySupportLineRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierCheekWallAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierCheekWall_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierCheekWall_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierCheekWall_Height" typeName="double" displayLabel="Height" category="CheekWallProperties_Cheek_Wall" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCheekWall_TopLength" typeName="double" displayLabel="Top Length" category="CheekWallProperties_Cheek_Wall" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCheekWall_BtmLength" typeName="double" displayLabel="Bottom Length" category="CheekWallProperties_Cheek_Wall" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCheekWall_Width" typeName="double" displayLabel="Width" category="CheekWallProperties_Cheek_Wall" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCheekWall_WidthOffset" typeName="double" displayLabel="Width Offset" category="CheekWallProperties_Cheek_Wall" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCheekWall_LengthOffset" typeName="double" displayLabel="Length Offset" category="CheekWallProperties_Cheek_Wall" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCheekWall_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierCheekWallAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierCheekWallAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierComponent_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierCrashWallAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierCrashWall_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierCrashWall_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierCrashWall_WallExtraLengthTop" typeName="double" displayLabel="Wall Extra Length Top" category="CrashWallProperties_Crash_Wall" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCrashWall_WallExtraLengthBottom" typeName="double" displayLabel="Wall Extra Length Bottom" category="CrashWallProperties_Crash_Wall" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCrashWall_WallThicknessTop" typeName="double" displayLabel="Wall Thickness Top" category="CrashWallProperties_Crash_Wall" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCrashWall_WallThicknessBottom" typeName="double" displayLabel="Wall Thickness Bottom" category="CrashWallProperties_Crash_Wall" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCrashWall_WallHeight" typeName="double" displayLabel="Wall Height" category="CrashWallProperties_Crash_Wall" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCrashWall_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierCrashWallAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierCrashWallAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierFootingSlopedExtraTopLengthAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pierfooting_SlopedExtraTopLength" typeName="double" displayLabel="Top Extra Length" category="FootingProperties_Footing" priority="-14" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierFootingSlopedExtraTopLengthAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierFootingSlopedExtraTopLengthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierFootingWithConcretePadAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierFooting_ConcretePadTransverseOffset" typeName="double" displayLabel="Concrete Pad Transverse Offset" category="FootingProperties_Footing" priority="-17" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierFooting_ConcretePadThickness" typeName="double" displayLabel="Concrete Pad Thickness" category="FootingProperties_Footing" priority="-19" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierFooting_ConcretePadLongitudinalOffset" typeName="double" displayLabel="Concrete Pad Longitudinal Offset" category="FootingProperties_Footing" priority="-18" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierFootingWithConcretePadAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierFootingWithConcretePadAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierRockSocketAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierRockSocket_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierRockSocket_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierRockSocket_Diameter" typeName="double" displayLabel="Rock Socket Diameter" category="RockSocketProperties_Rock_Socket" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierRockSocket_Length" typeName="double" displayLabel="Rock Socket Length" category="RockSocketProperties_Rock_Socket" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierRockSocket_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierRockSocketAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierRockSocketAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PierStrutAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierStrut_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="PierStrut_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierStrut_Height" typeName="double" displayLabel="Height" category="StrutProperties_Strut" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_Depth" typeName="double" displayLabel="Depth" category="StrutProperties_Strut" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_OffsetFromCap" typeName="double" displayLabel="Offset From Cap" category="StrutProperties_Strut" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_EndOffset" typeName="double" displayLabel="Right Offset" category="StrutProperties_Strut" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_ExtensionLength" typeName="double" displayLabel="Extension Length" category="StrutProperties_Strut" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_StartCol" typeName="int" displayLabel="Start Column" category="StrutProperties_Strut" priority="-5"/>
+        <ECProperty propertyName="PierStrut_EndCol" typeName="int" displayLabel="End Column" category="StrutProperties_Strut" priority="-6"/>
+        <ECProperty propertyName="PierStrut_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPierStrutAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PierStrutAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PileWallPierCapBaseAspect" modifier="Abstract">
+        <BaseClass>PierCapCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_BackWallDepth" typeName="double" displayLabel="Back Wall Depth" category="CapProperties_Cap" priority="-16" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_BackWallWidth" typeName="double" displayLabel="Back Wall Width" category="CapProperties_Cap" priority="-17" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_HorizontalOffset" typeName="double" displayLabel="Back Wall Horizontal Offset" category="CapProperties_Cap" priority="-18" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_VerticalOffset" typeName="double" displayLabel="Back Wall Vertical Offset" category="CapProperties_Cap" priority="-19" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_Length" typeName="double" displayLabel="Length" category="CapProperties_Cap" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_Width" typeName="double" displayLabel="Width" category="CapProperties_Cap" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_Height" typeName="double" displayLabel="Height" category="CapProperties_Cap" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_ElevationLeft" typeName="double" displayLabel="Elevation Left" category="CapProperties_Cap" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_ElevationRight" typeName="double" displayLabel="Elevation Right" category="CapProperties_Cap" priority="-6" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PileCapPierCapAspect">
+        <BaseClass>PileWallPierCapBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPileCapPierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PileCapPierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PileWallPierCapCorbelBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PierCap_HasCorbel" typeName="boolean" displayLabel="Corbel" category="CapProperties_Cap" priority="-24"/>
+        <ECProperty propertyName="PierCap_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PileWallPierCapNoCorbelAspect">
+        <BaseClass>PileWallPierCapCorbelBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPileWallPierCapNoCorbelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PileWallPierCapNoCorbelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PileWallPierCapWithCorbelAspect">
+        <BaseClass>PileWallPierCapCorbelBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_CorbelWidth" typeName="double" displayLabel="Corbel Width" category="CapProperties_Cap" priority="-20" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_CorbelDepth" typeName="double" displayLabel="Corbel Depth" category="CapProperties_Cap" priority="-21" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_CorbelSlopeDepth" typeName="double" displayLabel="Corbel Slope Depth" category="CapProperties_Cap" priority="-22" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_CorbelVertOffset" typeName="double" displayLabel="Corbel Vertical Offset" category="CapProperties_Cap" priority="-23" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPileWallPierCapWithCorbelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PileWallPierCapWithCorbelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangleDrilledShaftPierFootingAspect">
+        <BaseClass>PierFootingBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangleDrilledShaftPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangleDrilledShaftPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularPierColumnBaseAspect" modifier="Abstract">
+        <BaseClass>PierColumnCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_Width" typeName="double" displayLabel="Width" category="ColumnProperties_Column" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_Depth" typeName="double" displayLabel="Depth" category="ColumnProperties_Column" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="RectangularBevelPierColumnAspect">
+        <BaseClass>RectangularPierColumnBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_BevelX" typeName="double" displayLabel="Bevel Length X" category="ColumnProperties_Column" priority="-8" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierColumn_BevelY" typeName="double" displayLabel="Bevel Length Y" category="ColumnProperties_Column" priority="-9" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularBevelPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularBevelPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularChamferPierColumnAspect">
+        <BaseClass>RectangularPierColumnBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_ChamferLength" typeName="double" displayLabel="Fillet Radius" category="ColumnProperties_Column" priority="-11" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularChamferPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularChamferPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularCombinedCommonPierFootingAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Pierfooting_SlopedExtraTopLength" typeName="double" displayLabel="Top Extra Length" category="FootingProperties_Footing" priority="-14" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularCombinedCommonPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularCombinedCommonPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularPierFootingBaseAspect" modifier="Abstract">
+        <BaseClass>PierFootingCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="Pierfooting_RotationAngle" typeName="double" displayLabel="Rotation" category="FootingProperties_Footing" priority="-5" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Pierfooting_Sloped" typeName="boolean" displayLabel="Sloped" category="FootingProperties_Footing" priority="-6"/>
+        <ECProperty propertyName="Pierfooting_Height" typeName="double" displayLabel="Height" category="FootingProperties_Footing" priority="-9" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pierfooting_SlopeHeight" typeName="double" displayLabel="Slope Depth" category="FootingProperties_Footing" priority="-10" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pierfooting_SlopedTopWidth" typeName="double" displayLabel="Top Width" category="FootingProperties_Footing" priority="-11" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pierfooting_SlopedTopLength" typeName="double" displayLabel="Top Length" category="FootingProperties_Footing" priority="-12" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierFooting_HasConcretePad" typeName="boolean" displayLabel="Concrete Pad" category="FootingProperties_Footing" priority="-20"/>
+        <ECProperty propertyName="PierFooting_ConcretePadMaterial" typeName="string" displayLabel="Concrete Pad Material" category="BridgeModelerAttributes_Material_Material" priority="299920">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="RectangularPierFootingCommonBaseAspect" modifier="Abstract">
+        <BaseClass>RectangularPierFootingBaseAspect</BaseClass>
+        <ECProperty propertyName="Pierfooting_Width" typeName="double" displayLabel="Width" category="FootingProperties_Footing" priority="-7" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="RectangularCombinedPierFootingAspect">
+        <BaseClass>RectangularPierFootingCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="Pierfooting_ExtraLength" typeName="double" displayLabel="Extra Length" category="FootingProperties_Footing" priority="-13" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularCombinedPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularCombinedPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularFilletPierColumnAspect">
+        <BaseClass>RectangularPierColumnBaseAspect</BaseClass>
+        <ECProperty propertyName="PierColumn_FilletRadius" typeName="double" displayLabel="Fillet Radius" category="ColumnProperties_Column" priority="-10" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularFilletPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularFilletPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularIsolatedPierFootingAspect">
+        <BaseClass>RectangularPierFootingCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="Pierfooting_Length" typeName="double" displayLabel="Length" category="FootingProperties_Footing" priority="-8" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularIsolatedPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularIsolatedPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RegularPierCapCommonBaseAspect" modifier="Abstract">
+        <BaseClass>RegularPierCapBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_FilletRadius" typeName="double" displayLabel="Fillet Radius" category="CapProperties_Cap" priority="-7" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_ChamferLength" typeName="double" displayLabel="Chamfer Length" category="CapProperties_Cap" priority="-8" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="RectangularPierCapAspect">
+        <BaseClass>RegularPierCapCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_BottomLength" typeName="double" displayLabel="Bottom Length" category="CapProperties_Cap" priority="-11" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_BottomWidth" typeName="double" displayLabel="Bottom Width" category="CapProperties_Cap" priority="-12" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularPierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularPierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularPierColumnAspect">
+        <BaseClass>RectangularPierColumnBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularPierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectangularPierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectangularPileAspect">
+        <BaseClass>RectangularPileBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectangularPileAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="true">
+            <Class class="RectangularPileAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RectCombinedWithCrashWallPierFootingAspect">
+        <BaseClass>RectangularPierFootingBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRectCombinedWithCrashWallPierFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RectCombinedWithCrashWallPierFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RolledShapesBeamSegmentAspect">
+        <BaseClass>SteelSPCBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRolledShapesBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RolledShapesBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentalBalanceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SegmentalBalance_Name" typeName="string" displayLabel="Name" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="399950"/>
+        <ECProperty propertyName="SegmentalBalance_Description" typeName="string" displayLabel="Description" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="399940"/>
+        <ECProperty propertyName="SegmentalBalance_TemplateName" typeName="string" displayLabel="Template Name" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="399930"/>
+        <ECProperty propertyName="SegmentalBalance_NumberOfSeg" typeName="int" displayLabel="Number Of Segments" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="399920"/>
+        <ECProperty propertyName="SegmentalBalance_Volume" typeName="double" displayLabel="Volume" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="399910" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="SegmentalBalance_SurfaceArea" typeName="double" displayLabel="Surface Area" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="399900" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SegmentalBalance_MaterialPierName" typeName="string" displayLabel="Pier Material" category="BridgeModelerAttributes_Material_Material" priority="400000"/>
+        <ECProperty propertyName="SegmentalBalance_MaterialTypicalName" typeName="string" displayLabel="Typical Material" category="BridgeModelerAttributes_Material_Material" priority="399999"/>
+        <ECProperty propertyName="SegmentalBalance_MaterialExtensionName" typeName="string" displayLabel="Expansion Material" category="BridgeModelerAttributes_Material_Material" priority="399998"/>
+        <ECProperty propertyName="SegmentalBalance_MaterialCIPName" typeName="string" displayLabel="Closure Material" category="BridgeModelerAttributes_Material_Material" priority="399997"/>
+        <ECProperty propertyName="SegmentalBalance_BuildOrderPierName" typeName="int" displayLabel="Pier Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399996"/>
+        <ECProperty propertyName="SegmentalBalance_BuildOrderTypicalName" typeName="int" displayLabel="Typical Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399995"/>
+        <ECProperty propertyName="SegmentalBalance_BuildOrderExtensionName" typeName="int" displayLabel="Expansion Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399994"/>
+        <ECProperty propertyName="SegmentalBalance_BuildOrderCIPName" typeName="int" displayLabel="Closure Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399993"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentalBalanceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentalBalanceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentalBalanceRuleAspect">
+        <BaseClass>SolidByTemplateRuleAspect</BaseClass>
+        <ECProperty propertyName="SegmentalBalanceRule_NumberOfTypical" typeName="int" displayLabel="Number Of Typical" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299999"/>
+        <ECProperty propertyName="SegmentalBalanceRule_TypSegLength" typeName="string" displayLabel="Seg. Length (#@L1 #@L2 | #@L1)" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299998"/>
+        <ECProperty propertyName="SegmentalBalanceRule_PierSegLength" typeName="string" displayLabel="Pier Seg Length (Back : Ahead)" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299997"/>
+        <ECProperty propertyName="SegmentalBalanceRule_CIPSegLength" typeName="double" displayLabel="CIP Length" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalBalanceRule_Offset" typeName="double" displayLabel="Start Station Offset" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalBalanceRule_UseChord" typeName="boolean" displayLabel="Chorded" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299994"/>
+        <ECProperty propertyName="SegmentalBalanceRule_MaxTypical" typeName="boolean" displayLabel="Maximize Typical Segments" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299993"/>
+        <ECProperty propertyName="SegmentalBalanceRule_TemplateOrientation" typeName="SegmentalBalanceRuleAspect_SegmentalBalanceRule_TemplateOrientation_Enum" displayLabel="Template Orientation" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299992"/>
+        <ECProperty propertyName="SegmentalBalanceRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalBalanceRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalBalanceRule_Template" typeName="string" displayLabel="Template" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299988"/>
+        <ECProperty propertyName="SegmentalBalanceRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalBalanceRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalBalanceRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299985">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SegmentalBalanceRule_PointControl" typeName="string" displayLabel="Point Control" category="SegmentalBalancedCategory_Segmental_Cantilever" priority="299984"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentalBalanceRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentalBalanceRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentalSpanAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SegmentalSpan_Name" typeName="string" displayLabel="Name" category="SegmentalSpanCategory_Span_by_Span" priority="399950"/>
+        <ECProperty propertyName="SegmentalSpan_Description" typeName="string" displayLabel="Description" category="SegmentalSpanCategory_Span_by_Span" priority="399940"/>
+        <ECProperty propertyName="SegmentalSpan_TemplateName" typeName="string" displayLabel="Template Name" category="SegmentalSpanCategory_Span_by_Span" priority="399935"/>
+        <ECProperty propertyName="SegmentalSpan_NumberOfSpan" typeName="int" displayLabel="Number Of Spans" category="SegmentalSpanCategory_Span_by_Span" priority="399930"/>
+        <ECProperty propertyName="SegmentalSpan_NumberOfSeg" typeName="int" displayLabel="Number Of Segments" category="SegmentalSpanCategory_Span_by_Span" priority="399920"/>
+        <ECProperty propertyName="SegmentalSpan_Volume" typeName="double" displayLabel="Volume" category="SegmentalSpanCategory_Span_by_Span" priority="399910" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="SegmentalSpan_SurfaceArea" typeName="double" displayLabel="Surface Area" category="SegmentalSpanCategory_Span_by_Span" priority="399900" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SegmentalSpan_MaterialPierName" typeName="string" displayLabel="Pier Material" category="BridgeModelerAttributes_Material_Material" priority="400000"/>
+        <ECProperty propertyName="SegmentalSpan_MaterialTypicalName" typeName="string" displayLabel="Typical Material" category="BridgeModelerAttributes_Material_Material" priority="399999"/>
+        <ECProperty propertyName="SegmentalSpan_MaterialExtensionName" typeName="string" displayLabel="Expansion Material" category="BridgeModelerAttributes_Material_Material" priority="399998"/>
+        <ECProperty propertyName="SegmentalSpan_MaterialCIPName" typeName="string" displayLabel="Closure Material" category="BridgeModelerAttributes_Material_Material" priority="399997"/>
+        <ECProperty propertyName="SegmentalSpan_BuildOrderPierName" typeName="int" displayLabel="Pier Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399996"/>
+        <ECProperty propertyName="SegmentalSpan_BuildOrderTypicalName" typeName="int" displayLabel="Typical Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399995"/>
+        <ECProperty propertyName="SegmentalSpan_BuildOrderExtensionName" typeName="int" displayLabel="Expansion Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399994"/>
+        <ECProperty propertyName="SegmentalSpan_BuildOrderCIPName" typeName="int" displayLabel="Closure Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="399993"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentalSpanAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentalSpanAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentalSpanBetweenSupportLinesRuleAspect">
+        <BaseClass>SolidByTemplateRuleAspect</BaseClass>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_StartOffset" typeName="double" displayLabel="Start Station Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_EndOffset" typeName="double" displayLabel="End Station Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_ExpEndBentLength" typeName="double" displayLabel="Expansion EndBent Length" category="SegmentalSpanCategory_Span_by_Span" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_TypSegLength" typeName="double" displayLabel="Typical Length" category="SegmentalSpanCategory_Span_by_Span" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_PierSegLength" typeName="double" displayLabel="Pier Typical Length" category="SegmentalSpanCategory_Span_by_Span" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_UseChord" typeName="boolean" displayLabel="Chorded" category="SegmentalSpanCategory_Span_by_Span" priority="299985"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_UseVariableConstraint" typeName="boolean" displayLabel="Use Variable Constraint" category="SegmentalSpanCategory_Span_by_Span" priority="299984"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_UsePointConstraint" typeName="boolean" displayLabel="Use Point Constraint" category="SegmentalSpanCategory_Span_by_Span" priority="299983"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_SplitClosure" typeName="boolean" displayLabel="Split Closure" category="SegmentalSpanCategory_Span_by_Span" priority="299982"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRuleTemplateOrientation" typeName="SegmentalSpanBetweenSupportLinesRuleAspect_SegmentalSpanBetweenSupportLinesRuleTemplateOrientation_Enum" displayLabel="Template Orientation" category="SegmentalSpanCategory_Span_by_Span" priority="299981"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_Template" typeName="string" displayLabel="Template" category="SegmentalSpanCategory_Span_by_Span" priority="299988"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="SegmentalSpanCategory_Span_by_Span" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="SegmentalSpanCategory_Span_by_Span" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="SegmentalSpanCategory_Span_by_Span" priority="299985">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SegmentalSpanBetweenSupportLinesRule_PointControl" typeName="string" displayLabel="Point Control" category="SegmentalSpanCategory_Span_by_Span" priority="299984"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentalSpanBetweenSupportLinesRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentalSpanBetweenSupportLinesRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentalSpanRuleAspect">
+        <BaseClass>SolidByTemplateRuleAspect</BaseClass>
+        <ECProperty propertyName="SegmentalSpanRule_StartOffset" typeName="double" displayLabel="Start Station Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_EndOffset" typeName="double" displayLabel="End Station Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_ExpEndBentLength" typeName="double" displayLabel="Expansion EndBent Length" category="SegmentalSpanCategory_Span_by_Span" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_ExpPierLength" typeName="double" displayLabel="Expansion Pier Length" category="SegmentalSpanCategory_Span_by_Span" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_TypSegLength" typeName="double" displayLabel="Typical Length" category="SegmentalSpanCategory_Span_by_Span" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_PierSegLength" typeName="double" displayLabel="Pier Typical Length" category="SegmentalSpanCategory_Span_by_Span" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_UseChord" typeName="boolean" displayLabel="Chorded" category="SegmentalSpanCategory_Span_by_Span" priority="299993"/>
+        <ECProperty propertyName="SegmentalSpanRule_SplitClosure" typeName="boolean" displayLabel="Split Closure" category="SegmentalSpanCategory_Span_by_Span" priority="299992"/>
+        <ECProperty propertyName="SegmentalSpanRuleTemplateOrientation" typeName="SegmentalSpanRuleAspect_SegmentalSpanRuleTemplateOrientation_Enum" displayLabel="Template Orientation" category="SegmentalSpanCategory_Span_by_Span" priority="299991"/>
+        <ECProperty propertyName="SegmentalSpanRule_HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="SegmentalSpanCategory_Span_by_Span" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_Template" typeName="string" displayLabel="Template" category="SegmentalSpanCategory_Span_by_Span" priority="299988"/>
+        <ECProperty propertyName="SegmentalSpanRule_ChordTolerance" typeName="double" displayLabel="Chord Tolerance" category="SegmentalSpanCategory_Span_by_Span" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_MaximumDistanceBetweenSections" typeName="double" displayLabel="Max Dist Between Sections" category="SegmentalSpanCategory_Span_by_Span" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentalSpanRule_VarConst" typeName="string" displayLabel="Variable Constraint" category="SegmentalSpanCategory_Span_by_Span" priority="299985">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SegmentalSpanRule_PointControl" typeName="string" displayLabel="Point Control" category="SegmentalSpanCategory_Span_by_Span" priority="299984"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentalSpanRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentalSpanRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Segment_Name" typeName="string" displayLabel="Name" category="SegmentProperties_Segment_Properties" priority="299985"/>
+        <ECProperty propertyName="Segment_Length" typeName="double" displayLabel="Length" category="SegmentProperties_Segment_Properties" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Segment_Type" typeName="string" displayLabel="Type" category="SegmentProperties_Segment_Properties" priority="299983"/>
+        <ECProperty propertyName="Segment_Side" typeName="string" displayLabel="Side" category="SegmentProperties_Segment_Properties" priority="299982"/>
+        <ECProperty propertyName="Segment_Index" typeName="int" displayLabel="Index" category="SegmentProperties_Segment_Properties" priority="299981"/>
+        <ECProperty propertyName="Segment_Volume" typeName="double" displayLabel="Volume" category="SegmentProperties_Segment_Properties" priority="299980" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Segment_Weight" typeName="double" displayLabel="Weight" category="SegmentProperties_Segment_Properties" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Segment_Area" typeName="double" displayLabel="Surface Area" category="SegmentProperties_Segment_Properties" priority="299978" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Segment_BuildOrder" typeName="int" displayLabel="Build Order" category="SegmentProperties_Segment_Properties" priority="299977"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SegmentCollectionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SegmentCollection_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSegmentCollectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SegmentCollectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ShearConnectorGroupGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ShearConnectorGroupGroup_Name" typeName="string" displayLabel="Name" category="ShearConnectorGroupsProperties_Shear_Studs_Groups_Properties" priority="299950"/>
+        <ECProperty propertyName="ShearConnectorGroupGroup_Description" typeName="string" displayLabel="Description" category="ShearConnectorGroupsProperties_Shear_Studs_Groups_Properties" priority="299940"/>
+        <ECProperty propertyName="ShearConnectorGroupGroup_LayoutDefinition" typeName="string" displayLabel="Shear Studs Placement" category="ShearConnectorGroupsProperties_Shear_Studs_Groups_Properties" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsShearConnectorGroupGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ShearConnectorGroupGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ShearConnectorHolderAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ShearConnectorHolder_Name" typeName="string" displayLabel="Name" category="ShearConnectorProperties_Shear_Stud_Properties" priority="299999"/>
+        <ECProperty propertyName="ShearConnectorHolder_ShearConnectorArrangementName" typeName="string" displayLabel="Shear Studs Group" category="ShearConnectorProperties_Shear_Stud_Properties" priority="299998"/>
+        <ECProperty propertyName="ShearConnectorHolder_ShearConnectorGroupName" typeName="string" displayLabel="Shear Studs Groups" category="ShearConnectorProperties_Shear_Stud_Properties" priority="299997"/>
+        <ECProperty propertyName="ShearConnectorHolder_Section" typeName="string" displayLabel="Template" category="ShearConnectorProperties_Shear_Stud_Properties" priority="299996"/>
+        <ECProperty propertyName="ShearConnectorHolder_Volume" typeName="double" displayLabel="Volume" category="ShearConnectorProperties_Shear_Stud_Properties" priority="299995" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="ShearConnectorHolder_Weight" typeName="double" displayLabel="Weight" category="ShearConnectorProperties_Shear_Stud_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsShearConnectorHolderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ShearConnectorHolderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ShearConnectorsHolderAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ShearConnectorsHolder_Name" typeName="string" displayLabel="Name" category="ConnectorGroupArrangementProperties_Shear_Studs_Group_Properties" priority="299999"/>
+        <ECProperty propertyName="ShearConnectorsHolder_Template" typeName="string" displayLabel="Template" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299998"/>
+        <ECProperty propertyName="ShearConnectorsHolder_ConnectorType" typeName="ShearConnectorsHolderAspect_ShearConnectorsHolder_ConnectorType_Enum" displayLabel="Shear Connector Type" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299997"/>
+        <ECProperty propertyName="ShearConnectorsHolder_Section" typeName="string" displayLabel="Section" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299996"/>
+        <ECProperty propertyName="ShearConnectorsHolder_Material" typeName="string" displayLabel="Material" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299995"/>
+        <ECProperty propertyName="ShearConnectorsHolder_Height" typeName="double" displayLabel="Total Height" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ShearConnectorsHolder_HeadHeight" typeName="double" displayLabel="Head Height" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ShearConnectorsHolder_Diameter" typeName="double" displayLabel="Stud Diameter" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ShearConnectorsHolder_HeadDiameter" typeName="double" displayLabel="Head Diameter" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ShearConnectorsHolder_Length" typeName="double" displayLabel="&lt;- TotalLength -&gt;" category="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ShearConnectorsHolder_TotalWeight" typeName="double" displayLabel="Total Components Weight" category="ConnectorGroupArrangementProperties_Shear_Studs_Group_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ShearConnectorsHolder_TotalVolume" typeName="double" displayLabel="Total Components Volume" category="ConnectorGroupArrangementProperties_Shear_Studs_Group_Properties" priority="299987" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="ShearConnectorsHolder_LayoutDefinition" typeName="string" displayLabel="Shear Studs Placement" category="ConnectorGroupArrangementProperties_Shear_Studs_Group_Properties" priority="299986"/>
+        <ECProperty propertyName="ShearConnectorsHolder_MainBuildOrder" typeName="int" displayLabel="Shear Studs Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="299985"/>
+        <ECProperty propertyName="ShearConnectorsHolder_TotalNumber" typeName="int" displayLabel="Total Studs Number" category="ConnectorGroupArrangementProperties_Shear_Studs_Group_Properties" priority="299989"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsShearConnectorsHolderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ShearConnectorsHolderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SleeperSlab_Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SleeperSlab_Name" typeName="string" displayLabel="Name" category="SleeperSlabProperties_Sleeper_Slab" priority="400000"/>
+        <ECProperty propertyName="SleeperSlab_Description" typeName="string" displayLabel="Description" category="SleeperSlabProperties_Sleeper_Slab" priority="399999"/>
+        <ECProperty propertyName="SleeperSlab_TemplateName" typeName="string" displayLabel="Template Name" category="SleeperSlabProperties_Sleeper_Slab" priority="200000"/>
+        <ECProperty propertyName="SleeperSlab_Length" typeName="double" displayLabel="Length" category="SleeperSlabProperties_Sleeper_Slab" priority="199999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_Width" typeName="double" displayLabel="Width" category="SleeperSlabProperties_Sleeper_Slab" priority="199998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_Height" typeName="double" displayLabel="Height" category="SleeperSlabProperties_Sleeper_Slab" priority="199997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_ElevationLeft" typeName="double" displayLabel="Elevation Left" category="SleeperSlabProperties_Sleeper_Slab" priority="199996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_ElevationRight" typeName="double" displayLabel="Elevation Right" category="SleeperSlabProperties_Sleeper_Slab" priority="199995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_BackWallDepth" typeName="double" displayLabel="Back Wall Depth" category="SleeperSlabProperties_Sleeper_Slab" priority="199994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_BackWallWidth" typeName="double" displayLabel="Back Wall Width" category="SleeperSlabProperties_Sleeper_Slab" priority="199993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_HorizontalOffset" typeName="double" displayLabel="Back Wall Horizontal Offset" category="SleeperSlabProperties_Sleeper_Slab" priority="199992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_VerticalOffset" typeName="double" displayLabel="Back Wall Vertical Offset" category="SleeperSlabProperties_Sleeper_Slab" priority="199991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlab_MainMaterial" typeName="string" displayLabel="Sleeper Slab Material" category="BridgeModelerAttributes_Material_Material" priority="199990"/>
+        <ECProperty propertyName="SleeperSlab_MainBuildOrder" typeName="int" displayLabel="Build Order" category="BridgeModelerAttributes_BuildOrder_Build_Order" priority="199989"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSleeperSlab_Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SleeperSlab_Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SleeperSlabByApproachRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SleeperSlabByApproachRuleTemplateXmlFragment" typeName="string" displayLabel="Sleeper Slab Template" category="SleeperSlabProperties_Sleeper_Slab" priority="299999"/>
+        <ECProperty propertyName="SleeperSlabByApproachRule_ElevationConstraints" typeName="string" displayLabel="Elevation Constraints" category="SleeperSlabProperties_Sleeper_Slab" priority="299998"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleHorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="SleeperSlabProperties_Sleeper_Slab" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleLongitudinalOffset" typeName="double" displayLabel="Longitudinal Offset" category="SleeperSlabProperties_Sleeper_Slab" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleConformBackWallWithDeckTop" typeName="boolean" displayLabel="Conform Back Wall With Approach Top" category="SleeperSlabProperties_Sleeper_Slab" priority="299995"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleBWVertOffsetFromApproachSlabTop" typeName="double" displayLabel="Back Wall Vertical Offset From Slab Top" category="SleeperSlabProperties_Sleeper_Slab" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleConformWithDeckBot" typeName="boolean" displayLabel="Conform With Approach Bottom" category="SleeperSlabProperties_Sleeper_Slab" priority="299993"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleVertOffsetFromApproachSlabBot" typeName="double" displayLabel="Vertical Offset From Slab Bottom" category="SleeperSlabProperties_Sleeper_Slab" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSlabByApproachRule_LengthAdjustment" typeName="SleeperSlabByApproachRuleAspect_SleeperSlabByApproachRule_LengthAdjustment_Enum" displayLabel="Sleeper Length Adjustment" category="SleeperSlabProperties_Sleeper_Slab" priority="299991"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleApplySkewToSolids" typeName="boolean" displayLabel="Apply Skew To Solids" category="SleeperSlabProperties_Sleeper_Slab" priority="299990"/>
+        <ECProperty propertyName="SleeperSlabByApproachRuleLocation" typeName="SleeperSlabByApproachRuleAspect_SleeperSlabByApproachRuleLocation_Enum" displayLabel="Location" category="SleeperSlabProperties_Sleeper_Slab" priority="300000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSleeperSlabByApproachRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SleeperSlabByApproachRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsSolidByTemplateRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SolidByTemplateRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SolidEntityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SolidEntity_SurfaceArea" typeName="double" displayLabel="Surface Area" category="SolidAttributes_Solid" priority="299940" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SolidEntity_Volume" typeName="double" displayLabel="Volume" category="SolidAttributes_Solid" priority="299950" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSolidEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SolidEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StemWallPierCapAspect">
+        <BaseClass>PileWallPierCapBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_FootingOffset" typeName="double" displayLabel="Footing Offset" category="CapProperties_Cap" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStemWallPierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StemWallPierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StrutAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>StrutAspect is no longer in use. Use PierStrutAspect instead.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="Strut_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="Strut_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="PierStrut_Height" typeName="double" displayLabel="Height" category="StrutProperties_Strut" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_Depth" typeName="double" displayLabel="Depth" category="StrutProperties_Strut" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_OffsetFromCap" typeName="double" displayLabel="Offset From Cap" category="StrutProperties_Strut" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_EndOffset" typeName="double" displayLabel="Right Offset" category="StrutProperties_Strut" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_ExtensionLength" typeName="double" displayLabel="Extension Length" category="StrutProperties_Strut" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierStrut_StartCol" typeName="int" displayLabel="Start Column" category="StrutProperties_Strut" priority="-5"/>
+        <ECProperty propertyName="PierStrut_EndCol" typeName="int" displayLabel="End Column" category="StrutProperties_Strut" priority="-6"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStrutAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StrutAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SupportLineAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SupportLine_Name" typeName="string" displayLabel="Name" category="SupportLineProperties_SupportLine" priority="299950"/>
+        <ECProperty propertyName="SupportLine_Description" typeName="string" displayLabel="Description" category="SupportLineProperties_SupportLine" priority="299940"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSupportLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SupportLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SupportLineBtMidPointRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SupportLineBtMidPointRule_Length" typeName="double" displayLabel="Length" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_DirectionInputMode" typeName="SupportLineBtMidPointRuleAspect_SupportLineBtMidPointRule_DirectionInputMode_Enum" displayLabel="Direction Mode" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299996"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_Direction" typeName="double" displayLabel="Direction" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299995" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_StationAlong" typeName="double" displayLabel="Distance Along" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_StationAlong_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'SupportLineBtMidPointRule_StationAlong' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SupportLineBtMidPointRule_Skew" typeName="double" displayLabel="Skew" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299994" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_TargetLineStartPoint" typeName="point3d" displayLabel="Start Point" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299993"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_DistanceAlong" typeName="double" displayLabel="&lt;- DistanceAlong -&gt;" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299992" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SupportLineBtMidPointRule_Station" typeName="double" displayLabel="Station" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299997" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="SupportLineBtMidPointRule_Offset" typeName="double" displayLabel="Horizontal Offset" category="SupportLineRuleAttributes_SupportLine_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSupportLineBtMidPointRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SupportLineBtMidPointRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TaperedPierCapAspect">
+        <BaseClass>RegularPierCapCommonBaseAspect</BaseClass>
+        <ECProperty propertyName="PierCap_MinimumHeight" typeName="double" displayLabel="Minimum Height" category="CapProperties_Cap" priority="-13" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_LeftDelta" typeName="double" displayLabel="Left Taper Length" category="CapProperties_Cap" priority="-14" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PierCap_RightDelta" typeName="double" displayLabel="Right Taper Length" category="CapProperties_Cap" priority="-15" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTaperedPierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TaperedPierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TendonAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Tendon_Name" typeName="string" displayLabel="Name" category="TendonGroupProperties_Tendon_Properties" priority="299950"/>
+        <ECProperty propertyName="Tendon_NumberOfStrands" typeName="int" displayLabel="Number Of Strands" category="TendonGroupProperties_Tendon_Properties" priority="299949"/>
+        <ECProperty propertyName="Tendon_Description" typeName="string" displayLabel="Description" category="TendonGroupProperties_Tendon_Properties" priority="299948"/>
+        <ECProperty propertyName="Tendon_Type" typeName="string" displayLabel="Type" category="TendonGroupProperties_Tendon_Properties" priority="299947"/>
+        <ECProperty propertyName="Tendon_Material" typeName="string" displayLabel="Tendon Material" category="TendonGroupProperties_Tendon_Properties" priority="299946"/>
+        <ECProperty propertyName="Tendon_Diameter" typeName="double" displayLabel="Tendon Diameter" category="TendonGroupProperties_Tendon_Properties" priority="299945" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_Area" typeName="double" displayLabel="Tendon Area" category="TendonGroupProperties_Tendon_Properties" priority="299944" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Tendon_DuctDiameter" typeName="double" displayLabel="Duct Diameter" category="TendonGroupProperties_Tendon_Properties" priority="299943" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_DuctArea" typeName="double" displayLabel="Duct Area" category="TendonGroupProperties_Tendon_Properties" priority="299942" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Tendon_Length" typeName="double" displayLabel="Length" category="TendonGroupProperties_Tendon_Properties" priority="299941" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_Number" typeName="int" displayLabel="Number" category="TendonGroupProperties_Tendon_Properties" priority="299940"/>
+        <ECProperty propertyName="TendonPROPTendonDirty" typeName="boolean" displayLabel="Seg. Geom. Changed" category="TendonGroupProperties_Tendon_Properties" priority="299939"/>
+        <ECProperty propertyName="Tendon_Profile" typeName="string" displayLabel="Profile" category="TendonGroupProperties_Tendon_Properties" priority="299938"/>
+        <ECProperty propertyName="Tendon_Master" typeName="string" displayLabel="Master" category="TendonGroupProperties_Tendon_Properties" priority="299937"/>
+        <ECProperty propertyName="Tendon_IsActive" typeName="string" displayLabel="Is Active" category="TendonGroupProperties_Tendon_Properties" priority="299936"/>
+        <ECProperty propertyName="Tendon_SleeveLengthBeg" typeName="double" displayLabel="Sleeve Length Beg" category="TendonGroupProperties_Tendon_Properties" priority="299935" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_SleeveLengthEnd" typeName="double" displayLabel="Sleeve Length End" category="TendonGroupProperties_Tendon_Properties" priority="299934" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_DevLengthBeg" typeName="double" displayLabel="Dev Length Beg" category="TendonGroupProperties_Tendon_Properties" priority="299933" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_DevLengthEnd" typeName="double" displayLabel="Dev Length End" category="TendonGroupProperties_Tendon_Properties" priority="299932" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Tendon_Beta" typeName="double" displayLabel="Beta" category="TendonGroupProperties_Tendon_Properties" priority="299931"/>
+        <ECProperty propertyName="Tendon_BetaUnit" typeName="string" displayLabel="Tenadon Beta Unit" category="TendonGroupProperties_Tendon_Properties" priority="299930">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Tendon_FrictionCoeff" typeName="double" displayLabel="Friction Coefficient" category="TendonGroupProperties_Tendon_Properties" priority="299929"/>
+        <ECProperty propertyName="Tendon_WobbleFactorK" typeName="double" displayLabel="Wobble Factor" category="TendonGroupProperties_Tendon_Properties" priority="299928"/>
+        <ECProperty propertyName="Tendon_WobbleFactorUnit" typeName="double" displayLabel="Wobble Factor Unit" category="TendonGroupProperties_Tendon_Properties" priority="299927">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Tendon_Actions" typeName="string" displayLabel="Tendon Actions" category="TendonGroupProperties_Tendon_Properties" priority="299926"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTendonAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TendonAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TopCoverPlateBeamSegmentAspect">
+        <BaseClass>SteelSPCBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTopCoverPlateBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TopCoverPlateBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TopFlangeBeamSegmentAspect">
+        <BaseClass>SteelFlangeBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTopFlangeBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TopFlangeBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TopPlateBeamSegmentAspect">
+        <BaseClass>SteelBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTopPlateBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TopPlateBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TransverseStiffenerAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TransverseStiffener_Name" typeName="string" displayLabel="Name" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299999"/>
+        <ECProperty propertyName="TransverseStiffenerOffsetFromTopOfWeb" typeName="double" displayLabel="Top Of Web Offset" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerOffsetFromBtmOfWeb" typeName="double" displayLabel="Btm Of Web Offset" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerHeight" typeName="double" displayLabel="Height" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerWidth" typeName="double" displayLabel="Width" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerThickness" typeName="double" displayLabel="Thickness" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerTopInnerH" typeName="double" displayLabel="Top Inner H" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerTopInnerV" typeName="double" displayLabel="Top Inner V" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerTopOuterH" typeName="double" displayLabel="Top Outer H" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerTopOuterV" typeName="double" displayLabel="Top Outer V" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerBtmInnerH" typeName="double" displayLabel="Btm Inner H" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerBtmInnerV" typeName="double" displayLabel="Btm Inner V" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerBtmOuterH" typeName="double" displayLabel="Btm Outer H" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerBtmOuterV" typeName="double" displayLabel="Btm Outer V" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TransverseStiffenerVolume" typeName="double" displayLabel="Volume" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299985" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="TransverseStiffenerTemplateName" typeName="string" displayLabel="Template Name" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299984"/>
+        <ECProperty propertyName="TransverseStiffenerMaterial" typeName="string" displayLabel="Material" category="TransverseStiffenerProperties_Transverse_Stiffener_Properties" priority="299983"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTransverseStiffenerAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TransverseStiffenerAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TransverseStiffenerGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TransverseStiffenerGroup_Name" typeName="string" displayLabel="Name" category="TransverseStiffenerGroupProperties_Transverse_Stiffener_Group_Properties" priority="299950"/>
+        <ECProperty propertyName="TransverseStiffenerGroup_Description" typeName="string" displayLabel="Description" category="TransverseStiffenerGroupProperties_Transverse_Stiffener_Group_Properties" priority="299949"/>
+        <ECProperty propertyName="TransverseStiffenerGroup_LayoutDefinition" typeName="string" displayLabel="Stiffener Placement" category="TransverseStiffenerGroupProperties_Transverse_Stiffener_Group_Properties" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTransverseStiffenerGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TransverseStiffenerGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TubGirderGroupAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TubGirderGroup_Name" typeName="string" displayLabel="Name" category="TubGirderGroupProperties_Tub_Girder_Group_Properties" priority="299950"/>
+        <ECProperty propertyName="TubGirderGroup_Description" typeName="string" displayLabel="Description" category="TubGirderGroupProperties_Tub_Girder_Group_Properties" priority="299949"/>
+        <ECProperty propertyName="TubGirderGroup_GirderDefinition" typeName="string" displayLabel="Tub Girder Definition" category="TubGirderGroupProperties_Tub_Girder_Group_Properties" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTubGirderGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TubGirderGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TubGirderGroupByBeamCorridorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TubGirderGroupByBeamCorridorRuleRotateGirders" typeName="boolean" displayLabel="Rotate Girders" category="TubGirderRuleAttributes_Rule_Property" priority="300000"/>
+        <ECProperty propertyName="TubGirderGroupByBeamCorridorRuleEndCutOrientation" typeName="TubGirderGroupByBeamCorridorRuleAspect_TubGirderGroupByBeamCorridorRuleEndCutOrientation_Enum" displayLabel="End Cut Orientation" category="TubGirderRuleAttributes_Rule_Property" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTubGirderGroupByBeamCorridorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TubGirderGroupByBeamCorridorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TubGirderSegmentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TubGirderSegment_Type" typeName="TubGirderSegmentAspect_TubGirderSegment_Type_Enum" displayLabel="Type" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299999"/>
+        <ECProperty propertyName="TubGirderSegment_TypeText" typeName="string" displayLabel="Type Text" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299998"/>
+        <ECProperty propertyName="TubGirderSegment_Length" typeName="double" displayLabel="Length" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Width" typeName="double" displayLabel="Width" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Offset" typeName="double" displayLabel="Offset" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Thickness" typeName="double" displayLabel="Thickness" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_StartWidth" typeName="double" displayLabel="Start Width" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_EndWidth" typeName="double" displayLabel="End Width" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material" typeName="string" displayLabel="Material" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299991"/>
+        <ECProperty propertyName="TubGirderSegment_Material_UnitPrice" typeName="double" displayLabel="Material Unit Price" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_UnitWeight" typeName="double" displayLabel="Unit Wt" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_CTE" typeName="double" displayLabel="CTE" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_E" typeName="double" displayLabel="E" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Poisson" typeName="double" displayLabel="Poisson" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Steel_FU" typeName="double" displayLabel="Fu" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Steel_Fy" typeName="double" displayLabel="Fy" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Steel_G" typeName="double" displayLabel="G" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Concrete_FC" typeName="double" displayLabel="f’c" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Concrete_FCi" typeName="double" displayLabel="f’ci" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_Material_Concrete_MR" typeName="double" displayLabel="MR" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TubGirderSegment_TubGirderGroupName" typeName="string" displayLabel="Tub Girder Group" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299979"/>
+        <ECProperty propertyName="TubGirderSegment_SpanName" typeName="string" displayLabel="Span Name" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299978"/>
+        <ECProperty propertyName="TubGirderSegment_TubGirderName" typeName="string" displayLabel="Tub Girder" category="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" priority="299977"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTubGirderSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TubGirderSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="UndefinedBeamSegmentAspect">
+        <BaseClass>BeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsUndefinedBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="UndefinedBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VariablePierCapAspect">
+        <BaseClass>RegularPierCapBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVariablePierCapAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VariablePierCapAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VariablePierColumnAspect">
+        <BaseClass>PierColumnCommonBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVariablePierColumnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VariablePierColumnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WebBeamSegmentAspect">
+        <BaseClass>SteelFlangeBeamSegmentBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWebBeamSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WebBeamSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WingwallAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Wingwall_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="Wingwall_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="Wingwall_Length" typeName="double" displayLabel="Length" category="WingwallProperties_Wingwall" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_Height" typeName="double" displayLabel="Height" category="WingwallProperties_Wingwall" priority="-1" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_TopHorizontalOffset" typeName="double" displayLabel="Top Horizontal Offset" category="WingwallProperties_Wingwall" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_TopVerticalOffset" typeName="double" displayLabel="Top Vertical Offset" category="WingwallProperties_Wingwall" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_BtmVerticalOffset" typeName="double" displayLabel="Bottom Vertical Offset" category="WingwallProperties_Wingwall" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_BtmHorizontalOffset" typeName="double" displayLabel="Bottom Horizontal Offset" category="WingwallProperties_Wingwall" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_TopThickness" typeName="double" displayLabel="Top Thickness" category="WingwallProperties_Wingwall" priority="-6" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_BtmThickness" typeName="double" displayLabel="Bottom Thickness" category="WingwallProperties_Wingwall" priority="-7" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_AdditionalBtmVertOffset" typeName="double" displayLabel="Additional Bottom Vertical Offset" category="WingwallProperties_Wingwall" priority="-8" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_FootingOffset" typeName="double" displayLabel="Footing Offset" category="WingwallProperties_Wingwall" priority="-9" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Wingwall_Material" typeName="string" displayLabel="Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+        <ECProperty propertyName="Wingwall_UseTopSlope" typeName="boolean" displayLabel="Use Top Slope" category="WingwallProperties_Wingwall" priority="-10"/>
+        <ECProperty propertyName="Wingwall_TopSlope" typeName="string" displayLabel="Top Slope" category="WingwallProperties_Wingwall" priority="-11"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWingwallAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WingwallAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WingWallByAbutmentRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WingWallByAbutmentRuleOrientation" typeName="WingWallByAbutmentRuleAspect_WingWallByAbutmentRuleOrientation_Enum" displayLabel="Orientation" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299999"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleVerticalOffset" typeName="double" displayLabel="Vertical Offset" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleAlignWithAbutment" typeName="boolean" displayLabel="Align With Abutment" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299997"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleTransverseOffset" typeName="double" displayLabel="Transverse Offset" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleLongitudinalOffset" typeName="double" displayLabel="Longitudinal Offset" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleParallelToAlignment" typeName="boolean" displayLabel="Parallel To Alignment" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299993"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleSkewAngle" typeName="double" displayLabel="Skew Angle" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299991" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleAdjustHeightToBackwall" typeName="boolean" displayLabel="Adjust Height to Backwall" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299990"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleComputeLength" typeName="boolean" displayLabel="Compute Length" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299989"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleFillSlope" typeName="string" displayLabel="Fill Slope" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299988"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleBermHorizontalOffset" typeName="double" displayLabel="Berm Horizontal Offset" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleBermVerticalOffset" typeName="double" displayLabel="Berm Vertical Offset" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleLengthExtension" typeName="double" displayLabel="Length Extension" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleTemplateXmlFragment" typeName="string" displayLabel="Wingwall Template" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299984">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="WingWallByAbutmentRuleTemplateName" typeName="string" displayLabel="Template Name" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299983"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleAlignWithFrontFaceOfBackWall" typeName="boolean" displayLabel="Align With FFBW" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299995"/>
+        <ECProperty propertyName="WingWallByAbutmentRuleUseSlopeFromProfile" typeName="boolean" displayLabel="Use Slope From Profile" category="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" priority="299992"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWingWallByAbutmentRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WingWallByAbutmentRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WingwallFootingAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WingwallFooting_Name" typeName="string" displayLabel="Name" category="BridgeModelerAttributes_General" priority="299950"/>
+        <ECProperty propertyName="WingwallFooting_SupportName" typeName="string" displayLabel="Support Name" category="BridgeModelerAttributes_General" priority="299940"/>
+        <ECProperty propertyName="WingwallFooting_TopElevation" typeName="double" displayLabel="Top Elevation" category="FootingProperties_Footing" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_Sloped" typeName="boolean" displayLabel="Sloped" category="FootingProperties_Footing" priority="-1"/>
+        <ECProperty propertyName="WingwallFooting_Width" typeName="double" displayLabel="Width" category="FootingProperties_Footing" priority="-2" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_Length" typeName="double" displayLabel="Length" category="FootingProperties_Footing" priority="-3" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_Height" typeName="double" displayLabel="Height" category="FootingProperties_Footing" priority="-4" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_SlopeHeight" typeName="double" displayLabel="Slope Depth" category="FootingProperties_Footing" priority="-5" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_SlopedTopWidth" typeName="double" displayLabel="Top Width" category="FootingProperties_Footing" priority="-6" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_SlopedTopLength" typeName="double" displayLabel="Top Length" category="FootingProperties_Footing" priority="-7" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="WingwallFooting_Material" typeName="string" displayLabel="Footing Material" category="BridgeModelerAttributes_Material_Material" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWingwallFootingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WingwallFootingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PipePileAspect">
+        <BaseClass>PileBaseAspect</BaseClass>
+        <ECProperty propertyName="Pile_OutsideDiameter" typeName="double" displayLabel="Outside Diameter" category="BridgeModelerAttributes_Pier" priority="-13" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_WallThickness" typeName="double" displayLabel="Wall Thickness" category="BridgeModelerAttributes_Pier" priority="-14" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_ThicknessOutside" typeName="double" displayLabel="Flange Thickness" category="BridgeModelerAttributes_Pier" priority="-16" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Pile_ThicknessInside" typeName="double" displayLabel="Web Thickness" category="BridgeModelerAttributes_Pier" priority="-17" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <PropertyCategory typeName="AbutmentWingWallRuleAttributes_Abutment_Wingwall_Placement_Rule" description="AbutmentWingWallRuleAttributes" displayLabel="Abutment Wingwall Placement Rule" priority="300000"/>
+    <PropertyCategory typeName="AccessoryProperties_Accessory" description="AccessoryProperties" displayLabel="Accessory" priority="399999"/>
+    <PropertyCategory typeName="AnalyticalProperties_Analytical" description="AnalyticalProperties" displayLabel="Analytical" priority="600"/>
+    <PropertyCategory typeName="AnalyticalProperties_Analytical_Properties" description="AnalyticalProperties" displayLabel="Analytical Properties" priority="600"/>
+    <PropertyCategory typeName="ApproachRefLineRuleAttributes_Approach_Reference_Line_Rule" description="ApproachRefLineRuleAttributes" displayLabel="Approach Reference Line Rule" priority="0"/>
+    <PropertyCategory typeName="ApproachRefLineRuleAttributes_ApproachRefLineRule" description="ApproachRefLineRuleAttributes" displayLabel="&lt;- ApproachRefLineRule -&gt;" priority="0"/>
+    <PropertyCategory typeName="ApproachSlabBreakbackProperties_Approach_Slab_Breakbacks" description="ApproachSlabBreakbackProperties" displayLabel="Approach Slab Breakbacks" priority="399997"/>
+    <PropertyCategory typeName="ApproachSlabProperties_Approach_Slab" description="ApproachSlabProperties" displayLabel="Approach Slab" priority="399999"/>
+    <PropertyCategory typeName="AuxObjectRuleAttributes_Rule_Property" description="AuxObjectRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="BarrierProperties_Barrier" description="BarrierProperties" displayLabel="Barrier" priority="300000"/>
+    <PropertyCategory typeName="BeamGroupProperties_Beam_Group_Properties" description="BeamGroupProperties" displayLabel="Beam Group Properties" priority="300000"/>
+    <PropertyCategory typeName="BeamSegmentProperties_Beam_Segment_Properties" description="BeamSegmentProperties" displayLabel="Beam Segment Properties" priority="300000"/>
+    <PropertyCategory typeName="BearingRuleAttributes_Rule_Property" description="BearingRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="BellProperties_Bell" description="BellProperties" displayLabel="Bell" priority="399999"/>
+    <PropertyCategory typeName="BottomFlangePlatesProperties_Bottom_Flange_Plates_Properties" description="BottomFlangePlatesProperties" displayLabel="Bottom Flange Plates Properties" priority="299898"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Abutment" description="BridgeModelerAttributes" displayLabel="Abutment" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Abutment_Wingwall" description="BridgeModelerAttributes" displayLabel="Abutment Wingwall" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Accessory" description="BridgeModelerAttributes" displayLabel="Accessory" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Approach_Reference_Line" description="BridgeModelerAttributes" displayLabel="Approach Reference Line" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_ApproachRefLine" description="BridgeModelerAttributes" displayLabel="&lt;- ApproachRefLine -&gt;" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Auxiliary" description="BridgeModelerAttributes" displayLabel="Auxiliary" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Barrier_Properties" description="BridgeModelerAttributes" displayLabel="Barrier Properties" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Beam" description="BridgeModelerAttributes" displayLabel="Beam" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Beam_Layout" description="BridgeModelerAttributes" displayLabel="Beam Layout" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Bearing_Group" description="BridgeModelerAttributes" displayLabel="Bearing Group" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Bridge" description="BridgeModelerAttributes" displayLabel="Bridge" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_BuildOrder_Build_Order" description="BridgeModelerAttributes-BuildOrder" displayLabel="Build Order" priority="100000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Custom_Abutment" description="BridgeModelerAttributes" displayLabel="Custom Abutment" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Custom_Pier" description="BridgeModelerAttributes" displayLabel="Custom Pier" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Deck_Properties" description="BridgeModelerAttributes" displayLabel="Deck Properties" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Excavation_Properties" description="BridgeModelerAttributes" displayLabel="Excavation Properties" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_General" description="BridgeModelerAttributes" displayLabel="General" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Material_Material" description="BridgeModelerAttributes-Material" displayLabel="Material" priority="100000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Pier" description="BridgeModelerAttributes" displayLabel="Pier" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_SupportLine" description="BridgeModelerAttributes" displayLabel="SupportLine" priority="300000"/>
+    <PropertyCategory typeName="BridgeModelerAttributes_Unit" description="BridgeModelerAttributes" displayLabel="Unit" priority="300000"/>
+    <PropertyCategory typeName="CapProperties_Cap" description="CapProperties" displayLabel="Cap" priority="399999"/>
+    <PropertyCategory typeName="CheekWallProperties_Cheek_Wall" description="CheekWallProperties" displayLabel="Cheek Wall" priority="399999"/>
+    <PropertyCategory typeName="ColumnProperties_Column" description="ColumnProperties" displayLabel="Column" priority="399999"/>
+    <PropertyCategory typeName="ComponentProperties_Component_Properties" description="ComponentProperties" displayLabel="Component Properties" priority="300000"/>
+    <PropertyCategory typeName="ConcreteDiaphragmGroupProperties_Concrete_Diaphragm_Collection" description="ConcreteDiaphragmGroupProperties" displayLabel="Concrete Diaphragm Collection" priority="300000"/>
+    <PropertyCategory typeName="ConcreteDiaphragmProperties_Concrete_Diaphragm" description="ConcreteDiaphragmProperties" displayLabel="Concrete Diaphragm" priority="300000"/>
+    <PropertyCategory typeName="ConnectorGroupArrangementProperties_Shear_Studs_Group_Properties" description="ConnectorGroupArrangementProperties" displayLabel="Shear Studs Group Properties" priority="300000"/>
+    <PropertyCategory typeName="CrashWallProperties_Crash_Wall" description="CrashWallProperties" displayLabel="Crash Wall" priority="399999"/>
+    <PropertyCategory typeName="CrossFrameGroupProperties_Cross_Frame_Group_Properties" description="CrossFrameGroupProperties" displayLabel="Cross-Frame Group Properties" priority="300000"/>
+    <PropertyCategory typeName="CrossFrameProperties_Cross_Frame_Properties" description="CrossFrameProperties" displayLabel="Cross-Frame Properties" priority="300000"/>
+    <PropertyCategory typeName="CrossFrameTemplateProperties_Cross_Frame_Template_Properties" description="CrossFrameTemplateProperties" displayLabel="Cross-Frame Template Properties" priority="300000"/>
+    <PropertyCategory typeName="CustomObjectRuleAttributes_Rule_Property" description="CustomObjectRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="CustomPierRuleAttributes_Rule_Property" description="CustomPierRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="DeckBreakbackProperties_Deck_Breakbacks" description="DeckBreakbackProperties" displayLabel="Deck Breakbacks" priority="399998"/>
+    <PropertyCategory typeName="DeckByMultiTemplateRuleAttributes_Rule_Property" description="DeckByMultiTemplateRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="DeckProperties_Deck" description="DeckProperties" displayLabel="Deck" priority="300000"/>
+    <PropertyCategory typeName="ExcavationRuleAttributes_Excavation_Rule" description="ExcavationRuleAttributes" displayLabel="Excavation Rule" priority="299999"/>
+    <PropertyCategory typeName="FieldSpliceComponentProperties_Field_Splice_Component_Properties" description="FieldSpliceComponentProperties" displayLabel="Field Splice Component Properties" priority="300000"/>
+    <PropertyCategory typeName="FieldSpliceGroupProperties_Field_Splice_Group" description="FieldSpliceGroupProperties" displayLabel="Field Splice Group" priority="300000"/>
+    <PropertyCategory typeName="FieldSpliceProperties_Field_Splice_Properties" description="FieldSpliceProperties" displayLabel="Field Splice Properties" priority="300000"/>
+    <PropertyCategory typeName="FootingProperties_Footing" description="FootingProperties" displayLabel="Footing" priority="399999"/>
+    <PropertyCategory typeName="GenCompMappedAttributes_Gen_Comp_Mapped" description="GenCompMappedAttributes" displayLabel="Gen Comp Mapped" priority="300000"/>
+    <PropertyCategory typeName="PierBySupportLineRuleAttributes_Substructure_Placement_Rule" description="PierBySupportLineRuleAttributes" displayLabel="Substructure Placement Rule" priority="299999"/>
+    <PropertyCategory typeName="PileProperties_Pile" description="PileProperties" displayLabel="Pile" priority="399999"/>
+    <PropertyCategory typeName="RockSocketProperties_Rock_Socket" description="RockSocketProperties" displayLabel="Rock Socket" priority="399999"/>
+    <PropertyCategory typeName="SegmentalBalancedCategory_Segmental_Cantilever" description="SegmentalBalancedCategory" displayLabel="Segmental Cantilever" priority="300000"/>
+    <PropertyCategory typeName="SegmentalSpanCategory_Span_by_Span" description="SegmentalSpanCategory" displayLabel="Span by Span" priority="300000"/>
+    <PropertyCategory typeName="SegmentProperties_Segment_Properties" description="SegmentProperties" displayLabel="Segment Properties" priority="300000"/>
+    <PropertyCategory typeName="ShearConnectorGroupsProperties_Shear_Studs_Groups_Properties" description="ShearConnectorGroupsProperties" displayLabel="Shear Studs Groups Properties" priority="300000"/>
+    <PropertyCategory typeName="ShearConnectorProperties_Shear_Stud_Properties" description="ShearConnectorProperties" displayLabel="Shear Stud Properties" priority="300000"/>
+    <PropertyCategory typeName="ShearConnectorTemplateProperties_Shear_Stud_Template_Properties" description="ShearConnectorTemplateProperties" displayLabel="Shear Stud Template Properties" priority="300000"/>
+    <PropertyCategory typeName="SleeperSlabProperties_Sleeper_Slab" description="SleeperSlabProperties" displayLabel="Sleeper Slab" priority="399999"/>
+    <PropertyCategory typeName="SolidAttributes_Solid" description="SolidAttributes" displayLabel="Solid" priority="300000"/>
+    <PropertyCategory typeName="SolidByTemplateRuleAttributes_Rule_Property" description="SolidByTemplateRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="StrutProperties_Strut" description="StrutProperties" displayLabel="Strut" priority="399999"/>
+    <PropertyCategory typeName="SupportLineProperties_SupportLine" description="SupportLineProperties" displayLabel="SupportLine" priority="300000"/>
+    <PropertyCategory typeName="SupportLineRuleAttributes_SupportLine_Rule" description="SupportLineRuleAttributes" displayLabel="SupportLine Rule" priority="0"/>
+    <PropertyCategory typeName="TendonGroupProperties_Tendon_Properties" description="TendonGroupProperties" displayLabel="Tendon Properties" priority="300000"/>
+    <PropertyCategory typeName="TopFlangePlatesProperties_Top_Flange_Plates_Properties" description="TopFlangePlatesProperties" displayLabel="Top Flange Plates Properties" priority="299900"/>
+    <PropertyCategory typeName="TransverseStiffenerGroupProperties_Transverse_Stiffener_Group_Properties" description="TransverseStiffenerGroupProperties" displayLabel="Transverse Stiffener Group Properties" priority="300000"/>
+    <PropertyCategory typeName="TransverseStiffenerProperties_Transverse_Stiffener_Properties" description="TransverseStiffenerProperties" displayLabel="Transverse Stiffener Properties" priority="300000"/>
+    <PropertyCategory typeName="TubGirderGroupProperties_Tub_Girder_Group_Properties" description="TubGirderGroupProperties" displayLabel="Tub Girder Group Properties" priority="300000"/>
+    <PropertyCategory typeName="TubGirderRuleAttributes_Rule_Property" description="TubGirderRuleAttributes" displayLabel="Rule Property" priority="300000"/>
+    <PropertyCategory typeName="TubGirderSegmentProperties_Tub_Girder_Segment_Properties" description="TubGirderSegmentProperties" displayLabel="Tub Girder Segment Properties" priority="300000"/>
+    <PropertyCategory typeName="WebPlatesbProperties_Web_Plates_Properties" description="WebPlatesbProperties" displayLabel="Web Plates Properties" priority="299897"/>
+    <PropertyCategory typeName="WingwallProperties_Wingwall" description="WingwallProperties" displayLabel="Wingwall" priority="399999"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifCommon.01.00.05.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifCommon.01.00.05.ecschema.xml
@@ -1,0 +1,1618 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifCommon" alias="cifcmn" version="01.00.05" description="iModel Connector schema containing aspect classes with common properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifUnits" version="01.00.01" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="ApplyTemplateCorridorAspect_Mirror_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ApplyTemplateCorridorAspect_Reflect_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CircularArcAspect_LinearElement_CircularArc_DegreeOfCurveDefinition_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Arc" value="0" displayLabel="Arc"/>
+        <ECEnumerator name="Chord" value="1" displayLabel="Chord"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CivilCellAspect_IsValid_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ClosedLinearComplexAspect_ClosedLinearComplex_IsClockWise_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ClosedLineStringAspect_LinearElement_ClosedLineString_IsClockWise_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Yes" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="No" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CurveWideningAspect_CurveWidening_Enabled_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CurveWideningAspect_CurveWidening_Overlap_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Shorten_Transition_Lengths" value="0" displayLabel="Shorten Transition Lengths"/>
+        <ECEnumerator name="Shift_Maximum_Widening_Points_onto_Curves" value="1" displayLabel="Shift Maximum Widening Points onto Curves"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CurveWideningAspect_CurveWidening_UseSpiralLengthForTransition_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DistanceAlongSlopeEntityAspect_SlopeStyle_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Linear" value="3" displayLabel="Linear"/>
+        <ECEnumerator name="Reverse_Biquadratic" value="7" displayLabel="Reverse Biquadratic"/>
+        <ECEnumerator name="Reverse_Cubic" value="8" displayLabel="Reverse Cubic"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DTMEntityBySelectedElementsSourceProviderAspect_FeatureType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Break_Line" value="1" displayLabel="Break Line"/>
+        <ECEnumerator name="Contour" value="4" displayLabel="Contour"/>
+        <ECEnumerator name="Drape_Void" value="8" displayLabel="Drape Void"/>
+        <ECEnumerator name="Hole" value="6" displayLabel="Hole"/>
+        <ECEnumerator name="Boundary" value="0" displayLabel="Boundary"/>
+        <ECEnumerator name="DrapeBoundary" value="28" displayLabel="&lt;- DrapeBoundary -&gt;"/>
+        <ECEnumerator name="Island" value="7" displayLabel="Island"/>
+        <ECEnumerator name="Spot" value="9" displayLabel="Spot"/>
+        <ECEnumerator name="Soft_Break_Line" value="2" displayLabel="Soft Break Line"/>
+        <ECEnumerator name="Void" value="5" displayLabel="Void"/>
+        <ECEnumerator name="BreakVoid" value="25" displayLabel="&lt;- BreakVoid -&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DTMEntityImportSourcePropertyProviderAspect_DTM_IncludeSpotFeatures_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DTMEntityImportSourcePropertyProviderAspect_DTM_NameFeatures_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="EndConditionExceptionsAspect_ECEType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Left_Override" value="0" displayLabel="Left Override"/>
+        <ECEnumerator name="Right_Override" value="1" displayLabel="Right Override"/>
+        <ECEnumerator name="Left_Transition" value="2" displayLabel="Left Transition"/>
+        <ECEnumerator name="Right_Transition" value="3" displayLabel="Right Transition"/>
+        <ECEnumerator name="Backbone_Only_Left" value="4" displayLabel="Backbone Only (Left)"/>
+        <ECEnumerator name="Backbone_Only_Right" value="5" displayLabel="Backbone Only (Right)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="EndConditionExceptionsAspect_Enabled_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FlowLineEntityAspect_FlowLineEntity_Formula_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Gallaway" value="0" displayLabel="Gallaway"/>
+        <ECEnumerator name="Road_Research_Laboratory" value="1" displayLabel="Road Research Laboratory"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="MeshSurfaceEntityAspect_VolumeOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Design" value="2" displayLabel="Design"/>
+        <ECEnumerator name="Existing" value="1" displayLabel="Existing"/>
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Subgrade" value="4" displayLabel="Subgrade"/>
+        <ECEnumerator name="Substrata" value="3" displayLabel="Substrata"/>
+        <ECEnumerator name="Cut" value="5" displayLabel="Cut"/>
+        <ECEnumerator name="Fill" value="6" displayLabel="Fill"/>
+        <ECEnumerator name="Unsuitable" value="7" displayLabel="Unsuitable"/>
+        <ECEnumerator name="Custom" value="8" displayLabel="Custom"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ParametricConstraintAspect_Enabled_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PointControlAspect_Enabled_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PointControlAspect_Mode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Horizontal" value="0" displayLabel="Horizontal"/>
+        <ECEnumerator name="Vertical" value="1" displayLabel="Vertical"/>
+        <ECEnumerator name="Both" value="2" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PointControlAspect_UseAsSecondaryAlignment_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReadOnlyCircularArcAspect_LinearElement_CircularArc_DegreeOfCurveDefinition_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Arc" value="0" displayLabel="Arc"/>
+        <ECEnumerator name="Chord" value="1" displayLabel="Chord"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReadOnlyClosedLinearComplexAspect_ClosedLinearComplex_IsClockWise_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReadOnlyClosedLineStringAspect_LinearElement_ClosedLineString_IsClockWise_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Yes" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="No" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StrokingPropertiesClassAspect_StrokingStepMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Increment" value="0" displayLabel="Increment"/>
+        <ECEnumerator name="Equal_Distance" value="1" displayLabel="Equal Distance"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="CivilPresentation" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ApplyTemplateCorridorAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Corridor_Corridor" priority="299999"/>
+        <ECProperty propertyName="HorizontalName" typeName="string" displayLabel="Horizontal Name" category="Corridor_Corridor" priority="299998"/>
+        <ECProperty propertyName="VerticalName" typeName="string" displayLabel="Profile Name" category="Corridor_Corridor" priority="-3"/>
+        <ECProperty propertyName="ExteriorArc" typeName="double" displayLabel="Exterior Corner Sweep Angle" category="Corridor_Corridor" priority="-4" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Mirror" typeName="ApplyTemplateCorridorAspect_Mirror_BoolEnum" displayLabel="Mirror" category="Corridor_Corridor" priority="-5"/>
+        <ECProperty propertyName="Reflect" typeName="ApplyTemplateCorridorAspect_Reflect_BoolEnum" displayLabel="Reflect" category="Corridor_Corridor" priority="-6"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="LinearElementAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="LinearElement_Length" typeName="double" displayLabel="Length" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryAttributes_Geometry" priority="299990"/>
+        <ECProperty propertyName="LinearElement_EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryAttributes_Geometry" priority="299980"/>
+        <ECProperty propertyName="LinearElement_Length3d" typeName="double" displayLabel="&lt;- LENGTH 3d -&gt;" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="BSplineAspect">
+        <BaseClass>LinearElementAspect</BaseClass>
+        <ECProperty propertyName="BSpline_IsRational" typeName="int" displayLabel="BSpline_IsRational" category="Miscellaneous_BSpline" priority="0"/>
+        <ECProperty propertyName="BSpline_KnotsCount" typeName="int" displayLabel="BSpline_KnotsCount" category="Miscellaneous_BSpline" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ReadOnlyLinearElementAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="LinearElement_Length" typeName="double" displayLabel="Length" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryAttributes_Geometry" priority="299990"/>
+        <ECProperty propertyName="LinearElement_EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryAttributes_Geometry" priority="299980"/>
+        <ECProperty propertyName="LinearElement_Length3d" typeName="double" displayLabel="&lt;- LENGTH 3d -&gt;" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="CircularArcAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_CircularArc_Radius" typeName="double" displayLabel="Radius" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_CircularArc_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="299974" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_CircularArc_Tangent" typeName="double" displayLabel="Tangent" category="GeometryAttributes_Geometry" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_CircularArc_Chord" typeName="double" displayLabel="Chord" category="GeometryAttributes_Geometry" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_CircularArc_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_CircularArc_EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299890" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_CircularArc_DegreeOfCurve" typeName="double" displayLabel="Degree of Curvature" category="GeometryAttributes_Geometry" priority="299870" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_CircularArc_DegreeOfCurveDefinition" typeName="CircularArcAspect_LinearElement_CircularArc_DegreeOfCurveDefinition_Enum" displayLabel="Degree of Curvature Definition" category="GeometryAttributes_Geometry" priority="299880"/>
+        <ECProperty propertyName="LinearElement_CircularArc_CenterPoint" typeName="point3d" displayLabel="Center Point" category="GeometryAttributes_Geometry" priority="299860"/>
+        <ECProperty propertyName="LinearElement_CircularArc_Hand" typeName="string" displayLabel="Hand" category="GeometryAttributes_Geometry" priority="299880"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CivilCellAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Name_General_Category" priority="299999"/>
+        <ECProperty propertyName="IsValid" typeName="CivilCellAspect_IsValid_BoolEnum" displayLabel="Valid for Placement" category="Name_General_Category" priority="299998"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CivilCellReferenceAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Name_General_Category" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CivilObjectAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Name_General_Category" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ReadOnlyLinearComplexAspect">
+        <BaseClass>LinearElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ClosedLinearComplexAspect">
+        <BaseClass>ReadOnlyLinearComplexAspect</BaseClass>
+        <ECProperty propertyName="ClosedLinearComplex_IsClockWise" typeName="ClosedLinearComplexAspect_ClosedLinearComplex_IsClockWise_BoolEnum" displayLabel="Clockwise" category="GeometryAttributes_Geometry" priority="299960"/>
+        <ECProperty propertyName="ClosedLinearComplex_Area" typeName="double" displayLabel="Area" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="LineStringAspect">
+        <BaseClass>LinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_LineString_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299900"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ClosedLineStringAspect">
+        <BaseClass>LineStringAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_LineString_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299900"/>
+        <ECProperty propertyName="LinearElement_ClosedLineString_IsClockWise" typeName="ClosedLineStringAspect_LinearElement_ClosedLineString_IsClockWise_Enum" displayLabel="Clockwise" category="GeometryAttributes_Geometry" priority="299000"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ProfiledElementAspect">
+        <BaseClass>LinearElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="SpiralAspect">
+        <BaseClass>ProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Spiral_StartRadius" typeName="double" displayLabel="Start Radius" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndRadius" typeName="double" displayLabel="End Radius" category="GeometryAttributes_Geometry" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="299870" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_Spiral_Constant" typeName="double" displayLabel="Constant" category="GeometryAttributes_Geometry" priority="299860" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongTangent" typeName="double" displayLabel="Long Tangent" category="GeometryAttributes_Geometry" priority="299850" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_ShortTangent" typeName="double" displayLabel="Short Tangent" category="GeometryAttributes_Geometry" priority="299840" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongChord" typeName="double" displayLabel="Long Chord" category="GeometryAttributes_Geometry" priority="299830" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Xs" typeName="double" displayLabel="Xs" category="GeometryAttributes_Geometry" priority="299820" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Ys" typeName="double" displayLabel="Ys" category="GeometryAttributes_Geometry" priority="299810" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_PValue" typeName="double" displayLabel="P" category="GeometryAttributes_Geometry" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_KValue" typeName="double" displayLabel="K" category="GeometryAttributes_Geometry" priority="299790" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299780" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299770" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_IntrinsicPoint" typeName="point3d" displayLabel="Intrinsic Point" category="GeometryAttributes_Geometry" priority="299700"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartArcCenterPoint" typeName="point3d" displayLabel="Start Arc Center Point" category="GeometryAttributes_Geometry" priority="299690"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndArcCenterPoint" typeName="point3d" displayLabel="End Arc Center Point" category="GeometryAttributes_Geometry" priority="299680"/>
+        <ECProperty propertyName="LinearElement_Spiral_Hand" typeName="string" displayLabel="Hand" category="GeometryAttributes_Geometry" priority="299760"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ClothoidAspect">
+        <BaseClass>SpiralAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Spiral_StartRadius" typeName="double" displayLabel="Start Radius" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndRadius" typeName="double" displayLabel="End Radius" category="GeometryAttributes_Geometry" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="299870" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_Spiral_Constant" typeName="double" displayLabel="Constant" category="GeometryAttributes_Geometry" priority="299860" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongTangent" typeName="double" displayLabel="Long Tangent" category="GeometryAttributes_Geometry" priority="299850" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_ShortTangent" typeName="double" displayLabel="Short Tangent" category="GeometryAttributes_Geometry" priority="299840" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongChord" typeName="double" displayLabel="Long Chord" category="GeometryAttributes_Geometry" priority="299830" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Xs" typeName="double" displayLabel="Xs" category="GeometryAttributes_Geometry" priority="299820" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Ys" typeName="double" displayLabel="Ys" category="GeometryAttributes_Geometry" priority="299810" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_PValue" typeName="double" displayLabel="P" category="GeometryAttributes_Geometry" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_KValue" typeName="double" displayLabel="K" category="GeometryAttributes_Geometry" priority="299790" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299780" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299770" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_IntrinsicPoint" typeName="point3d" displayLabel="Intrinsic Point" category="GeometryAttributes_Geometry" priority="299700"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartArcCenterPoint" typeName="point3d" displayLabel="Start Arc Center Point" category="GeometryAttributes_Geometry" priority="299690"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndArcCenterPoint" typeName="point3d" displayLabel="End Arc Center Point" category="GeometryAttributes_Geometry" priority="299680"/>
+        <ECProperty propertyName="LinearElement_Spiral_Hand" typeName="string" displayLabel="Hand" category="GeometryAttributes_Geometry" priority="299760"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CompoundElementAspect">
+        <BaseClass>ProfiledElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CorridorAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Corridor_Corridor" priority="299999"/>
+        <ECProperty propertyName="HorizontalName" typeName="string" displayLabel="Horizontal Name" category="Corridor_Corridor" priority="299998"/>
+        <ECProperty propertyName="UseActiveDesignProfile" typeName="boolean" displayLabel="Use Active Profile" category="Corridor_Corridor" priority="299997"/>
+        <ECProperty propertyName="ProfileEntity" typeName="string" displayLabel="Profile Name" category="Corridor_Corridor" priority="299996"/>
+        <ECProperty propertyName="ActiveStation0" typeName="double" displayLabel="ActiveStation0" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation1" typeName="double" displayLabel="ActiveStation1" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation2" typeName="double" displayLabel="ActiveStation2" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation3" typeName="double" displayLabel="ActiveStation3" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation4" typeName="double" displayLabel="ActiveStation4" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation5" typeName="double" displayLabel="ActiveStation5" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation6" typeName="double" displayLabel="ActiveStation6" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ActiveStation7" typeName="double" displayLabel="ActiveStation7" category="Miscellaneous_Corridor" priority="0">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="CurveWideningAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="CurveWidening_Enabled" typeName="CurveWideningAspect_CurveWidening_Enabled_BoolEnum" displayLabel="Enabled" category="CurveWidening_Curve_Widening" priority="299999"/>
+        <ECProperty propertyName="CurveWidening_Description" typeName="string" displayLabel="Description" category="CurveWidening_Curve_Widening" priority="299998"/>
+        <ECProperty propertyName="CurveWidening_Point" typeName="string" displayLabel="Point" category="CurveWidening_Curve_Widening" priority="299997"/>
+        <ECProperty propertyName="CurveWidening_TransitionOnTangent" typeName="double" displayLabel="Percent Transition on Tangent" category="CurveWidening_Curve_Widening" priority="299996"/>
+        <ECProperty propertyName="CurveWidening_UseSpiralLengthForTransition" typeName="CurveWideningAspect_CurveWidening_UseSpiralLengthForTransition_BoolEnum" displayLabel="Use Spiral Length for Transition" category="CurveWidening_Curve_Widening" priority="299995"/>
+        <ECProperty propertyName="CurveWidening_Overlap" typeName="CurveWideningAspect_CurveWidening_Overlap_Enum" displayLabel="Overlap" category="CurveWidening_Curve_Widening" priority="299994"/>
+        <ECProperty propertyName="CurveWidening_Priority" typeName="int" displayLabel="Priority" category="CurveWidening_Curve_Widening" priority="299993"/>
+        <ECProperty propertyName="CurveWidening_WideningTableFileName" typeName="string" displayLabel="Widening Table" category="CurveWidening_Curve_Widening" priority="299992"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DistanceAlongSlopeEntityAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="ReferenceDistanceAlongEntry" typeName="double" displayLabel="Reference Distance" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceDistanceAlongEntry_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'ReferenceDistanceAlongEntry' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ReferenceStartDistanceAlongEntry" typeName="double" displayLabel="Start Reference Distance" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceStartDistanceAlongEntry_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'ReferenceStartDistanceAlongEntry' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ReferenceEndDistanceAlongEntry" typeName="double" displayLabel="End Reference Distance" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceEndDistanceAlongEntry_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'ReferenceEndDistanceAlongEntry' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ReferenceSlopeEntry" typeName="double" displayLabel="Slope" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299995" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="ReferenceStartSlopeEntry" typeName="double" displayLabel="Start Slope" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299992" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="ReferenceEndSlopeEntry" typeName="double" displayLabel="End Slope" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299989" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="ReferenceOffsetEntry" typeName="double" displayLabel="Vertical Offset" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceStartOffsetEntry" typeName="double" displayLabel="Start Vertical Offset" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceEndOffsetEntry" typeName="double" displayLabel="End Vertical Offset" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceDesignSpeedEntry" typeName="double" displayLabel="Design Speed" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299987" kindOfQuantity="cifu:VELOCITY"/>
+        <ECProperty propertyName="ReferenceArcLength1Entry" typeName="double" displayLabel="Arc Length 1" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceArcLength2Entry" typeName="double" displayLabel="Arc Length 2" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SlopeStyle" typeName="DistanceAlongSlopeEntityAspect_SlopeStyle_Enum" displayLabel="Slope Style" category="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" priority="299997"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityBySelectedElementsSourceProviderAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="FeatureType" typeName="DTMEntityBySelectedElementsSourceProviderAspect_FeatureType_Enum" displayLabel="FeatureType" category="TerrainModelBySelectedElementAttributes_Create_from_Elements_UnLinked" priority="300000"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityImportSourcePropertyProviderAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="DTM_ObjectSetting" typeName="string" displayLabel="Feature Definition" category="FeatureDefinition_Feature_Definition" priority="299980"/>
+        <ECProperty propertyName="DTM_NamePrefix" typeName="string" displayLabel="Name" category="FeatureDefinition_Feature_Definition" priority="299975"/>
+        <ECProperty propertyName="DTM_IncludeSpotFeatures" typeName="DTMEntityImportSourcePropertyProviderAspect_DTM_IncludeSpotFeatures_BoolEnum" displayLabel="Include Spot Features" category="TriangulationOptions_Triangulation_Options" priority="299965"/>
+        <ECProperty propertyName="DTM_NameFeatures" typeName="DTMEntityImportSourcePropertyProviderAspect_DTM_NameFeatures_BoolEnum" displayLabel="Name all Features" category="TriangulationOptions_Triangulation_Options" priority="299940"/>
+        <ECProperty propertyName="DTM_MaxSideLength" typeName="double" displayLabel="Maximum Side Length" category="TriangulationOptions_Triangulation_Options" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsApplyTemplateCorridorAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ApplyTemplateCorridorAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBSplineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BSplineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCircularArcAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CircularArcAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCivilCellAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CivilCellAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCivilCellReferenceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CivilCellReferenceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCivilObjectAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CivilObjectAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsClosedLinearComplexAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ClosedLinearComplexAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsClosedLineStringAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ClosedLineStringAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsClothoidAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ClothoidAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCompoundElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CompoundElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCorridorAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CorridorAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCurveWideningAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CurveWideningAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDistanceAlongSlopeEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DistanceAlongSlopeEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityBySelectedElementsSourceProviderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityBySelectedElementsSourceProviderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityImportSourcePropertyProviderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityImportSourcePropertyProviderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="EndConditionExceptionsAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" category="EndConditionException_End_Condition_Exception" priority="299998"/>
+        <ECProperty propertyName="Enabled" typeName="EndConditionExceptionsAspect_Enabled_BoolEnum" displayLabel="Enabled" category="EndConditionException_End_Condition_Exception" priority="299999"/>
+        <ECProperty propertyName="ECEType" typeName="EndConditionExceptionsAspect_ECEType_Enum" displayLabel="ECException Type" category="EndConditionException_End_Condition_Exception" priority="299997"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsEndConditionExceptionsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="EndConditionExceptionsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FeatureBaseAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="DefinitionName" typeName="string" displayLabel="Feature Definition" category="FeatureProperties_Feature" priority="299999"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="FeatureAspect">
+        <BaseClass>FeatureBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFeatureAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FeatureAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsFeatureBaseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FeatureBaseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FeatureWithNameAspect">
+        <BaseClass>FeatureBaseAspect</BaseClass>
+        <ECProperty propertyName="FeatureName" typeName="string" displayLabel="Feature Name" category="FeatureProperties_Feature" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFeatureWithNameAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FeatureWithNameAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowLineEntityAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="FlowLineEntity_Formula" typeName="FlowLineEntityAspect_FlowLineEntity_Formula_Enum" displayLabel="Formula" category="FlowLineEntity_Aquaplaning" priority="299980"/>
+        <ECProperty propertyName="FlowLineEntity_RainfallIntensity" typeName="double" displayLabel="Rainfall Intensity" category="FlowLineEntity_Aquaplaning" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowLineEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowLineEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GeographicCoordinateSystemAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="GeographicCoordinateSystem_ImageCoordinateMethodName" typeName="string" displayLabel="Source" category="ProjectionProperties_Geographical_Coordinate_Systems" priority="299990"/>
+        <ECProperty propertyName="GeographicCoordinateSystem_ImageCoordinateDescription" typeName="string" displayLabel="Source Description" category="ProjectionProperties_Geographical_Coordinate_Systems" priority="299980"/>
+        <ECProperty propertyName="GeographicCoordinateSystem_ImageCoordinateUnits" typeName="string" displayLabel="Source Units" category="ProjectionProperties_Geographical_Coordinate_Systems" priority="299970"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGeographicCoordinateSystemAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GeographicCoordinateSystemAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="InternalStationEquationAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackLocation" typeName="double" displayLabel="BackLocation" category="Miscellaneous_Internal_Station_Equation" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackLocation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'BackLocation' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BackStation" typeName="string" displayLabel="Back Station" category="StationingProperties_Stationing" priority="299995"/>
+        <ECProperty propertyName="AheadStation" typeName="string" displayLabel="Ahead Station" category="StationingProperties_Stationing" priority="299994"/>
+        <ECProperty propertyName="LengthDifference" typeName="string" displayLabel="Length Difference" category="StationingProperties_Stationing" priority="299993"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsInternalStationEquationAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="InternalStationEquationAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IntersectionPointStruct">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="IntersectionPointStation" typeName="double" displayLabel="Station" category="Miscellaneous_Intersection_Point" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="IntersectionPointSkewAngle" typeName="double" displayLabel="SkewAngle" category="Miscellaneous_Intersection_Point" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="IntersectionPointElevation" typeName="double" displayLabel="Elevation" category="Miscellaneous_Intersection_Point" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIntersectionPointStruct" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IntersectionPointStruct"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="KeyStationAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="KeyStation_Key_Station" priority="299999" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'Station' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsKeyStationAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="KeyStationAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Line3dAspect">
+        <BaseClass>ProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Length" typeName="double" displayLabel="Length" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryAttributes_Geometry" priority="299990"/>
+        <ECProperty propertyName="LinearElement_EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryAttributes_Geometry" priority="299980"/>
+        <ECProperty propertyName="LinearElement_Line3d_Direction" typeName="double" displayLabel="Direction" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLine3dAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Line3dAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinearComplexAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinearComplexAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinearComplexAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsLinearElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinearElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineAspect">
+        <BaseClass>LinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Line_Direction" typeName="double" displayLabel="Direction" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:BEARING"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineString3dAspect">
+        <BaseClass>ProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_LineString3d_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineString3dAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineString3dAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsLineStringAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineStringAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="MeshSurfaceEntityAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="MeshSurfaceEntity_Volume" typeName="double" displayLabel="Volume" category="MeshSurfaceEntity_Component_Layer" priority="300000" kindOfQuantity="cifu:VOLUME">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'MeshSurfaceEntity_CivilVolume' instead</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="MeshSurfaceEntity_Depth" typeName="double" displayLabel="Depth" category="MeshSurfaceEntity_Component_Layer" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MeshSurfaceEntity_Description" typeName="string" displayLabel="Description" category="MeshSurfaceEntity_Component_Layer" priority="299980"/>
+        <ECProperty propertyName="MeshSurfaceEntity_StartStation" typeName="string" displayLabel="Start Station [Deprecated]" category="MeshSurfaceEntity_Component_Layer" priority="299950">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new MeshSurfaceEntity_StartStationNumeric property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="MeshSurfaceEntity_EndStation" typeName="string" displayLabel="End Station [Deprecated]" category="MeshSurfaceEntity_Component_Layer" priority="299940">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new MeshSurfaceEntity_EndStationNumeric property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="MeshSurfaceEntity_MaterialSubtype" typeName="string" displayLabel="Material Subtype" category="MeshSurfaceEntity_Component_Layer" priority="299930"/>
+        <ECProperty propertyName="MeshSurfaceEntity_SlopedArea" typeName="double" displayLabel="Top Sloped Area" category="MeshQuantities_Civil_Quantities" priority="299920" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="MeshSurfaceEntity_PlanarArea" typeName="double" displayLabel="Planar Area" category="MeshQuantities_Civil_Quantities" priority="299910" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="MeshSurfaceEntity_CivilVolume" typeName="double" displayLabel="Volume" category="MeshQuantities_Civil_Quantities" priority="299900" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="VolumeOption" typeName="MeshSurfaceEntityAspect_VolumeOption_Enum" displayLabel="Volume Option" category="MeshSurfaceEntity_Component_Layer" priority="299925"/>
+        <ECProperty propertyName="MeshSurfaceEntity_StartStationNumeric" typeName="double" displayLabel="Start Station" category="MeshSurfaceEntity_Component_Layer" priority="299950" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="MeshSurfaceEntity_EndStationNumeric" typeName="double" displayLabel="End Station" category="MeshSurfaceEntity_Component_Layer" priority="299940" kindOfQuantity="cifu:STATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsMeshSurfaceEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="MeshSurfaceEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ObjectStatusAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="ObjectStatusHandler_ObjectStatus_ObjectName" typeName="string" displayLabel="Name" category="CivilObjectStatusAttributes_Object_Status" priority="299900"/>
+        <ECProperty propertyName="ObjectStatusHandler_ObjectStatus_ShortDescription" typeName="string" displayLabel="Type" category="CivilObjectStatusAttributes_Object_Status" priority="299800"/>
+        <ECProperty propertyName="ObjectStatusHandler_ObjectStatus_Description" typeName="string" displayLabel="Description" category="CivilObjectStatusAttributes_Object_Status" priority="299700"/>
+        <ECProperty propertyName="ObjectStatusHandler_ObjectStatus_ApplicationID" typeName="string" displayLabel="Application" category="CivilObjectStatusAttributes_Object_Status" priority="299600"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsObjectStatusAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ObjectStatusAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ParametricConstraintBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Label" typeName="string" displayLabel="Constraint Label" category="ParametricConstraint_Parametric_Constraint" priority="299998"/>
+        <ECProperty propertyName="Enabled" typeName="ParametricConstraintAspect_Enabled_BoolEnum" displayLabel="Enabled" category="ParametricConstraint_Parametric_Constraint" priority="299999"/>
+        <ECProperty propertyName="Surface" typeName="string" displayLabel="Surface" category="ParametricConstraint_Parametric_Constraint" priority="-9"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ParametricConstraintAngleAspect">
+        <BaseClass>ParametricConstraintBaseAspect</BaseClass>
+        <ECProperty propertyName="StartAngle" typeName="double" displayLabel="Start Angle" category="ParametricConstraint_Parametric_Constraint" priority="299993" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StopAngle" typeName="double" displayLabel="Stop Angle" category="ParametricConstraint_Parametric_Constraint" priority="299992" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsParametricConstraintAngleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ParametricConstraintAngleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ParametricConstraintSlopeAspect">
+        <BaseClass>ParametricConstraintBaseAspect</BaseClass>
+        <ECProperty propertyName="StartSlope" typeName="double" displayLabel="Start Slope" category="ParametricConstraint_Parametric_Constraint" priority="299995" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="StopSlope" typeName="double" displayLabel="Stop Slope" category="ParametricConstraint_Parametric_Constraint" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsParametricConstraintSlopeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ParametricConstraintSlopeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ParametricConstraintValueAspect">
+        <BaseClass>ParametricConstraintBaseAspect</BaseClass>
+        <ECProperty propertyName="StartValue" typeName="double" displayLabel="Start Value" category="ParametricConstraint_Parametric_Constraint" priority="299997"/>
+        <ECProperty propertyName="StopValue" typeName="double" displayLabel="Stop Value" category="ParametricConstraint_Parametric_Constraint" priority="299996"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsParametricConstraintValueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ParametricConstraintValueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PointControlAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Enabled" typeName="PointControlAspect_Enabled_BoolEnum" displayLabel="Enabled" category="PointControl_PointControl" priority="299999"/>
+        <ECProperty propertyName="ControlDescription" typeName="string" displayLabel="Control Description" category="PointControl_PointControl" priority="299998"/>
+        <ECProperty propertyName="Point" typeName="string" displayLabel="Point" category="PointControl_PointControl" priority="299995"/>
+        <ECProperty propertyName="Mode" typeName="PointControlAspect_Mode_Enum" displayLabel="Mode" category="PointControl_PointControl" priority="299997"/>
+        <ECProperty propertyName="ControlType" typeName="string" displayLabel="Control Type" category="PointControl_PointControl" priority="299996"/>
+        <ECProperty propertyName="PlanElement" typeName="string" displayLabel="Plan Element" category="PointControl_PointControl" priority="299994"/>
+        <ECProperty propertyName="ProfileElement" typeName="string" displayLabel="Profile Element" category="PointControl_PointControl" priority="299993"/>
+        <ECProperty propertyName="Range" typeName="double" displayLabel="Range" category="PointControl_PointControl" priority="299991"/>
+        <ECProperty propertyName="Corridor" typeName="string" displayLabel="Corridor" category="PointControl_PointControl" priority="299990"/>
+        <ECProperty propertyName="ReferenceFeature" typeName="string" displayLabel="Reference Feature" category="PointControl_PointControl" priority="299989"/>
+        <ECProperty propertyName="Superelevation" typeName="string" displayLabel="Superelevation" category="PointControl_PointControl" priority="299988"/>
+        <ECProperty propertyName="Cant" typeName="string" displayLabel="Cant" category="PointControl_PointControl" priority="299995"/>
+        <ECProperty propertyName="ReferencePoint" typeName="string" displayLabel="Reference Point" category="PointControl_PointControl" priority="299987"/>
+        <ECProperty propertyName="Elevation" typeName="double" displayLabel="Elevation" category="PointControl_PointControl" priority="299986"/>
+        <ECProperty propertyName="Grade" typeName="double" displayLabel="Grade" category="PointControl_PointControl" priority="299985" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="UseAsSecondaryAlignment" typeName="PointControlAspect_UseAsSecondaryAlignment_BoolEnum" displayLabel="Use as Secondary Alignment" category="PointControl_PointControl" priority="299984"/>
+        <ECProperty propertyName="Priority" typeName="int" displayLabel="Priority" category="PointControl_PointControl" priority="299983"/>
+        <ECProperty propertyName="HorizontalStartOffset" typeName="double" displayLabel="Horizontal Start Offset" category="PointControl_PointControl" priority="299982"/>
+        <ECProperty propertyName="HorizontalStopOffset" typeName="double" displayLabel="Horizontal Stop Offset" category="PointControl_PointControl" priority="299981"/>
+        <ECProperty propertyName="VerticalStartOffset" typeName="double" displayLabel="Vertical Start Offset" category="PointControl_PointControl" priority="299980"/>
+        <ECProperty propertyName="VerticalStopOffset" typeName="double" displayLabel="Vertical Stop Offset" category="PointControl_PointControl" priority="299979"/>
+        <ECProperty propertyName="ParentCurveWidening" typeName="string" displayLabel="Parent Curve Widening" category="PointControl_PointControl" priority="-22"/>
+        <ECProperty propertyName="CenterCantPoint" typeName="string" displayLabel="Center Cant Point" category="PointControl_PointControl" priority="299994"/>
+        <ECProperty propertyName="LeftCantPoint" typeName="string" displayLabel="Left Cant Point" category="PointControl_PointControl" priority="299993"/>
+        <ECProperty propertyName="RightCantPoint" typeName="string" displayLabel="Right Cant Point" category="PointControl_PointControl" priority="299992"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPointControlAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PointControlAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PointEntity2dAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="PointEntity2dPoint" typeName="point3d" displayLabel="Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299999"/>
+        <ECProperty propertyName="PointEntity2d_X" typeName="double" displayLabel="X" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PointEntity2d_Y" typeName="double" displayLabel="Y" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PointEntity2d_Elevation" typeName="double" displayLabel="Elevation" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PointEntity2d_Rotation" typeName="double" displayLabel="Rotation" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299960" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="PointEntity2d_RotationOffset" typeName="double" displayLabel="Rotation Offset" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299955" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="PointEntity2d_RotationReference" typeName="string" displayLabel="Rotation Reference" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299953"/>
+        <ECProperty propertyName="PointEntity2d_AbsoluteAngle" typeName="boolean" displayLabel="Absolute Angle" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299950"/>
+        <ECProperty propertyName="PointEntity2d_Description" typeName="string" displayLabel="Description" category="FeatureProperties_Feature" priority="299910"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPointEntity2dAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PointEntity2dAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PointGroupAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="PointGroup_NumberOfPoints" typeName="int" displayLabel="Number Of Points" category="PointGroupCategoryAttributes_Point_Group" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPointGroupAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PointGroupAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PointOrderedListAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="PointOrderedList_Elevation" typeName="double" displayLabel="Elevation" category="PointOrderedListAttributes_Point_Ordered_List" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPointOrderedListAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PointOrderedListAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PortalEntityAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Portal_Portal" priority="299999"/>
+        <ECProperty propertyName="ParametricCell" typeName="string" displayLabel="&lt;- ParametricCell -&gt;" category="Portal_Portal" priority="299990"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPortalEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PortalEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileElementAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_ProfileElement_DeltaX" typeName="double" displayLabel="DeltaX" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ProfileCircularArcAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="ProfileCircularArc_EndSlope" typeName="double" displayLabel="Slope End" category="GeometryAttributes_Geometry" priority="298950"/>
+        <ECProperty propertyName="ProfileCircularArc_StartSlope" typeName="double" displayLabel="Slope Start" category="GeometryAttributes_Geometry" priority="298960"/>
+        <ECProperty propertyName="ProfileCircularArc_RightTangent" typeName="point3d" displayLabel="Right Tangent" category="GeometryAttributes_Geometry" priority="298940"/>
+        <ECProperty propertyName="ProfileCircularArc_LeftTangent" typeName="point3d" displayLabel="Left Tangent" category="GeometryAttributes_Geometry" priority="298930"/>
+        <ECProperty propertyName="ProfileCircularArc_EndLocalAbscissa" typeName="double" displayLabel="Local Abscissa End" category="GeometryAttributes_Geometry" priority="298920"/>
+        <ECProperty propertyName="ProfileCircularArc_StartLocalAbscissa" typeName="double" displayLabel="Local Abscissa Start" category="GeometryAttributes_Geometry" priority="298910"/>
+        <ECProperty propertyName="ProfileCircularArc_VPIPoint" typeName="point3d" displayLabel="VPI Point" category="GeometryAttributes_Geometry" priority="298900"/>
+        <ECProperty propertyName="ProfileCircularArc_ProjectedLength" typeName="double" displayLabel="Projected Length" category="GeometryAttributes_Geometry" priority="298890" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_RightLength" typeName="double" displayLabel="Right Extent" category="GeometryAttributes_Geometry" priority="298880" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_LeftLength" typeName="double" displayLabel="Left Extent" category="GeometryAttributes_Geometry" priority="298870" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="298990" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ProfileCircularArc_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299000" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="ProfileCircularArc_Radius" typeName="double" displayLabel="Radius" category="GeometryAttributes_Geometry" priority="298980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_CenterPoint" typeName="point3d" displayLabel="Center Point" category="GeometryAttributes_Geometry" priority="298970"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileCircularArcAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileCircularArcAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileComplexAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileComplexAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileComplexAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsProfiledElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfiledElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileLineAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_ProfileLine_Slope" typeName="double" displayLabel="Slope" category="GeometryAttributes_Geometry" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileLineStringAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_ProfileLineString_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileLineStringAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileLineStringAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileParabolaAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="ProfileParabola_VPIPoint" typeName="point3d" displayLabel="VPI Point" category="GeometryAttributes_Geometry" priority="298950"/>
+        <ECProperty propertyName="ProfileParabola_SummitPoint" typeName="point3d" displayLabel="Summit Point" category="GeometryAttributes_Geometry" priority="298940"/>
+        <ECProperty propertyName="ProfileParabola_StartSlope" typeName="double" displayLabel="Slope Start" category="GeometryAttributes_Geometry" priority="298930"/>
+        <ECProperty propertyName="ProfileParabola_EndSlope" typeName="double" displayLabel="Slope End" category="GeometryAttributes_Geometry" priority="298920"/>
+        <ECProperty propertyName="ProfileParabola_KValue" typeName="double" displayLabel="K" category="GeometryAttributes_Geometry" priority="298910" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileParabola_LeftLength" typeName="double" displayLabel="Left Extent" category="GeometryAttributes_Geometry" priority="298890" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileParabola_RightLength" typeName="double" displayLabel="Right Extent" category="GeometryAttributes_Geometry" priority="298880" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileParabolaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileParabolaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfilePointbyIntersectionRuleAspect" displayLabel="Profile Intersection Point">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="ProfilePointbyIntersectionRuleAttributes_Profile_Intersection_Point" priority="299800" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Elevation" typeName="double" displayLabel="Elevation" category="ProfilePointbyIntersectionRuleAttributes_Profile_Intersection_Point" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Name" typeName="double" displayLabel="Name" category="ProfilePointbyIntersectionRuleAttributes_Profile_Intersection_Point" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfilePointbyIntersectionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfilePointbyIntersectionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RadiusTransitionAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="ParameterName" typeName="string" displayLabel="Name" category="Radius_Transition_Setting_Attributes_Radius_Transition_Settings" priority="300000"/>
+        <ECProperty propertyName="ParameterDefaultTransitionLength" typeName="double" displayLabel="Default Transition Length" category="Radius_Transition_Setting_Attributes_Radius_Transition_Settings" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParameterMinTransitionLength" typeName="double" displayLabel="Minimum Transition Length" category="Radius_Transition_Setting_Attributes_Radius_Transition_Settings" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParameterRadius" typeName="double" displayLabel="Radius" category="Radius_Transition_Setting_Attributes_Radius_Transition_Settings" priority="300000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRadiusTransitionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RadiusTransitionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyBSplineAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+        <ECProperty propertyName="BSpline_IsRational" typeName="int" displayLabel="BSpline_IsRational" category="Miscellaneous_Read_Only_BSpline" priority="0"/>
+        <ECProperty propertyName="BSpline_KnotsCount" typeName="int" displayLabel="BSpline_KnotsCount" category="Miscellaneous_Read_Only_BSpline" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyBSplineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyBSplineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyCircularArcAspect">
+        <BaseClass>LinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_CircularArc_Radius" typeName="double" displayLabel="Radius" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_CircularArc_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="299974" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_CircularArc_Tangent" typeName="double" displayLabel="Tangent" category="GeometryAttributes_Geometry" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_CircularArc_Chord" typeName="double" displayLabel="Chord" category="GeometryAttributes_Geometry" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_CircularArc_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_CircularArc_EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299890" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_CircularArc_DegreeOfCurve" typeName="double" displayLabel="Degree of Curvature" category="GeometryAttributes_Geometry" priority="299870" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_CircularArc_DegreeOfCurveDefinition" typeName="ReadOnlyCircularArcAspect_LinearElement_CircularArc_DegreeOfCurveDefinition_Enum" displayLabel="Degree of Curvature Definition" category="GeometryAttributes_Geometry" priority="299880"/>
+        <ECProperty propertyName="LinearElement_CircularArc_CenterPoint" typeName="point3d" displayLabel="Center Point" category="GeometryAttributes_Geometry" priority="299860"/>
+        <ECProperty propertyName="LinearElement_CircularArc_Hand" typeName="string" displayLabel="Hand" category="GeometryAttributes_Geometry" priority="299880"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyCircularArcAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyCircularArcAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyClosedLinearComplexAspect">
+        <BaseClass>LinearComplexAspect</BaseClass>
+        <ECProperty propertyName="ClosedLinearComplex_IsClockWise" typeName="ReadOnlyClosedLinearComplexAspect_ClosedLinearComplex_IsClockWise_BoolEnum" displayLabel="Clockwise" category="GeometryAttributes_Geometry" priority="299960"/>
+        <ECProperty propertyName="ClosedLinearComplex_Area" typeName="double" displayLabel="Area" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyClosedLinearComplexAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyClosedLinearComplexAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyLineStringAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_LineString_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299900"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ReadOnlyClosedLineStringAspect">
+        <BaseClass>ReadOnlyLineStringAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_LineString_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299900"/>
+        <ECProperty propertyName="LinearElement_ClosedLineString_IsClockWise" typeName="ReadOnlyClosedLineStringAspect_LinearElement_ClosedLineString_IsClockWise_Enum" displayLabel="Clockwise" category="GeometryAttributes_Geometry" priority="299000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyClosedLineStringAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyClosedLineStringAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyProfiledElementAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ReadOnlySpiralAspect">
+        <BaseClass>ReadOnlyProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Spiral_StartRadius" typeName="double" displayLabel="Start Radius" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndRadius" typeName="double" displayLabel="End Radius" category="GeometryAttributes_Geometry" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="299870" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_Spiral_Constant" typeName="double" displayLabel="Constant" category="GeometryAttributes_Geometry" priority="299860" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongTangent" typeName="double" displayLabel="Long Tangent" category="GeometryAttributes_Geometry" priority="299850" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_ShortTangent" typeName="double" displayLabel="Short Tangent" category="GeometryAttributes_Geometry" priority="299840" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongChord" typeName="double" displayLabel="Long Chord" category="GeometryAttributes_Geometry" priority="299830" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Xs" typeName="double" displayLabel="Xs" category="GeometryAttributes_Geometry" priority="299820" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Ys" typeName="double" displayLabel="Ys" category="GeometryAttributes_Geometry" priority="299810" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_PValue" typeName="double" displayLabel="P" category="GeometryAttributes_Geometry" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_KValue" typeName="double" displayLabel="K" category="GeometryAttributes_Geometry" priority="299790" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299780" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299770" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_IntrinsicPoint" typeName="point3d" displayLabel="Intrinsic Point" category="GeometryAttributes_Geometry" priority="299700"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartArcCenterPoint" typeName="point3d" displayLabel="Start Arc Center Point" category="GeometryAttributes_Geometry" priority="299690"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndArcCenterPoint" typeName="point3d" displayLabel="End Arc Center Point" category="GeometryAttributes_Geometry" priority="299680"/>
+        <ECProperty propertyName="LinearElement_Spiral_Hand" typeName="string" displayLabel="Hand" category="GeometryAttributes_Geometry" priority="299760"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ReadOnlyClothoidAspect">
+        <BaseClass>ReadOnlySpiralAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Spiral_StartRadius" typeName="double" displayLabel="Start Radius" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndRadius" typeName="double" displayLabel="End Radius" category="GeometryAttributes_Geometry" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="299870" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LinearElement_Spiral_Constant" typeName="double" displayLabel="Constant" category="GeometryAttributes_Geometry" priority="299860" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongTangent" typeName="double" displayLabel="Long Tangent" category="GeometryAttributes_Geometry" priority="299850" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_ShortTangent" typeName="double" displayLabel="Short Tangent" category="GeometryAttributes_Geometry" priority="299840" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_LongChord" typeName="double" displayLabel="Long Chord" category="GeometryAttributes_Geometry" priority="299830" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Xs" typeName="double" displayLabel="Xs" category="GeometryAttributes_Geometry" priority="299820" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_Ys" typeName="double" displayLabel="Ys" category="GeometryAttributes_Geometry" priority="299810" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_PValue" typeName="double" displayLabel="P" category="GeometryAttributes_Geometry" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_KValue" typeName="double" displayLabel="K" category="GeometryAttributes_Geometry" priority="299790" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299780" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299770" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LinearElement_Spiral_IntrinsicPoint" typeName="point3d" displayLabel="Intrinsic Point" category="GeometryAttributes_Geometry" priority="299700"/>
+        <ECProperty propertyName="LinearElement_Spiral_StartArcCenterPoint" typeName="point3d" displayLabel="Start Arc Center Point" category="GeometryAttributes_Geometry" priority="299690"/>
+        <ECProperty propertyName="LinearElement_Spiral_EndArcCenterPoint" typeName="point3d" displayLabel="End Arc Center Point" category="GeometryAttributes_Geometry" priority="299680"/>
+        <ECProperty propertyName="LinearElement_Spiral_Hand" typeName="string" displayLabel="Hand" category="GeometryAttributes_Geometry" priority="299760"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyClothoidAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyClothoidAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyCompoundElementAspect">
+        <BaseClass>ReadOnlyProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Length" typeName="double" displayLabel="Length" category="GeometryAttributes_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearElement_StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryAttributes_Geometry" priority="299990"/>
+        <ECProperty propertyName="LinearElement_EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryAttributes_Geometry" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyCompoundElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyCompoundElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyLine3dAspect">
+        <BaseClass>ReadOnlyProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Line3d_Direction" typeName="double" displayLabel="Direction" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyLine3dAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyLine3dAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyLinearComplexAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyLinearComplexAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyLinearElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyLinearElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyLineAspect">
+        <BaseClass>ReadOnlyLinearElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_Line_Direction" typeName="double" displayLabel="Direction" category="GeometryAttributes_Geometry" priority="299900" kindOfQuantity="cifu:BEARING"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyLineString3dAspect">
+        <BaseClass>ReadOnlyProfiledElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_LineString3d_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyLineString3dAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyLineString3dAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyLineStringAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyLineStringAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyProfileCircularArcAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="ProfileCircularArc_EndSlope" typeName="double" displayLabel="Slope End" category="GeometryAttributes_Geometry" priority="298950"/>
+        <ECProperty propertyName="ProfileCircularArc_StartSlope" typeName="double" displayLabel="Slope Start" category="GeometryAttributes_Geometry" priority="298960"/>
+        <ECProperty propertyName="ProfileCircularArc_RightTangent" typeName="point3d" displayLabel="Right Tangent" category="GeometryAttributes_Geometry" priority="298940"/>
+        <ECProperty propertyName="ProfileCircularArc_LeftTangent" typeName="point3d" displayLabel="Left Tangent" category="GeometryAttributes_Geometry" priority="298930"/>
+        <ECProperty propertyName="ProfileCircularArc_EndLocalAbscissa" typeName="double" displayLabel="Local Abscissa End" category="GeometryAttributes_Geometry" priority="298920"/>
+        <ECProperty propertyName="ProfileCircularArc_StartLocalAbscissa" typeName="double" displayLabel="Local Abscissa Start" category="GeometryAttributes_Geometry" priority="298910"/>
+        <ECProperty propertyName="ProfileCircularArc_VPIPoint" typeName="point3d" displayLabel="VPI Point" category="GeometryAttributes_Geometry" priority="298900"/>
+        <ECProperty propertyName="ProfileCircularArc_ProjectedLength" typeName="double" displayLabel="Projected Length" category="GeometryAttributes_Geometry" priority="298890" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_RightLength" typeName="double" displayLabel="Right Extent" category="GeometryAttributes_Geometry" priority="298880" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_LeftLength" typeName="double" displayLabel="Left Extent" category="GeometryAttributes_Geometry" priority="298870" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_SweepAngle" typeName="double" displayLabel="Sweep Angle" category="GeometryAttributes_Geometry" priority="298990" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ProfileCircularArc_StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299000" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="ProfileCircularArc_Radius" typeName="double" displayLabel="Radius" category="GeometryAttributes_Geometry" priority="298980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileCircularArc_CenterPoint" typeName="point3d" displayLabel="Center Point" category="GeometryAttributes_Geometry" priority="298970"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyProfileCircularArcAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyProfileCircularArcAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyProfileComplexAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyProfileComplexAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyProfileComplexAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyProfiledElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyProfiledElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyProfileLineAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_ProfileLine_Slope" typeName="double" displayLabel="Slope" category="GeometryAttributes_Geometry" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyProfileLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyProfileLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyProfileLineStringAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="LinearElement_ProfileLineString_VerticesCount" typeName="int" displayLabel="Count" category="GeometryAttributes_Geometry" priority="299000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyProfileLineStringAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyProfileLineStringAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReadOnlyProfileParabolaAspect">
+        <BaseClass>ProfileElementAspect</BaseClass>
+        <ECProperty propertyName="ProfileParabola_VPIPoint" typeName="point3d" displayLabel="VPI Point" category="GeometryAttributes_Geometry" priority="298950"/>
+        <ECProperty propertyName="ProfileParabola_SummitPoint" typeName="point3d" displayLabel="Summit Point" category="GeometryAttributes_Geometry" priority="298940"/>
+        <ECProperty propertyName="ProfileParabola_StartSlope" typeName="double" displayLabel="Slope Start" category="GeometryAttributes_Geometry" priority="298930"/>
+        <ECProperty propertyName="ProfileParabola_EndSlope" typeName="double" displayLabel="Slope End" category="GeometryAttributes_Geometry" priority="298920"/>
+        <ECProperty propertyName="ProfileParabola_KValue" typeName="double" displayLabel="K" category="GeometryAttributes_Geometry" priority="298910" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileParabola_LeftLength" typeName="double" displayLabel="Left Extent" category="GeometryAttributes_Geometry" priority="298890" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileParabola_RightLength" typeName="double" displayLabel="Right Extent" category="GeometryAttributes_Geometry" priority="298880" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlyProfileParabolaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlyProfileParabolaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsReadOnlySpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReadOnlySpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SecondaryAlignmentAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="SecondaryAlignmentName" typeName="string" displayLabel="Name" category="SecondaryAlignment_Secondary_Alignment" priority="299999"/>
+        <ECProperty propertyName="StartOffset" typeName="double" displayLabel="Start Offset" category="SecondaryAlignment_Secondary_Alignment" priority="299998"/>
+        <ECProperty propertyName="StopOffset" typeName="double" displayLabel="Stop Offset" category="SecondaryAlignment_Secondary_Alignment" priority="-3"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSecondaryAlignmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SecondaryAlignmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StationEquationAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackLocation" typeName="double" displayLabel="BackLocation" category="Miscellaneous_Station_Equation" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackLocation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'BackLocation' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BackStation" typeName="string" displayLabel="Back Station" category="StationingProperties_Stationing" priority="299995"/>
+        <ECProperty propertyName="AheadStation" typeName="string" displayLabel="Ahead Station" category="StationingProperties_Stationing" priority="299994"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStationEquationAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StationEquationAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StationingEntityAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="AssignedStation" typeName="string" displayLabel="Assigned Station" category="StationingProperties_Stationing" priority="299999"/>
+        <ECProperty propertyName="AssignedLocation" typeName="double" displayLabel="Assigned Location" category="StationingProperties_Stationing" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AssignedLocation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'AssignedLocation' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BeginStation" typeName="string" displayLabel="Begin Station" category="StationingProperties_Stationing" priority="299998"/>
+        <ECProperty propertyName="EndStation" typeName="string" displayLabel="End Station" category="StationingProperties_Stationing" priority="299997"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStationingEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StationingEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StrokingPropertiesClassAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="StrokingStepMethod" typeName="StrokingPropertiesClassAspect_StrokingStepMethod_Enum" displayLabel="Stroking Step Method" category="StrokingDefinition_Stroking_Definition" priority="0"/>
+        <ECProperty propertyName="LinearStroking" typeName="double" displayLabel="Linear Stroking" category="StrokingDefinition_Stroking_Definition" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CurveStroking" typeName="double" displayLabel="Curve Stroking" category="StrokingDefinition_Stroking_Definition" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileStroking" typeName="double" displayLabel="Profile Stroking" category="StrokingDefinition_Stroking_Definition" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStrokingPropertiesClassAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StrokingPropertiesClassAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TargetAliasAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="TargetAlias_Target_Alias" priority="299999"/>
+        <ECProperty propertyName="Type" typeName="string" displayLabel="Type" category="TargetAlias_Target_Alias" priority="299998"/>
+        <ECProperty propertyName="UseClosest" typeName="boolean" displayLabel="Use Closest" category="TargetAlias_Target_Alias" priority="299997"/>
+        <ECProperty propertyName="Aliases" typeName="string" displayLabel="Aliases" category="TargetAlias_Target_Alias" priority="299996"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTargetAliasAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TargetAliasAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TemplateDropAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="HorizontalName" typeName="string" displayLabel="Horizontal Name" category="TemplateDrop_Template_Drop" priority="-3"/>
+        <ECProperty propertyName="TemplateName" typeName="string" displayLabel="Template Name" category="TemplateDrop_Template_Drop" priority="0"/>
+        <ECProperty propertyName="Interval" typeName="double" displayLabel="Interval" category="TemplateDrop_Template_Drop" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" category="TemplateDrop_Template_Drop" priority="-4"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTemplateDropAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TemplateDropAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TemplateTransitionAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartTemplateName" typeName="string" displayLabel="Start Template Name" category="TemplateTransitionRuleAttributes_Template_Transition" priority="299999"/>
+        <ECProperty propertyName="EndTemplateName" typeName="string" displayLabel="End Template Name" category="TemplateTransitionRuleAttributes_Template_Transition" priority="299998"/>
+        <ECProperty propertyName="Interval" typeName="double" displayLabel="Interval" category="TemplateTransitionRuleAttributes_Template_Transition" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" category="TemplateTransitionRuleAttributes_Template_Transition" priority="299996"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTemplateTransitionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TemplateTransitionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ThreeDCutViewAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartStation" typeName="double" displayLabel="Start Station" category="ClipVolume_Clip_Volume" priority="299998"/>
+        <ECProperty propertyName="EndStation" typeName="double" displayLabel="End Station" category="ClipVolume_Clip_Volume" priority="299994"/>
+        <ECProperty propertyName="CutOffset" typeName="double" displayLabel="Cut Offset" category="ClipVolume_Clip_Volume" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BottomElevation" typeName="double" displayLabel="Bottom Elevation" category="ClipVolume_Clip_Volume" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TopElevation" typeName="double" displayLabel="Top Elevation" category="ClipVolume_Clip_Volume" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ClipStartStation" typeName="boolean" displayLabel="Clip Start Station" category="ClipVolume_Clip_Volume" priority="299999"/>
+        <ECProperty propertyName="ClipEndStation" typeName="boolean" displayLabel="Clip End Station" category="ClipVolume_Clip_Volume" priority="299995"/>
+        <ECProperty propertyName="ClipBottomElevation" typeName="boolean" displayLabel="Clip Bottom Elevation" category="ClipVolume_Clip_Volume" priority="299993"/>
+        <ECProperty propertyName="ClipTopElevation" typeName="boolean" displayLabel="Clip Top Elevation" category="ClipVolume_Clip_Volume" priority="299997"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsThreeDCutViewAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ThreeDCutViewAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VerticalCurveAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" priority="300000"/>
+        <ECProperty propertyName="SagMinimum" typeName="double" displayLabel="Sag Minimum" category="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" priority="300000"/>
+        <ECProperty propertyName="SagDefault" typeName="double" displayLabel="Sag Default" category="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" priority="300000"/>
+        <ECProperty propertyName="CrestMinimum" typeName="double" displayLabel="Crest Minimum" category="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" priority="300000"/>
+        <ECProperty propertyName="CrestDefault" typeName="double" displayLabel="Crest Default" category="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" priority="300000"/>
+        <ECProperty propertyName="Speed" typeName="double" displayLabel="Speed" category="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" priority="300000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVerticalCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VerticalCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VerticalDesignStandardAspect">
+        <BaseClass>CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinimumSlope" typeName="double" displayLabel="Minimum Slope" category="Design_Standard_Attributes_Vertical_Design_Standard" priority="299998" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="MaximumSlope" typeName="double" displayLabel="Maximum Slope" category="Design_Standard_Attributes_Vertical_Design_Standard" priority="299997" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="MaxDifferenceInGrade" typeName="double" displayLabel="Maximum Difference in Grade" category="Design_Standard_Attributes_Vertical_Design_Standard" priority="299993" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Table" typeName="string" displayLabel="Table" category="Design_Standard_Attributes_Vertical_Design_Standard" priority="299991"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVerticalDesignStandardAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VerticalDesignStandardAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="GeometricElementBoundsContentForSheet" modifier="None" strength="referencing">
+        <BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="bounds content for" polymorphic="true">
+            <Class class="bis:GeometricElement"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="has content bounded by" polymorphic="false">
+            <Class class="bis:Sheet"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="CivilObjectStatusAttributes_Object_Status" description="CivilObjectStatusAttributes" displayLabel="Object Status" priority="299990"/>
+    <PropertyCategory typeName="ClipVolume_Clip_Volume" description="ClipVolume" displayLabel="Clip Volume" priority="199800"/>
+    <PropertyCategory typeName="Corridor_Corridor" description="Corridor" displayLabel="Corridor" priority="199800"/>
+    <PropertyCategory typeName="CurveWidening_Curve_Widening" description="CurveWidening" displayLabel="Curve Widening" priority="199800"/>
+    <PropertyCategory typeName="Design_Standard_Attributes_Vertical_Design_Standard" description="Design Standard Attributes" displayLabel="Vertical Design Standard" priority="299999"/>
+    <PropertyCategory typeName="DistanceAlongSlopeEntityProperties_Distance_Along_Slope_Entity" description="DistanceAlongSlopeEntityProperties" displayLabel="Distance Along Slope Entity" priority="0"/>
+    <PropertyCategory typeName="EndConditionException_End_Condition_Exception" description="EndConditionException" displayLabel="End Condition Exception" priority="199800"/>
+    <PropertyCategory typeName="FeatureDefinition_Feature_Definition" description="FeatureDefinition" displayLabel="Feature Definition" priority="299990"/>
+    <PropertyCategory typeName="FeatureProperties_Feature" description="FeatureProperties" displayLabel="Feature" priority="299999"/>
+    <PropertyCategory typeName="FlowLineEntity_Aquaplaning" description="FlowLineEntity" displayLabel="Aquaplaning" priority="100000"/>
+    <PropertyCategory typeName="GeometryAttributes_Geometry" description="GeometryAttributes" displayLabel="Geometry" priority="300000"/>
+    <PropertyCategory typeName="GeometryPointsCategoryAttributes_Geometry_Points" description="GeometryPointsCategoryAttributes" displayLabel="Geometry Points" priority="4294967096"/>
+    <PropertyCategory typeName="KeyStation_Key_Station" description="KeyStation" displayLabel="Key Station" priority="199800"/>
+    <PropertyCategory typeName="MeshQuantities_Civil_Quantities" description="MeshQuantities" displayLabel="Civil Quantities" priority="100000"/>
+    <PropertyCategory typeName="MeshSurfaceEntity_Component_Layer" description="MeshSurfaceEntity" displayLabel="Component Layer" priority="100000"/>
+    <PropertyCategory typeName="Miscellaneous_BSpline" description="Miscellaneous" displayLabel="BSpline" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_BSpline_Presentation" description="Miscellaneous" displayLabel="BSpline_Presentation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_Corridor" description="Miscellaneous" displayLabel="Corridor" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_Corridor_Presentation" description="Miscellaneous" displayLabel="Corridor_Presentation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_Internal_Station_Equation" description="Miscellaneous" displayLabel="Internal Station Equation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_InternalStationEquation_Presentation" description="Miscellaneous" displayLabel="InternalStationEquation_Presentation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_Intersection_Point" description="Miscellaneous" displayLabel="Intersection Point" priority="401000"/>
+    <PropertyCategory typeName="Miscellaneous_IntersectionPointStruct" description="Miscellaneous" displayLabel="IntersectionPointStruct" priority="401000"/>
+    <PropertyCategory typeName="Miscellaneous_Read_Only_BSpline" description="Miscellaneous" displayLabel="Read Only BSpline" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_ReadOnlyBSpline_Presentation" description="Miscellaneous" displayLabel="ReadOnlyBSpline_Presentation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_Station_Equation" description="Miscellaneous" displayLabel="Station Equation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_StationEquation_Presentation" description="Miscellaneous" displayLabel="StationEquation_Presentation" priority="0"/>
+    <PropertyCategory typeName="Name_General_Category" description="Name" displayLabel="General Category" priority="300000"/>
+    <PropertyCategory typeName="ParametricConstraint_Parametric_Constraint" description="ParametricConstraint" displayLabel="Parametric Constraint" priority="199800"/>
+    <PropertyCategory typeName="PointControl_PointControl" description="PointControl" displayLabel="PointControl" priority="199800"/>
+    <PropertyCategory typeName="PointGroupCategoryAttributes_Point_Group" description="PointGroupCategoryAttributes" displayLabel="Point Group" priority="4294966996"/>
+    <PropertyCategory typeName="PointOrderedListAttributes_Point_Ordered_List" description="PointOrderedListAttributes" displayLabel="Point Ordered List" priority="0"/>
+    <PropertyCategory typeName="Portal_Portal" description="Portal" displayLabel="Portal" priority="199800"/>
+    <PropertyCategory typeName="ProfilePointbyIntersectionRuleAttributes_Profile_Intersection_Point" description="ProfilePointbyIntersectionRuleAttributes" displayLabel="Profile Intersection Point" priority="0"/>
+    <PropertyCategory typeName="ProjectionProperties_Geographical_Coordinate_Systems" description="ProjectionProperties" displayLabel="Geographical Coordinate Systems" priority="299980"/>
+    <PropertyCategory typeName="Radius_Transition_Setting_Attributes_Radius_Transition_Settings" description="Radius Transition Setting Attributes" displayLabel="Radius Transition Settings" priority="299999"/>
+    <PropertyCategory typeName="SecondaryAlignment_Secondary_Alignment" description="SecondaryAlignment" displayLabel="Secondary Alignment" priority="199800"/>
+    <PropertyCategory typeName="StationingProperties_Stationing" description="StationingProperties" displayLabel="Stationing" priority="0"/>
+    <PropertyCategory typeName="StrokingDefinition_Stroking_Definition" description="StrokingDefinition" displayLabel="Stroking Definition" priority="0"/>
+    <PropertyCategory typeName="TargetAlias_Target_Alias" description="TargetAlias" displayLabel="Target Alias" priority="199800"/>
+    <PropertyCategory typeName="TemplateDrop_Template_Drop" description="TemplateDrop" displayLabel="Template Drop" priority="199800"/>
+    <PropertyCategory typeName="TemplateTransitionRuleAttributes_Template_Transition" description="TemplateTransitionRuleAttributes" displayLabel="Template Transition" priority="300000"/>
+    <PropertyCategory typeName="TerrainModelBySelectedElementAttributes_Create_from_Elements_UnLinked" description="TerrainModelBySelectedElementAttributes" displayLabel="Create from Elements (UnLinked)" priority="299999"/>
+    <PropertyCategory typeName="TriangulationOptions_Triangulation_Options" description="TriangulationOptions" displayLabel="Triangulation Options" priority="299981"/>
+    <PropertyCategory typeName="Vertical_Curve_Setting_Attributes_VerticalCurveSettings" description="Vertical Curve Setting Attributes" displayLabel="&lt;- VerticalCurveSettings -&gt;" priority="299999"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifGeometricRules.01.00.03.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifGeometricRules.01.00.03.ecschema.xml
@@ -1,0 +1,3416 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifGeometricRules" alias="cifgr" version="01.00.03" description="iModel Connector schema containing aspect classes with common Geometric-rule properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.12" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.01" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.01" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="ArcBetweenElementArcRuleAspect_AheadTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementArcRuleBaseAspect_BackTaperDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Length_Ratio" value="1" displayLabel="Length Ratio"/>
+        <ECEnumerator name="Length_Offset" value="2" displayLabel="Length Offset"/>
+        <ECEnumerator name="Ratio_Offset" value="3" displayLabel="Ratio-Offset"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementArcRuleBaseAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementArcRuleBaseAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementArcRuleSpiralAspect_AheadTransitionAheadSpiralDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementsRuleAheadTransitionAspect_AheadTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementsRuleAheadTransitionSpiralAspect_AheadTransitionAheadSpiralDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementsRuleAspect_CurveTypeAtEnd_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Compound" value="2" displayLabel="Compound"/>
+        <ECEnumerator name="Reverse" value="1" displayLabel="Reverse"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementsRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementsRuleBackTransitionAheadSpiralAspect_BackTransitionAheadSpiralDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcBetweenElementsRuleBackTransitionAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcFromElementRuleBaseAspect_BackTaperDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Length_Ratio" value="1" displayLabel="Length Ratio"/>
+        <ECEnumerator name="Length_Offset" value="2" displayLabel="Length Offset"/>
+        <ECEnumerator name="Ratio_Offset" value="3" displayLabel="Ratio-Offset"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcFromElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Spiral" value="1" displayLabel="Spiral"/>
+        <ECEnumerator name="Curve" value="2" displayLabel="Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcFromElementRuleBaseAspect_Hand_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Clockwise" value="1" displayLabel="Clockwise"/>
+        <ECEnumerator name="Counter_Clockwise" value="-1" displayLabel="Counter Clockwise"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcFromElementRuleBaseAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcFromElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="Deflection" value="2" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="3" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcFromElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcToElementRuleBaseAspect_BackTaperDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Length_Ratio" value="1" displayLabel="Length Ratio"/>
+        <ECEnumerator name="Length_Offset" value="2" displayLabel="Length Offset"/>
+        <ECEnumerator name="Ratio_Offset" value="3" displayLabel="Ratio-Offset"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcToElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Spiral" value="1" displayLabel="Spiral"/>
+        <ECEnumerator name="Curve" value="2" displayLabel="Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcToElementRuleBaseAspect_Hand_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Clockwise" value="1" displayLabel="Clockwise"/>
+        <ECEnumerator name="Counter_Clockwise" value="-1" displayLabel="Counter Clockwise"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcToElementRuleBaseAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcToElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="Deflection" value="2" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="3" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ArcToElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BestFitHorizontalRuleAspect_BestFitForceSymmetricalSpirals_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BestFitHorizontalRuleAspect_BestFitIncludeSpirals_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ChamferBetweenElementsRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CircularArcRuleAspect_Side_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="One" value="0" displayLabel="1"/>
+        <ECEnumerator name="Two" value="1" displayLabel="2"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DistanceMonitorRuleAspect_DistanceMonitorRule_MonitorState_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="MonitorStatePassive" value="1" displayLabel="&lt;- MonitorStatePassive -&gt;"/>
+        <ECEnumerator name="MonitorStateActive" value="2" displayLabel="&lt;- MonitorStateActive -&gt;"/>
+        <ECEnumerator name="MonitorStateInActive" value="3" displayLabel="&lt;- MonitorStateInActive -&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DistanceMonitorRuleAspect_DistanceMonitorRule_MonitorType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="DistanceMonitorTypeMinMaxDistance" value="1" displayLabel="&lt;- DistanceMonitorTypeMinMaxDistance -&gt;"/>
+        <ECEnumerator name="DistanceMonitorTypeMinDistance" value="2" displayLabel="&lt;- DistanceMonitorTypeMinDistance -&gt;"/>
+        <ECEnumerator name="DistanceMonitorTypeMaxDistance" value="3" displayLabel="&lt;- DistanceMonitorTypeMaxDistance -&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DTMPondRuleAspect_PondTarget_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Elevation" value="2" displayLabel="Elevation"/>
+        <ECEnumerator name="Volume" value="1" displayLabel="Volume"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DTMSlopeTraceRuleAspect_TraceSlopeDirection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Up" value="0" displayLabel="Up"/>
+        <ECEnumerator name="Down" value="1" displayLabel="Down"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="EqualSpacePointAlongElementRuleAspect_EqualSpacePointAlongElementRule_ElevationMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Value" value="1" displayLabel="Value"/>
+        <ECEnumerator name="Named_Terrain_Model___Mesh" value="2" displayLabel="Named Terrain Model / Mesh"/>
+        <ECEnumerator name="Plan_Element" value="3" displayLabel="Plan Element"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="EqualSpacePointAlongElementRuleAspect_EqualSpacePointAlongElementRule_RotationMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Absolute_Value" value="1" displayLabel="Absolute Value"/>
+        <ECEnumerator name="Relative_to_alignment" value="2" displayLabel="Relative to alignment"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="EqualSpacePointRuleAspect_EqualSpacePointRule_ElevationMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Value" value="1" displayLabel="Value"/>
+        <ECEnumerator name="Named_Terrain_Model___Mesh" value="2" displayLabel="Named Terrain Model / Mesh"/>
+        <ECEnumerator name="Plan_Element" value="3" displayLabel="Plan Element"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="EqualSpacePointRuleAspect_EqualSpacePointRule_RotationMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Absolute_Value" value="1" displayLabel="Absolute Value"/>
+        <ECEnumerator name="Relative_to_alignment" value="2" displayLabel="Relative to alignment"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleAheadBaseAspect_AheadTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Spiral" value="1" displayLabel="Spiral"/>
+        <ECEnumerator name="Curve" value="3" displayLabel="Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleAheadTaperAspect_AheadTaperDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Length_Ratio" value="1" displayLabel="Length Ratio"/>
+        <ECEnumerator name="Length_Offset" value="2" displayLabel="Length Offset"/>
+        <ECEnumerator name="Ratio_Offset" value="3" displayLabel="Ratio-Offset"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleAheadTransitionCurveAspect_AheadTransitionDefinitionMethodArc_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="Deflection" value="2" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="3" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleAheadTransitionSpiralAspect_AheadTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleBackBaseAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Spiral" value="1" displayLabel="Spiral"/>
+        <ECEnumerator name="Curve" value="3" displayLabel="Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleBackTaperAspect_BackTaperDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Length_Ratio" value="1" displayLabel="Length Ratio"/>
+        <ECEnumerator name="Length_Offset" value="2" displayLabel="Length Offset"/>
+        <ECEnumerator name="Ratio_Offset" value="3" displayLabel="Ratio-Offset"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleBackTransitionCurveAspect_BackTransitionDefinitionMethodArc_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="Deflection" value="2" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="3" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="FilletRuleBackTransitionSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineBetweenElementsRuleAspect_AheadTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineBetweenElementsRuleAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineBetweenElementsRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineFromElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Spiral" value="1" displayLabel="Spiral"/>
+        <ECEnumerator name="Curve" value="2" displayLabel="Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineFromElementRuleBaseAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineFromElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="Deflection" value="2" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="3" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineFromElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LinElemToLinElemVariableOffsetRuleAspect_GeometryType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Base_Geometry" value="0" displayLabel="Base Geometry"/>
+        <ECEnumerator name="Extended_Geometry" value="1" displayLabel="Extended Geometry"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LinElemToLinElemVariableOffsetRuleAspect_PlacementMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Single_Offset" value="0" displayLabel="Single Offset"/>
+        <ECEnumerator name="Variable_Offset" value="1" displayLabel="Variable Offset"/>
+        <ECEnumerator name="Offset_And_Ratio" value="2" displayLabel="Offset And Ratio"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LinElemToLinElemVariableOffsetRuleAspect_Spiralized_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LinEnt3dByDTMEntityTraceRuleAspect_LinEnt3dByDTMEntityTraceRuleSlopeDirection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Up" value="0" displayLabel="Up"/>
+        <ECEnumerator name="Down" value="1" displayLabel="Down"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LinEnt3dByDTMEntityTraceSlopeRuleAspect_TraceSlopeDirection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Up" value="1" displayLabel="Up"/>
+        <ECEnumerator name="Down" value="2" displayLabel="Down"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LinEnt3dByPlanProfileRuleAspect_StrokingStepMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Increment" value="0" displayLabel="Increment"/>
+        <ECEnumerator name="Equal_Distance" value="1" displayLabel="Equal Distance"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineToElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Spiral" value="1" displayLabel="Spiral"/>
+        <ECEnumerator name="Curve" value="2" displayLabel="Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineToElementRuleBaseAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineToElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="Deflection" value="2" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="3" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LineToElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Pnt2dToLinElemPositionRuleAspect_PositionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Civil_Accudraw" value="-1" displayLabel="Civil Accudraw"/>
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="First" value="1" displayLabel="First"/>
+        <ECEnumerator name="Last" value="2" displayLabel="Last"/>
+        <ECEnumerator name="Mid_Point" value="3" displayLabel="Mid-Point"/>
+        <ECEnumerator name="Center" value="4" displayLabel="Center"/>
+        <ECEnumerator name="Origin" value="5" displayLabel="Origin"/>
+        <ECEnumerator name="Key_Point" value="6" displayLabel="Key Point"/>
+        <ECEnumerator name="Tangency" value="7" displayLabel="Tangency"/>
+        <ECEnumerator name="Perpendicular" value="8" displayLabel="Perpendicular"/>
+        <ECEnumerator name="BiSector" value="9" displayLabel="BiSector"/>
+        <ECEnumerator name="Nearest" value="10" displayLabel="Nearest"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileBy2LinearEnt3dTransitionRuleAspect_ProfileBy2LinearEnt3dTransitionRule_ProfileBy2LinearEnt3dTransitionRule_QuickTransitionMethod_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Parabolic"/>
+        <ECEnumerator name="False" value="0" displayLabel="Linear"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByDTMOffsetRuleAspect_DrapeOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Triangles" value="1" displayLabel="Triangles"/>
+        <ECEnumerator name="Break_Lines" value="2" displayLabel="Break Lines"/>
+        <ECEnumerator name="Interval" value="3" displayLabel="Interval"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByDTMOffsetRuleAspect_PointSelectionOnElement_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="All" value="1" displayLabel="All"/>
+        <ECEnumerator name="Vertices" value="2" displayLabel="Vertices"/>
+        <ECEnumerator name="Ends" value="3" displayLabel="Ends"/>
+        <ECEnumerator name="Centroid" value="4" displayLabel="Centroid"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByDTMOffsetRuleAspect_ProfileAdjustmentOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Minimum" value="2" displayLabel="Minimum"/>
+        <ECEnumerator name="Maximum" value="3" displayLabel="Maximum"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByPnt3dSlopeRuleAspect_PointProjection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Radial" value="1" displayLabel="Radial"/>
+        <ECEnumerator name="Through" value="2" displayLabel="Through"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByPnt3dSlopeRuleAspect_PointSelectionOnDepending_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="All" value="1" displayLabel="All"/>
+        <ECEnumerator name="Vertices" value="2" displayLabel="Vertices"/>
+        <ECEnumerator name="Ends" value="3" displayLabel="Ends"/>
+        <ECEnumerator name="Centroid" value="4" displayLabel="Centroid"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByPnt3dSlopeRuleAspect_ProfileAdjustment_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Minimum" value="2" displayLabel="Minimum"/>
+        <ECEnumerator name="Maximum" value="3" displayLabel="Maximum"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_PointSelectionOnDepending_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="All" value="1" displayLabel="All"/>
+        <ECEnumerator name="Vertices" value="2" displayLabel="Vertices"/>
+        <ECEnumerator name="Ends" value="3" displayLabel="Ends"/>
+        <ECEnumerator name="Centroid" value="4" displayLabel="Centroid"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_ProfileAdjustment_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Minimum" value="2" displayLabel="Minimum"/>
+        <ECEnumerator name="Maximum" value="3" displayLabel="Maximum"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_SlopeMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Crossfall" value="0" displayLabel="&lt;- Crossfall -&gt;"/>
+        <ECEnumerator name="Spline" value="2" displayLabel="Spline"/>
+        <ECEnumerator name="VerticalOffset" value="1" displayLabel="&lt;- VerticalOffset -&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_SlopeStyle_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Linear" value="3" displayLabel="Linear"/>
+        <ECEnumerator name="Reverse_Biquadratic" value="7" displayLabel="Reverse Biquadratic"/>
+        <ECEnumerator name="Reverse_Cubic" value="8" displayLabel="Reverse Cubic"/>
+        <ECEnumerator name="Extension" value="10" displayLabel="Extension"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAspect_PointSelectionOnDepending_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="All" value="1" displayLabel="All"/>
+        <ECEnumerator name="Vertices" value="2" displayLabel="Vertices"/>
+        <ECEnumerator name="Ends" value="3" displayLabel="Ends"/>
+        <ECEnumerator name="Centroid" value="4" displayLabel="Centroid"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAspect_ProfileAdjustment_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Minimum" value="2" displayLabel="Minimum"/>
+        <ECEnumerator name="Maximum" value="3" displayLabel="Maximum"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileByProjectingLinEnt3dSlopeRuleAspect_SlopeStyle_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Linear" value="3" displayLabel="Linear"/>
+        <ECEnumerator name="Reverse_Biquadratic" value="7" displayLabel="Reverse Biquadratic"/>
+        <ECEnumerator name="Reverse_Cubic" value="8" displayLabel="Reverse Cubic"/>
+        <ECEnumerator name="Extension" value="10" displayLabel="Extension"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileCurveBetweenElementsRuleAspect_CrestSagSelection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Crest" value="1" displayLabel="Crest"/>
+        <ECEnumerator name="Sag" value="2" displayLabel="Sag"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileCurveBetweenElementsRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileCurveFromElementRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileCurveToElementRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileElemToProfileElemVariableOffsetRuleAspect_PlacementMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Single_Offset" value="0" displayLabel="Single Offset"/>
+        <ECEnumerator name="Variable_Offset" value="1" displayLabel="Variable Offset"/>
+        <ECEnumerator name="Offset_And_Ratio" value="2" displayLabel="Offset And Ratio"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileLineBetweenElementsRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileLineFromElementRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileLineToElementRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileReverseTransitionRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReverseTransitionRuleAspect_Direction_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Forward" value="1" displayLabel="Forward"/>
+        <ECEnumerator name="Backward" value="0" displayLabel="Backward"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReverseTransitionRuleAspect_LoopOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReverseTransitionRuleAspect_TransitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Arc_Tangent_Arc" value="4" displayLabel="Arc Tangent Arc"/>
+        <ECEnumerator name="Asymmetrical_Reverse_Curve" value="7" displayLabel="Asymmetrical Reverse Curve"/>
+        <ECEnumerator name="Symmetrical_Reverse_Curve" value="6" displayLabel="Symmetrical Reverse Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReverseTransitionRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_CornerOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rounded" value="1" displayLabel="Rounded"/>
+        <ECEnumerator name="Square" value="2" displayLabel="Square"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_CutFillOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Cut_And_Fill" value="0" displayLabel="Cut And Fill"/>
+        <ECEnumerator name="Cut_Only" value="1" displayLabel="Cut Only"/>
+        <ECEnumerator name="Fill_Only" value="2" displayLabel="Fill Only"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_EndSlopeUpOrDown_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Up" value="1" displayLabel="Up"/>
+        <ECEnumerator name="Down" value="2" displayLabel="Down"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_Side_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Right" value="1" displayLabel="Right"/>
+        <ECEnumerator name="Left" value="2" displayLabel="Left"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_SlopeOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="To_Terrain_Model" value="1" displayLabel="To Terrain Model"/>
+        <ECEnumerator name="To_Elevation" value="2" displayLabel="To Elevation"/>
+        <ECEnumerator name="For_Horizontal_Distance" value="3" displayLabel="For Horizontal Distance"/>
+        <ECEnumerator name="For_Vertical_Distance" value="4" displayLabel="For Vertical Distance"/>
+        <ECEnumerator name="To_Terrain_Model_Or_Elevation" value="5" displayLabel="To Terrain Model Or Elevation"/>
+        <ECEnumerator name="To_Terrain_Model_Or_Horizontal_Distance" value="6" displayLabel="To Terrain Model Or Horizontal Distance"/>
+        <ECEnumerator name="To_Terrain_Model_Or_Vertical_Distance" value="7" displayLabel="To Terrain Model Or Vertical Distance"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_SlopeTransitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Parabolic" value="2" displayLabel="Parabolic"/>
+        <ECEnumerator name="Reverse_Symmetrical" value="3" displayLabel="Reverse Symmetrical"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RuledSurfaceBySlopeDTMRuleAspect_StartSlopeUpOrDown_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Up" value="1" displayLabel="Up"/>
+        <ECEnumerator name="Down" value="2" displayLabel="Down"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SightVisibilitySectionNamedEntityRuleAspect_CalculationMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Table" value="0" displayLabel="Table"/>
+        <ECEnumerator name="Italian_Stopping_Sight_Distance" value="1" displayLabel="Italian Stopping Sight Distance"/>
+        <ECEnumerator name="AASHTO_Stopping_Sight_Distance" value="2" displayLabel="AASHTO Stopping Sight Distance"/>
+        <ECEnumerator name="Australian_Stopping_Sight_Distance" value="3" displayLabel="Australian Stopping Sight Distance"/>
+        <ECEnumerator name="French_ARP_Stopping_Sight_Distance" value="4" displayLabel="French ARP Stopping Sight Distance"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SlopeMonitorRuleAspect_SlopeMonitorRule_MonitorState_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="MonitorStatePassive" value="1" displayLabel="&lt;- MonitorStatePassive -&gt;"/>
+        <ECEnumerator name="MonitorStateActive" value="2" displayLabel="&lt;- MonitorStateActive -&gt;"/>
+        <ECEnumerator name="MonitorStateInActive" value="3" displayLabel="&lt;- MonitorStateInActive -&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SlopeMonitorRuleAspect_SlopeMonitorRule_MonitorType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="SlopeMonitorTypeMinMaxDistance" value="1" displayLabel="&lt;- SlopeMonitorTypeMinMaxDistance -&gt;"/>
+        <ECEnumerator name="SlopeMonitorTypeMinDistance" value="2" displayLabel="&lt;- SlopeMonitorTypeMinDistance -&gt;"/>
+        <ECEnumerator name="SlopeMonitorTypeMaxDistance" value="3" displayLabel="&lt;- SlopeMonitorTypeMaxDistance -&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SpiralBetweenElementsRuleAspect_AheadTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SpiralBetweenElementsRuleAspect_BackTransitionDefinitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="6" displayLabel="None"/>
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SpiralBetweenElementsRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+        <ECEnumerator name="Ahead" value="3" displayLabel="Ahead"/>
+        <ECEnumerator name="Both" value="4" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SpiralFromElementRuleAspect_BackTransitionDefinitionMethodSpiral_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Length" value="1" displayLabel="Length"/>
+        <ECEnumerator name="A_Value" value="2" displayLabel="A-Value"/>
+        <ECEnumerator name="RL" value="3" displayLabel="RL"/>
+        <ECEnumerator name="Deflection" value="4" displayLabel="Deflection"/>
+        <ECEnumerator name="Offset" value="5" displayLabel="DeltaR"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SpiralFromElementRuleAspect_Hand_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Clockwise" value="1" displayLabel="Clockwise"/>
+        <ECEnumerator name="Counter_Clockwise" value="-1" displayLabel="Counter Clockwise"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SpiralFromElementRuleAspect_TruncateOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="1" displayLabel="None"/>
+        <ECEnumerator name="Back" value="2" displayLabel="Back"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationControlLineNamedEntityRuleAspect_SuperElevationControlLineNamedEntityRule_CopyValues_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationControlLineNamedEntityRuleAspect_SuperElevationControlLineNamedEntityRule_ExcludeNormalCrown_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationControlLineNamedEntityRuleAspect_SuperElevationControlLineNamedEntityRule_MirrorAll_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationNamedEntityRuleAspect_SuperElevationNamedEntityRule_SideOfCenterline_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Left" value="0" displayLabel="Left"/>
+        <ECEnumerator name="Right" value="1" displayLabel="Right"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationNamedEntityRuleAspect_SuperElevationNamedEntityRule_SuperType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Primary" value="0" displayLabel="Primary"/>
+        <ECEnumerator name="Auxiliary" value="1" displayLabel="Auxiliary"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationShoulderNamedEntityRuleAspect_SuperElevationShoulderNamedEntityRule_SetMaxSlope_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationShoulderNamedEntityRuleAspect_SuperElevationShoulderNamedEntityRule_SetMinSlope_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="True"/>
+        <ECEnumerator name="False" value="0" displayLabel="False"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SuperElevationShoulderNamedEntityRuleAspect_SuperElevationShoulderNamedEntityRule_TransitionMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Specified_Length" value="0" displayLabel="Specified Length"/>
+        <ECEnumerator name="Match_Transition_Slope" value="1" displayLabel="Match Transition Slope"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="ArcBetweenElementArcRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ArcBetweenElementArcRuleAttributes_Complex_Transition_between_Any_element_and_Arc_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ArcBetweenElementArcRuleAttributes_Complex_Transition_between_Any_element_and_Arc_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="ArcBetweenElementArcRuleAttributes_Complex_Transition_between_Any_element_and_Arc_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionIntermediateElementLength" typeName="double" displayLabel="Tangent Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperLength" typeName="double" displayLabel="Length" category="BackTaperAttributes_Back_Taper" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperOffset" typeName="double" displayLabel="Offset" category="BackTaperAttributes_Back_Taper" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperRatio" typeName="double" displayLabel="Ratio [Deprecated]" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new BackTaperRatioPercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BackTransitionLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionLink" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299986" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Start" typeName="point3d" displayLabel="Start" category="GeometryAttributes_Geometry" priority="299959" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="End" typeName="point3d" displayLabel="End" category="GeometryAttributes_Geometry" priority="299958" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryAttributes_Geometry" priority="299957" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperDefinitionMethod" typeName="ArcBetweenElementArcRuleBaseAspect_BackTaperDefinitionMethod_Enum" displayLabel="Method" category="BackTaperAttributes_Back_Taper" priority="299994"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="ArcBetweenElementArcRuleBaseAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299990"/>
+        <ECProperty propertyName="TruncateOption" typeName="ArcBetweenElementArcRuleBaseAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ArcBetweenElementArcRuleAttributes_Complex_Transition_between_Any_element_and_Arc_Rule" priority="299950"/>
+        <ECProperty propertyName="BackTaperRatioPercent" typeName="double" displayLabel="Ratio" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementArcRuleAspect">
+        <BaseClass>ArcBetweenElementArcRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionDefinitionMethod" typeName="ArcBetweenElementArcRuleAspect_AheadTransitionDefinitionMethod_Enum" displayLabel="Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299980"/>
+        <ECProperty propertyName="AheadTransitionLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionLink" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299977" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299976" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementArcRuleSpiralAspect">
+        <BaseClass>ArcBetweenElementArcRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionAheadSpiralLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299972" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralLink" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299971" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299969" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299968" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralDefinitionMethod" typeName="ArcBetweenElementArcRuleSpiralAspect_AheadTransitionAheadSpiralDefinitionMethod_Enum" displayLabel="Back Spiral Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299973"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ArcBetweenElementsRuleAttributes_Arc_Between_Arcs_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ArcBetweenElementsRuleAttributes_Arc_Between_Arcs_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="ArcBetweenElementsRuleAttributes_Arc_Between_Arcs_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcLength" typeName="double" displayLabel="Arc Length" category="GeometryAttributes_Geometry" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Start" typeName="point3d" displayLabel="Start" category="GeometryAttributes_Geometry" priority="299959" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="End" typeName="point3d" displayLabel="End" category="GeometryAttributes_Geometry" priority="299958" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryAttributes_Geometry" priority="299957" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CurveTypeAtEnd" typeName="ArcBetweenElementsRuleAspect_CurveTypeAtEnd_Enum" displayLabel="Curve Type At End" category="ArcBetweenElementsRuleAttributes_Arc_Between_Arcs_Rule" priority="299998"/>
+        <ECProperty propertyName="TruncateOption" typeName="ArcBetweenElementsRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ArcBetweenElementsRuleAttributes_Arc_Between_Arcs_Rule" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleAheadTransitionBaseAspect" modifier="Abstract">
+        <BaseClass>ArcBetweenElementsRuleBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleAheadTransitionAspect">
+        <BaseClass>ArcBetweenElementsRuleAheadTransitionBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionLink" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299977" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299976" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionIntermediateElementLength" typeName="double" displayLabel="Tangent Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDefinitionMethod" typeName="ArcBetweenElementsRuleAheadTransitionAspect_AheadTransitionDefinitionMethod_Enum" displayLabel="Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299980"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleAheadTransitionSpiralAspect">
+        <BaseClass>ArcBetweenElementsRuleAheadTransitionBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionAheadSpiralLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299972" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralLink" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299971" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299969" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299968" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionAheadSpiralDefinitionMethod" typeName="ArcBetweenElementsRuleAheadTransitionSpiralAspect_AheadTransitionAheadSpiralDefinitionMethod_Enum" displayLabel="Ahead Spiral Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299973"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleBackTransitionBaseAspect" modifier="Abstract">
+        <BaseClass>ArcBetweenElementsRuleBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleBackTransitionAheadSpiralAspect">
+        <BaseClass>ArcBetweenElementsRuleBackTransitionBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionAheadSpiralLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralLink" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299982" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDefinitionMethod" typeName="ArcBetweenElementsRuleBackTransitionAheadSpiralAspect_BackTransitionAheadSpiralDefinitionMethod_Enum" displayLabel="Ahead Spiral Method" category="BackTransitionAttributes_Back_Transition" priority="299986"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcBetweenElementsRuleBackTransitionAspect">
+        <BaseClass>ArcBetweenElementsRuleBackTransitionBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionLink" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299989" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionIntermediateElementLength" typeName="double" displayLabel="Tangent Length" category="BackTransitionAttributes_Back_Transition" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="ArcBetweenElementsRuleBackTransitionAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299993"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcFromElementRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcSweepAngle" typeName="double" displayLabel="Arc Sweep Angle" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299961" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ArcLength" typeName="double" displayLabel="Arc Length" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299953" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299954" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDirection" typeName="double" displayLabel="End Direction" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299955" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="BackTaperLength" typeName="double" displayLabel="Length" category="BackTaperAttributes_Back_Taper" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperOffset" typeName="double" displayLabel="Offset" category="BackTaperAttributes_Back_Taper" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperRatio" typeName="double" displayLabel="Ratio [Deprecated]" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new BackTaperRatioPercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BackTransitionRadiusRatio" typeName="double" displayLabel="Back Radius Ratio" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralLength" typeName="double" displayLabel="Ahead Spiral Length" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralParameter" typeName="double" displayLabel="Ahead Spiral A" category="BackTransitionAttributes_Back_Transition" priority="299973" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralRL" typeName="double" displayLabel="Ahead Spiral RL" category="BackTransitionAttributes_Back_Transition" priority="299972" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDeflection" typeName="double" displayLabel="Ahead Spiral Deflection" category="BackTransitionAttributes_Back_Transition" priority="299971" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDeltaR" typeName="double" displayLabel="Ahead Spiral DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionIntermediateElementLength" typeName="double" displayLabel="Tangent Length" category="BackTransitionAttributes_Back_Transition" priority="299969" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRadius" typeName="double" displayLabel="Radius" category="BackTransitionAttributes_Back_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalLength" typeName="double" displayLabel="Total Length" category="GeometryAttributes_Geometry" priority="299962" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcTangent" typeName="double" displayLabel="Arc Tangent" category="GeometryAttributes_Geometry" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalTangent" typeName="double" displayLabel="Total Tangent" category="GeometryAttributes_Geometry" priority="299959" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcDeflection" typeName="double" displayLabel="Arc Deflection" category="GeometryAttributes_Geometry" priority="299958" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="TotalDeflection" typeName="double" displayLabel="Total Deflection" category="GeometryAttributes_Geometry" priority="299957" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299956" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="Hand" typeName="ArcFromElementRuleBaseAspect_Hand_Enum" displayLabel="Hand" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299952"/>
+        <ECProperty propertyName="BackTaperDefinitionMethod" typeName="ArcFromElementRuleBaseAspect_BackTaperDefinitionMethod_Enum" displayLabel="Method" category="BackTaperAttributes_Back_Taper" priority="299994"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="ArcFromElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Type" category="BackTransitionAttributes_Back_Transition" priority="299986"/>
+        <ECProperty propertyName="TruncateOption" typeName="ArcFromElementRuleBaseAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ArcFromElementRuleAttributes_Arc_From_Element_Rule" priority="299950"/>
+        <ECProperty propertyName="BackTaperRatioPercent" typeName="double" displayLabel="Ratio" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcFromElementRuleArcRatioAspect">
+        <BaseClass>ArcFromElementRuleBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcFromElementRuleAspect">
+        <BaseClass>ArcFromElementRuleBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcFromElementRuleCurveAspect">
+        <BaseClass>ArcFromElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionCurveLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299977" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299976" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionCurveDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodArc" typeName="ArcFromElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299984"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcFromElementRuleSpiralAspect">
+        <BaseClass>ArcFromElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionSpiralLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299980" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodSpiral" typeName="ArcFromElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299985"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcToElementRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ArcToElementRuleAttributes_Arc_To_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299954" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ArcToElementRuleAttributes_Arc_To_Element_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDirection" typeName="double" displayLabel="End Direction" category="ArcToElementRuleAttributes_Arc_To_Element_Rule" priority="299955" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="BackTaperLength" typeName="double" displayLabel="Length" category="BackTaperAttributes_Back_Taper" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperOffset" typeName="double" displayLabel="Offset" category="BackTaperAttributes_Back_Taper" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperRatio" typeName="double" displayLabel="Ratio [Deprecated]" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new BackTaperRatioPercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BackTransitionRadiusRatio" typeName="double" displayLabel="Back Radius Ratio" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralLength" typeName="double" displayLabel="Ahead Spiral Length" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralParameter" typeName="double" displayLabel="Ahead Spiral A" category="BackTransitionAttributes_Back_Transition" priority="299973" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralRL" typeName="double" displayLabel="Ahead Spiral RL" category="BackTransitionAttributes_Back_Transition" priority="299972" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDeflection" typeName="double" displayLabel="Ahead Spiral Deflection" category="BackTransitionAttributes_Back_Transition" priority="299971" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionAheadSpiralDeltaR" typeName="double" displayLabel="Ahead Spiral DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRadius" typeName="double" displayLabel="Radius" category="BackTransitionAttributes_Back_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalLength" typeName="double" displayLabel="Total Length" category="GeometryAttributes_Geometry" priority="299962" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcSweepAngle" typeName="double" displayLabel="Arc Sweep Angle" category="GeometryAttributes_Geometry" priority="299961" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ArcTangent" typeName="double" displayLabel="Arc Tangent" category="GeometryAttributes_Geometry" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalTangent" typeName="double" displayLabel="Total Tangent" category="GeometryAttributes_Geometry" priority="299959" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcDeflection" typeName="double" displayLabel="Arc Deflection" category="GeometryAttributes_Geometry" priority="299958" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="TotalDeflection" typeName="double" displayLabel="Total Deflection" category="GeometryAttributes_Geometry" priority="299957" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299956" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="Hand" typeName="ArcToElementRuleBaseAspect_Hand_Enum" displayLabel="Hand" category="ArcToElementRuleAttributes_Arc_To_Element_Rule" priority="299952"/>
+        <ECProperty propertyName="BackTaperDefinitionMethod" typeName="ArcToElementRuleBaseAspect_BackTaperDefinitionMethod_Enum" displayLabel="Method" category="BackTaperAttributes_Back_Taper" priority="299994"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="ArcToElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Type" category="BackTransitionAttributes_Back_Transition" priority="299986"/>
+        <ECProperty propertyName="TruncateOption" typeName="ArcToElementRuleBaseAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ArcToElementRuleAttributes_Arc_To_Element_Rule" priority="299950"/>
+        <ECProperty propertyName="BackTaperRatioPercent" typeName="double" displayLabel="Ratio" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcToElementRuleArcRatioAspect">
+        <BaseClass>ArcToElementRuleBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcToElementRuleAspect">
+        <BaseClass>ArcToElementRuleBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcToElementRuleCurveAspect">
+        <BaseClass>ArcToElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionCurveLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299977" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299976" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionCurveDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionIntermediateElementLength" typeName="double" displayLabel="Tangent Length" category="BackTransitionAttributes_Back_Transition" priority="299969" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodArc" typeName="ArcToElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299984"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ArcToElementRuleSpiralAspect">
+        <BaseClass>ArcToElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionSpiralLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299980" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodSpiral" typeName="ArcToElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299985"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BestFitHorizontalRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BestFitEnvelope" typeName="double" displayLabel="Envelope" category="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitRadiusRounding" typeName="double" displayLabel="Radius Rounding" category="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitIncludeSpirals" typeName="BestFitHorizontalRuleAspect_BestFitIncludeSpirals_BoolEnum" displayLabel="Include Spirals" category="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" priority="299987"/>
+        <ECProperty propertyName="BestFitForceSymmetricalSpirals" typeName="BestFitHorizontalRuleAspect_BestFitForceSymmetricalSpirals_BoolEnum" displayLabel="Force Symmetrical Spirals" category="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" priority="299986"/>
+        <ECProperty propertyName="BestFitSpiralLengthRounding" typeName="double" displayLabel="Spiral Length Rounding" category="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitFlatteningRadius" typeName="double" displayLabel="Default Radius" category="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BestFitProfileRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BestFitTolerance" typeName="double" displayLabel="Upper Envelope" category="BestFitProfileRuleParamAttributes_Best_Fit_Parameters" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitStandardLift" typeName="double" displayLabel="Lower Envelope" category="BestFitProfileRuleParamAttributes_Best_Fit_Parameters" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitDesirableCrest" typeName="double" displayLabel="Desirable Crest Curve Length" category="BestFitProfileRuleParamAttributes_Best_Fit_Parameters" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitDesirableSag" typeName="double" displayLabel="Desirable Sag Curve Length" category="BestFitProfileRuleParamAttributes_Best_Fit_Parameters" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BestFitMinimumLength" typeName="double" displayLabel="Minimum Curve Length" category="BestFitProfileRuleParamAttributes_Best_Fit_Parameters" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ChamferBetweenElementsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackRadius" typeName="double" displayLabel="Back Radius" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadRadius" typeName="double" displayLabel="Ahead Radius" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ChamferApproachLength" typeName="double" displayLabel="Approach Length" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ChamferExitLength" typeName="double" displayLabel="Exit Length" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ChamferLinearLength" typeName="double" displayLabel="Chamfer Length" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ChamferPerpendicularLength" typeName="double" displayLabel="Perpendicular Length" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ChamferLinearAngle" typeName="double" displayLabel="Chamfer Angle" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299995" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ChamferBetweenElementsRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" priority="299988"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CircularArcRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Method" typeName="string" displayLabel="Method" category="ArcRuleAttributes_Arc_Rule" priority="299999"/>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ArcRuleAttributes_Arc_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcLength" typeName="double" displayLabel="Arc Length" category="ArcRuleAttributes_Arc_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweepAngle" typeName="double" displayLabel="Arc Sweep Angle" category="ArcRuleAttributes_Arc_Rule" priority="299996" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartDirection" typeName="double" displayLabel="Start Direction" category="ArcRuleAttributes_Arc_Rule" priority="299992" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="EndDirection" typeName="double" displayLabel="End Direction" category="ArcRuleAttributes_Arc_Rule" priority="299991" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="Vector" typeName="double" displayLabel="Perpendicular Vector" category="ArcRuleAttributes_Arc_Rule" priority="299990" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="TangentLength" typeName="double" displayLabel="Tangent Length" category="GeometryAttributes_Geometry" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Deflection" typeName="double" displayLabel="Deflection" category="GeometryAttributes_Geometry" priority="299988" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CenterPoint" typeName="point3d" displayLabel="Center" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Side" typeName="CircularArcRuleAspect_Side_Enum" displayLabel="Side" category="ArcRuleAttributes_Arc_Rule" priority="299995"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ComplexDTMEntityByDTMEntitiesRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Dummy" typeName="string" displayLabel="Edit Complex DTM" category="ComplexDTMEntityDefinitionAttributes_Complex_Terrain_Model_Definition" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConicSlopeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="ConicSlope_ConicSlope" priority="299999"/>
+        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" category="ConicSlope_ConicSlope" priority="299984"/>
+        <ECProperty propertyName="ElevationType" typeName="string" displayLabel="Elevation Type" category="ConicSlope_ConicSlope" priority="299991"/>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="ConicSlope_ConicSlope" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ConicSlope_TopRadiusPrimary" typeName="double" displayLabel="Primary Top Radius" category="ConicSlope_ConicSlope" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseSlopeRate" typeName="double" displayLabel="Primary Slope" category="ConicSlope_ConicSlope" priority="299995" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SideSlopeRate" typeName="double" displayLabel="Secondary Slope" category="ConicSlope_ConicSlope" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="FixedElevation" typeName="double" displayLabel="Fixed Elevation" category="ConicSlope_ConicSlope" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="OrigOffset" typeName="double" displayLabel="Origin Offset" category="ConicSlope_ConicSlope" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StarOffset" typeName="double" displayLabel="Start Offset" category="ConicSlope_ConicSlope" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AngleInterval" typeName="double" displayLabel="Angle Interval" category="ConicSlope_ConicSlope" priority="299996" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Angle" typeName="double" displayLabel="Angle" category="ConicSlope_ConicSlope" priority="299997" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CulvertRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="Culvert_CulvertRule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction" typeName="double" displayLabel="Direction" category="Culvert_CulvertRule" priority="299998" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="Culvert_CulvertRule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DesignStandardToLinElemRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VerticalDesignStandard" typeName="string" displayLabel="Vertical Design Standard" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299998"/>
+        <ECProperty propertyName="ParameterSpeed" typeName="double" displayLabel="Speed" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299997"/>
+        <ECProperty propertyName="ParameterDefaultRadius" typeName="double" displayLabel="Default Radius" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299996"/>
+        <ECProperty propertyName="ParameterMinRadius" typeName="double" displayLabel="Minimum Radius" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299995"/>
+        <ECProperty propertyName="ParameterCentripetalAcceleration" typeName="double" displayLabel="Centripetal Acceleration" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299994"/>
+        <ECProperty propertyName="ParameterInsureTangency" typeName="boolean" displayLabel="Check Tangency" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299993"/>
+        <ECProperty propertyName="ParameterIncludeTransitions" typeName="boolean" displayLabel="Include Transitions" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299992"/>
+        <ECProperty propertyName="ParameterMaxArcLength" typeName="double" displayLabel="Maximum Arc Length" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParameterMinArcLength" typeName="double" displayLabel="Minimum Arc Length" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParameterMaxTangentLength" typeName="double" displayLabel="Maximum Tangent Length" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParameterMinTangentLength" typeName="double" displayLabel="Minimum Tangent Length" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParameterMaxTangentToTangentDeflection" typeName="double" displayLabel="Maximum Deflection" category="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" priority="299984" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DistanceMonitorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinDistance" typeName="double" displayLabel="&lt;- DistanceMonitor_MinDistance -&gt;" category="DistanceMonitorDefinition_General_Category" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxDistance" typeName="double" displayLabel="&lt;- DistanceMonitor_MaxDistance -&gt;" category="DistanceMonitorDefinition_General_Category" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Message" typeName="string" displayLabel="&lt;- Monitor_Message -&gt;" category="DistanceMonitorDefinition_General_Category" priority="299500"/>
+        <ECProperty propertyName="DistanceMonitorRule_MonitorType" typeName="DistanceMonitorRuleAspect_DistanceMonitorRule_MonitorType_Enum" displayLabel="&lt;- MonitorType -&gt;" category="DistanceMonitorDefinition_General_Category" priority="299900"/>
+        <ECProperty propertyName="DistanceMonitorRule_MonitorState" typeName="DistanceMonitorRuleAspect_DistanceMonitorRule_MonitorState_Enum" displayLabel="&lt;- MonitorState -&gt;" category="DistanceMonitorDefinition_General_Category" priority="299600"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityByClippedDTMEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="DTMEntityByClippedDTMEntityRuleAttributes_Clipping" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="DTMEntityByClippedDTMEntityRuleAttributes_Clipping" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityByDeltaDTMEntitesRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Offset1" typeName="double" displayLabel="Offset 1" category="DTMEntityByDTMEntityRuleAttributes_Delta_Terrain_Model" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Offset2" typeName="double" displayLabel="Offset 2" category="DTMEntityByDTMEntityRuleAttributes_Delta_Terrain_Model" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityByDeltaPlaneEntitesRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Plane" typeName="double" displayLabel="Plane" category="DTMEntityByDTMEntityRuleAttributes_Delta_Plane" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityByDTMEntitesVolumeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Cut" typeName="double" displayLabel="&lt;- Cut -&gt;" category="DTMEntityVolumeByDTMEntitiesRuleAttributes_DTMEntityByDTMEntitiesVolumeDefinition" priority="299900" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Fill" typeName="double" displayLabel="&lt;- Fill -&gt;" category="DTMEntityVolumeByDTMEntitiesRuleAttributes_DTMEntityByDTMEntitiesVolumeDefinition" priority="299800" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Balance" typeName="double" displayLabel="&lt;- Balance -&gt;" category="DTMEntityVolumeByDTMEntitiesRuleAttributes_DTMEntityByDTMEntitiesVolumeDefinition" priority="299700" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityToDTMEntityAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MaxCutHeight" typeName="double" displayLabel="&lt;- DTMElemetToDTMElement_MaxCutHeight -&gt;" category="DTMEntityToDTMEntityAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxFillHeight" typeName="double" displayLabel="&lt;- DTMElemetToDTMElement_MaxFillHeight -&gt;" category="DTMEntityToDTMEntityAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CutVolume" typeName="double" displayLabel="&lt;- DTMElemetToDTMElement_CutVolume -&gt;" category="DTMEntityToDTMEntityAssociatorRuleAttributes_AssociationCategory" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="FillVolume" typeName="double" displayLabel="&lt;- DTMElemetToDTMElement_FillVolume -&gt;" category="DTMEntityToDTMEntityAssociatorRuleAttributes_AssociationCategory" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMEntityVolumeByPlaneRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Plane" typeName="double" displayLabel="Plane" category="DTMEntityVolumeByPlaneRuleAttributes_DTMEntityVolumeByPlaneRuleDefinition" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Cut" typeName="double" displayLabel="&lt;- Cut -&gt;" category="DTMEntityVolumeByPlaneRuleAttributes_DTMEntityVolumeByPlaneRuleDefinition" priority="299800" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Fill" typeName="double" displayLabel="&lt;- Fill -&gt;" category="DTMEntityVolumeByPlaneRuleAttributes_DTMEntityVolumeByPlaneRuleDefinition" priority="299700" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Volume" typeName="double" displayLabel="&lt;- Balance -&gt;" category="DTMEntityVolumeByPlaneRuleAttributes_DTMEntityVolumeByPlaneRuleDefinition" priority="299600" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMMeshByDTMEntityTemplateRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TemplateName" typeName="string" displayLabel="Template Name" category="DTMMeshByDTMEntityTemplateRuleAttributes_Mesh_Template" priority="300000"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMPondAnalysisRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PondVolume" typeName="double" displayLabel="Pond Volume" category="PondAnalysisAttributes_Pond_Analysis" priority="299900" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PondArea" typeName="double" displayLabel="Pond Area" category="PondAnalysisAttributes_Pond_Analysis" priority="299800" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="PondDepth" typeName="double" displayLabel="Pond Depth" category="PondAnalysisAttributes_Pond_Analysis" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PondElevation" typeName="double" displayLabel="Pond Elevation" category="PondAnalysisAttributes_Pond_Analysis" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMPondRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SideSlope" typeName="double" displayLabel="Side Slope" category="DTMPondRuleAttributes_Pond_Definition" priority="299990" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="FreeBoard" typeName="double" displayLabel="Freeboard" category="DTMPondRuleAttributes_Pond_Definition" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TargetVolume" typeName="double" displayLabel="Target Volume" category="DTMPondRuleAttributes_Pond_Definition" priority="299960" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="TargetElevation" typeName="double" displayLabel="Target Elevation" category="DTMPondRuleAttributes_Pond_Definition" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PondTarget" typeName="DTMPondRuleAspect_PondTarget_Enum" displayLabel="Pond Target" category="DTMPondRuleAttributes_Pond_Definition" priority="299970"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DTMSlopeTraceRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299800" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MinimumDepth" typeName="double" displayLabel="Minimum Depth" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Elevation1" typeName="double" displayLabel="Elevation 1" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299500" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Elevation2" typeName="double" displayLabel="Elevation 2" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299400" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LevelDifference" typeName="double" displayLabel="Elevation Difference" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299300" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TraceSlopeDirection" typeName="DTMSlopeTraceRuleAspect_TraceSlopeDirection_Enum" displayLabel="Direction" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsArcBetweenElementArcRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcBetweenElementArcRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcBetweenElementArcRuleSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcBetweenElementArcRuleSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcBetweenElementsRuleAheadTransitionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcBetweenElementsRuleAheadTransitionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcBetweenElementsRuleAheadTransitionSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcBetweenElementsRuleAheadTransitionSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcBetweenElementsRuleBackTransitionAheadSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcBetweenElementsRuleBackTransitionAheadSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcBetweenElementsRuleBackTransitionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcBetweenElementsRuleBackTransitionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcFromElementRuleArcRatioAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcFromElementRuleArcRatioAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcFromElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcFromElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcFromElementRuleCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcFromElementRuleCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcFromElementRuleSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcFromElementRuleSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcToElementRuleArcRatioAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcToElementRuleArcRatioAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcToElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcToElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcToElementRuleCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcToElementRuleCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsArcToElementRuleSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ArcToElementRuleSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBestFitHorizontalRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BestFitHorizontalRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBestFitProfileRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BestFitProfileRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsChamferBetweenElementsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ChamferBetweenElementsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCircularArcRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CircularArcRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsComplexDTMEntityByDTMEntitiesRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ComplexDTMEntityByDTMEntitiesRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConicSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConicSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCulvertRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CulvertRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDesignStandardToLinElemRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DesignStandardToLinElemRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDistanceMonitorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DistanceMonitorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityByClippedDTMEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityByClippedDTMEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityByDeltaDTMEntitesRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityByDeltaDTMEntitesRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityByDeltaPlaneEntitesRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityByDeltaPlaneEntitesRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityByDTMEntitesVolumeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityByDTMEntitesVolumeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityToDTMEntityAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityToDTMEntityAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMEntityVolumeByPlaneRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMEntityVolumeByPlaneRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMMeshByDTMEntityTemplateRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMMeshByDTMEntityTemplateRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMPondAnalysisRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMPondAnalysisRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMPondRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMPondRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDTMSlopeTraceRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DTMSlopeTraceRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="EqualSpacePointAlongElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_NoOfPoints" typeName="int" displayLabel="Number Of Points" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299998"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_Interval" typeName="double" displayLabel="Interval" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_Offset" typeName="double" displayLabel="Offset" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_Rotation" typeName="double" displayLabel="Rotation" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299993" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_StartDistance" typeName="double" displayLabel="Start Distance" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EqualSpacePointAlongElementRule_StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_EndDistance" typeName="double" displayLabel="End Distance" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_EndDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EqualSpacePointAlongElementRule_EndDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_CardinalPoint" typeName="boolean" displayLabel="End Points" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299990"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_ElevationMode" typeName="EqualSpacePointAlongElementRuleAspect_EqualSpacePointAlongElementRule_ElevationMode_Enum" displayLabel="Elevation Mode" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299995"/>
+        <ECProperty propertyName="EqualSpacePointAlongElementRule_RotationMode" typeName="EqualSpacePointAlongElementRuleAspect_EqualSpacePointAlongElementRule_RotationMode_Enum" displayLabel="Rotation Mode" category="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" priority="299994"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsEqualSpacePointAlongElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="EqualSpacePointAlongElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="EqualSpacePointRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="EqualSpacePointRule_StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EqualSpacePointRule_EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EqualSpacePointRule_NoOfPoints" typeName="int" displayLabel="Number Of Points" category="EqualSpacePointRuleAttributes_Equal_Space_Point_Rule" priority="299998"/>
+        <ECProperty propertyName="EqualSpacePointRule_Rotation" typeName="double" displayLabel="Rotation" category="EqualSpacePointRuleAttributes_Equal_Space_Point_Rule" priority="299995" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="EqualSpacePointRule_ElevationMode" typeName="EqualSpacePointRuleAspect_EqualSpacePointRule_ElevationMode_Enum" displayLabel="Elevation Mode" category="EqualSpacePointRuleAttributes_Equal_Space_Point_Rule" priority="299997"/>
+        <ECProperty propertyName="EqualSpacePointRule_RotationMode" typeName="EqualSpacePointRuleAspect_EqualSpacePointRule_RotationMode_Enum" displayLabel="Rotation Mode" category="EqualSpacePointRuleAttributes_Equal_Space_Point_Rule" priority="299996"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsEqualSpacePointRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="EqualSpacePointRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="FilletRuleAttributes_Fillet_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="FilletRuleAttributes_Fillet_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="FilletRuleAttributes_Fillet_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalLength" typeName="double" displayLabel="Total Length" category="GeometryAttributes_Geometry" priority="299958" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcSweepAngle" typeName="double" displayLabel="Arc Sweep Angle" category="GeometryAttributes_Geometry" priority="299957" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="ArcTangent" typeName="double" displayLabel="Arc Tangent" category="GeometryAttributes_Geometry" priority="299956" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalTangent" typeName="double" displayLabel="Total Tangent" category="GeometryAttributes_Geometry" priority="299955" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ArcDeflection" typeName="double" displayLabel="Arc Deflection" category="GeometryAttributes_Geometry" priority="299954" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="TotalDeflection" typeName="double" displayLabel="Total Deflection" category="GeometryAttributes_Geometry" priority="299953" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartDirection" typeName="double" displayLabel="Start Direction" category="GeometryAttributes_Geometry" priority="299952" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="EndDirection" typeName="double" displayLabel="End Direction" category="GeometryAttributes_Geometry" priority="299951" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="TruncateOption" typeName="FilletRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="FilletRuleAttributes_Fillet_Rule" priority="299950"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="FilletRuleAheadBaseAspect" modifier="Abstract">
+        <BaseClass>FilletRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionDefinitionMethod" typeName="FilletRuleAheadBaseAspect_AheadTransitionDefinitionMethod_Enum" displayLabel="Type" category="AheadTransitionAttributes_Ahead_Transition" priority="299972"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="FilletRuleAheadTaperAspect">
+        <BaseClass>FilletRuleAheadBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTaperEndOffsetRelativeToBaseElement" typeName="boolean" displayLabel="End Offset along base element" category="AheadTaperAttributes_Ahead_Taper" priority="299985"/>
+        <ECProperty propertyName="AheadTaperLength" typeName="double" displayLabel="Length" category="AheadTaperAttributes_Ahead_Taper" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTaperOffset" typeName="double" displayLabel="Offset" category="AheadTaperAttributes_Ahead_Taper" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTaperRatio" typeName="double" displayLabel="Ratio [Deprecated]" category="AheadTaperAttributes_Ahead_Taper" priority="299986" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new AheadTaperRatioPercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="AheadTaperDefinitionMethod" typeName="FilletRuleAheadTaperAspect_AheadTaperDefinitionMethod_Enum" displayLabel="Method" category="AheadTaperAttributes_Ahead_Taper" priority="299989"/>
+        <ECProperty propertyName="AheadTaperRatioPercent" typeName="double" displayLabel="Ratio" category="AheadTaperAttributes_Ahead_Taper" priority="299986" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleAheadTaperAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleAheadTaperAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleAheadTransitionArcRatioAspect">
+        <BaseClass>FilletRuleAheadBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleAheadTransitionArcRatioAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleAheadTransitionArcRatioAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleAheadTransitionCurveAspect">
+        <BaseClass>FilletRuleAheadBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionRadius" typeName="double" displayLabel="Radius" category="AheadTransitionAttributes_Ahead_Transition" priority="299963" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionRadiusRatio" typeName="double" displayLabel="Ahead Radius Ratio" category="AheadTransitionAttributes_Ahead_Transition" priority="299959" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionCurveLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299962" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionCurveDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299961" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionCurveDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDefinitionMethodArc" typeName="FilletRuleAheadTransitionCurveAspect_AheadTransitionDefinitionMethodArc_Enum" displayLabel="Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299969"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleAheadTransitionCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleAheadTransitionCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleAheadTransitionSpiralAspect">
+        <BaseClass>FilletRuleAheadBaseAspect</BaseClass>
+        <ECProperty propertyName="AheadTransitionSpiralLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299968" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299967" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionSpiralRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299966" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299965" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299964" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDefinitionMethodSpiral" typeName="FilletRuleAheadTransitionSpiralAspect_AheadTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299970"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleAheadTransitionSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleAheadTransitionSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleBackBaseAspect" modifier="Abstract">
+        <BaseClass>FilletRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="FilletRuleBackBaseAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Type" category="BackTransitionAttributes_Back_Transition" priority="299984"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="FilletRuleBackTaperAspect">
+        <BaseClass>FilletRuleBackBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTaperEndOffsetRelativeToBaseElement" typeName="boolean" displayLabel="End Offset along base element" category="BackTaperAttributes_Back_Taper" priority="299990"/>
+        <ECProperty propertyName="BackTaperLength" typeName="double" displayLabel="Length" category="BackTaperAttributes_Back_Taper" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperOffset" typeName="double" displayLabel="Offset" category="BackTaperAttributes_Back_Taper" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTaperRatio" typeName="double" displayLabel="Ratio [Deprecated]" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new BackTaperRatioPercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="BackTaperDefinitionMethod" typeName="FilletRuleBackTaperAspect_BackTaperDefinitionMethod_Enum" displayLabel="Method" category="BackTaperAttributes_Back_Taper" priority="299994"/>
+        <ECProperty propertyName="BackTaperRatioPercent" typeName="double" displayLabel="Ratio" category="BackTaperAttributes_Back_Taper" priority="299991" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleBackTaperAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleBackTaperAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleBackTransitionArcRatioAspect">
+        <BaseClass>FilletRuleBackBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleBackTransitionArcRatioAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleBackTransitionArcRatioAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleBackTransitionCurveAspect">
+        <BaseClass>FilletRuleBackBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionRadiusRatio" typeName="double" displayLabel="Back Radius Ratio" category="BackTransitionAttributes_Back_Transition" priority="299973" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRadius" typeName="double" displayLabel="Radius" category="BackTransitionAttributes_Back_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionCurveDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299974" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodArc" typeName="FilletRuleBackTransitionCurveAspect_BackTransitionDefinitionMethodArc_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299981"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleBackTransitionCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleBackTransitionCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FilletRuleBackTransitionSpiralAspect">
+        <BaseClass>FilletRuleBackBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionSpiralLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299977" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299976" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodSpiral" typeName="FilletRuleBackTransitionSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299982"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFilletRuleBackTransitionSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FilletRuleBackTransitionSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowModelFromDTMAnalysisRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RainfallIntensity" typeName="double" displayLabel="Rainfall Intensity" category="AquaplaningAttributes_Aquaplaning_Model" priority="300000"/>
+        <ECProperty propertyName="TextureDepth" typeName="double" displayLabel="Texture Depth" category="AquaplaningAttributes_Aquaplaning_Model" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="UseEASlope" typeName="boolean" displayLabel="Use Equal Area Slope" category="AquaplaningAttributes_Aquaplaning_Model" priority="299700"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowModelFromDTMAnalysisRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowModelFromDTMAnalysisRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IntervalDefinitionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIntervalDefinitionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IntervalDefinitionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineBetweenElementsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="lineBetweenElementsRuleAttributes_Line_Between_Elements_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="lineBetweenElementsRuleAttributes_Line_Between_Elements_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="LineBetweenElementsRuleAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299993"/>
+        <ECProperty propertyName="BackTransitionLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionLink" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299989" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDefinitionMethod" typeName="LineBetweenElementsRuleAspect_AheadTransitionDefinitionMethod_Enum" displayLabel="Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299987"/>
+        <ECProperty propertyName="AheadTransitionLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionLink" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299983" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LineDirection" typeName="double" displayLabel="Line Direction" category="GeometryAttributes_Geometry" priority="299975" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="LineLength" typeName="double" displayLabel="Line Length" category="GeometryAttributes_Geometry" priority="299976" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="LineBetweenElementsRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="lineBetweenElementsRuleAttributes_Line_Between_Elements_Rule" priority="299977"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineBetweenElementsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineBetweenElementsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineFromElementRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299954" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Offset" category="LineFromElementRuleAttributes_Line_From_Element_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Skew" typeName="double" displayLabel="Skew" category="LineFromElementRuleAttributes_Line_From_Element_Rule" priority="299994" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="LineFromElementRuleAttributes_Line_From_Element_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="LineFromElementRuleAttributes_Line_From_Element_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="LineFromElementRuleBaseAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="LineFromElementRuleAttributes_Line_From_Element_Rule" priority="299952"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="LineFromElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Type" category="BackTransitionAttributes_Back_Transition" priority="299986"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="LineFromElementRuleCurveAspect">
+        <BaseClass>LineFromElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionRadius" typeName="double" displayLabel="Radius" category="BackTransitionAttributes_Back_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299977" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299976" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionCurveDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodArc" typeName="LineFromElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299984"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineFromElementRuleCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineFromElementRuleCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineFromElementRuleSpiralAspect">
+        <BaseClass>LineFromElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionSpiralLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299980" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodSpiral" typeName="LineFromElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299985"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineFromElementRuleSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineFromElementRuleSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinElemToLinElemStartEndDistanceRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Station" category="LinElemToLinElemStartEndDistanceRuleAttributes_Station_Range" priority="199998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="Start Distance Value" category="LinElemToLinElemStartEndDistanceRuleAttributes_Station_Range" priority="199998" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Station" category="LinElemToLinElemStartEndDistanceRuleAttributes_Station_Range" priority="199996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="End Distance Value" category="LinElemToLinElemStartEndDistanceRuleAttributes_Station_Range" priority="199996" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinElemToLinElemStartEndDistanceRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinElemToLinElemStartEndDistanceRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinElemToLinElemVariableOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SingleOffsetValue" typeName="double" displayLabel="Offset" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartOffsetValue" typeName="double" displayLabel="Start Offset" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartOffsetValueManip" typeName="double" displayLabel="StartOffsetValueManip" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299997" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Distance" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="StartDistanceValueManip" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299998" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndOffsetValue" typeName="double" displayLabel="End Offset" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndOffsetValueManip" typeName="double" displayLabel="EndOffsetValueManip" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299994" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="RatioValue" typeName="double" displayLabel="Ratio [Deprecated]" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299993" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new RatioValuePercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Spiralized" typeName="LinElemToLinElemVariableOffsetRuleAspect_Spiralized_BoolEnum" displayLabel="Spiralized" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299987"/>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Distance" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndLengthValue" typeName="double" displayLabel="Length" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="EndDistanceValueManip" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299996" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="LengthValue" typeName="double" displayLabel="Length" category="GeometryAttributes_Geometry" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LengthAlongValue" typeName="double" displayLabel="Length Along" category="GeometryAttributes_Geometry" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDeltaDistanceValueManip" typeName="double" displayLabel="StartDeltaDistanceValueManip" category="Miscellaneous_Transition_Offset_Rule" priority="0" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDeltaDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDeltaDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDeltaDistanceValueManip" typeName="double" displayLabel="EndDeltaDistanceValueManip" category="Miscellaneous_Transition_Offset_Rule" priority="0" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDeltaDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDeltaDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="PlacementMethod" typeName="LinElemToLinElemVariableOffsetRuleAspect_PlacementMethod_Enum" displayLabel="Method" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="300000"/>
+        <ECProperty propertyName="GeometryType" typeName="LinElemToLinElemVariableOffsetRuleAspect_GeometryType_Enum" displayLabel="Type" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299986"/>
+        <ECProperty propertyName="RatioValuePercent" typeName="double" displayLabel="Ratio" category="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" priority="299993" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinElemToLinElemVariableOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinElemToLinElemVariableOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByDTMEntityPondRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Volume" typeName="double" displayLabel="Volume" category="PondRuleAttributes_Pond_Rule" priority="299900" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="Depth" typeName="double" displayLabel="Depth" category="PondRuleAttributes_Pond_Rule" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Elevation" typeName="double" displayLabel="Elevation" category="PondRuleAttributes_Pond_Rule" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByDTMEntityPondRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByDTMEntityPondRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByDTMEntityTraceRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LinEnt3dByDTMEntityTraceRuleDistance" typeName="double" displayLabel="&lt;- MinLowPoint -&gt;" category="LinEnt3dByDTMEntityTraceRule_Linear3d_ByTerrain_Trace_Rule" priority="299400" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinEnt3dByDTMEntityTraceRuleSlopeDirection" typeName="LinEnt3dByDTMEntityTraceRuleAspect_LinEnt3dByDTMEntityTraceRuleSlopeDirection_Enum" displayLabel="Direction" category="LinEnt3dByDTMEntityTraceRule_Linear3d_ByTerrain_Trace_Rule" priority="299500"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByDTMEntityTraceRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByDTMEntityTraceRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByDTMEntityTraceSlopeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299800" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MinimumDepth" typeName="double" displayLabel="Minimum Depth" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Elevation1" typeName="double" displayLabel="Elevation 1" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299500" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Elevation2" typeName="double" displayLabel="Elevation 2" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299400" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LevelDifference" typeName="double" displayLabel="Elevation Difference" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299300" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TraceSlopeDirection" typeName="LinEnt3dByDTMEntityTraceSlopeRuleAspect_TraceSlopeDirection_Enum" displayLabel="Direction" category="TraceSlopeRuleAttributes_Trace_Slope_Rule" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByDTMEntityTraceSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByDTMEntityTraceSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByDTMEntityWatershedRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfaceName" typeName="double" displayLabel="Surface Name" category="WatershedRuleAttributes_Watershed_Definition" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TotalArea" typeName="double" displayLabel="Total Area" category="WatershedRuleAttributes_Watershed_Definition" priority="299800" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByDTMEntityWatershedRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByDTMEntityWatershedRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByLinEnt3dRangeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Distance" category="LinEnt3dByLinEnt3dRangeRuleAttributes_Station_Range" priority="199998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="StartDistanceValueManip" category="LinEnt3dByLinEnt3dRangeRuleAttributes_Station_Range" priority="199998" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Distance" category="LinEnt3dByLinEnt3dRangeRuleAttributes_Station_Range" priority="199996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="EndDistanceValueManip" category="LinEnt3dByLinEnt3dRangeRuleAttributes_Station_Range" priority="199996" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByLinEnt3dRangeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByLinEnt3dRangeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByPlanProfileRangeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Distance" category="LinEnt3dByPlanProfileRangeRuleAttributes_Station_Range" priority="199998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="StartDistanceValueManip" category="LinEnt3dByPlanProfileRangeRuleAttributes_Station_Range" priority="199998" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Distance" category="LinEnt3dByPlanProfileRangeRuleAttributes_Station_Range" priority="199996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="EndDistanceValueManip" category="LinEnt3dByPlanProfileRangeRuleAttributes_Station_Range" priority="199996" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByPlanProfileRangeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByPlanProfileRangeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByPlanProfileRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LinearStroking" typeName="double" displayLabel="Linear Stroking" category="StrokingDefinition_Stroking_Definition" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CurveStroking" typeName="double" displayLabel="Curve Stroking" category="StrokingDefinition_Stroking_Definition" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileStroking" typeName="double" displayLabel="Profile Stroking" category="StrokingDefinition_Stroking_Definition" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StrokingStepMethod" typeName="LinEnt3dByPlanProfileRuleAspect_StrokingStepMethod_Enum" displayLabel="Stroking Step Method" category="StrokingDefinition_Stroking_Definition" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByPlanProfileRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByPlanProfileRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEnt3dByVolumeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SideSlope" typeName="double" displayLabel="Side Slope" category="LinEnt3dByVolumeRuleAttributes_Linear3d_by_Volume" priority="299990" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="FreeBoard" typeName="double" displayLabel="Freeboard" category="LinEnt3dByVolumeRuleAttributes_Linear3d_by_Volume" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TargetVolume" typeName="double" displayLabel="Target Volume" category="LinEnt3dByVolumeRuleAttributes_Linear3d_by_Volume" priority="299960" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEnt3dByVolumeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEnt3dByVolumeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinEntityToLinEntityAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinDistance" typeName="double" displayLabel="&lt;- LinElemToLinElem_MinDistance -&gt;" category="LinEntityToLinEntityAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxDistance" typeName="double" displayLabel="&lt;- LinElemToLinElem_MaxDistance -&gt;" category="LinEntityToLinEntityAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartStation" typeName="double" displayLabel="&lt;- LinElemToLinElem_StartStation -&gt;" category="LinEntityToLinEntityAssociatorRuleAttributes_AssociationCategory" priority="299700" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="StartStation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndStation" typeName="double" displayLabel="&lt;- LinElemToLinElem_EndStation -&gt;" category="LinEntityToLinEntityAssociatorRuleAttributes_AssociationCategory" priority="299600" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="EndStation_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinEntityToLinEntityAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinEntityToLinEntityAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineSegmentRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="LineSegmentRuleAttributes_Line_Between_Points_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction" typeName="double" displayLabel="Direction" category="LineSegmentRuleAttributes_Line_Between_Points_Rule" priority="299998" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineSegmentRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineSegmentRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineToElementRuleBaseAspect" modifier="Abstract">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299954" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Offset" category="LineToElementRuleAttributes_Line_To_Element_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Skew" typeName="double" displayLabel="Skew" category="LineToElementRuleAttributes_Line_To_Element_Rule" priority="299994" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="LineToElementRuleAttributes_Line_To_Element_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="LineToElementRuleBaseAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="LineToElementRuleAttributes_Line_To_Element_Rule" priority="299952"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="LineToElementRuleBaseAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Type" category="BackTransitionAttributes_Back_Transition" priority="299986"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="LineToElementRuleCurveAspect">
+        <BaseClass>LineToElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionRadius" typeName="double" displayLabel="Radius" category="BackTransitionAttributes_Back_Transition" priority="299978" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299977" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionCurveDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299976" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionCurveDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299975" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodArc" typeName="LineToElementRuleCurveAspect_BackTransitionDefinitionMethodArc_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299984"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineToElementRuleCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineToElementRuleCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LineToElementRuleSpiralAspect">
+        <BaseClass>LineToElementRuleBaseAspect</BaseClass>
+        <ECProperty propertyName="BackTransitionSpiralLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299980" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodSpiral" typeName="LineToElementRuleSpiralAspect_BackTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299985"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLineToElementRuleSpiralAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LineToElementRuleSpiralAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PlaceCircleRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Method" typeName="string" displayLabel="Method" category="ArcRuleAttributes_Circle_Rule" priority="299999"/>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ArcRuleAttributes_Circle_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CenterPoint" typeName="point3d" displayLabel="Center" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPlaceCircleRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PlaceCircleRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToLinElemAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="&lt;- Pnt2dToLinElem_Station -&gt;" category="Pnt2dToLinElemAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="&lt;- Pnt2dToLinElem_Offset -&gt;" category="Pnt2dToLinElemAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToLinElemAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToLinElemAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToLinElemPositionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PositionType" typeName="Pnt2dToLinElemPositionRuleAspect_PositionType_Enum" displayLabel="PositionType" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToLinElemPositionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToLinElemPositionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToLinElemTwoConstraintsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299600" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'Station' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="Offset" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToLinElemTwoConstraintsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToLinElemTwoConstraintsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToOneLinElemOnePnt2dTwoConstraintsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299000" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="Offset" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299200" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dX" typeName="double" displayLabel="dX" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dY" typeName="double" displayLabel="dY" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Distance" typeName="double" displayLabel="Distance" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299400" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction" typeName="double" displayLabel="Direction" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299600" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="DirectionAsAngle" typeName="double" displayLabel="DirectionAsAngle" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299600" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="dStation" typeName="double" displayLabel="dStation" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dOffset" typeName="double" displayLabel="dOffset" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299920" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToOneLinElemOnePnt2dTwoConstraintsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToOneLinElemOnePnt2dTwoConstraintsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToOnePnt2dTwoConstraintsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="dX" typeName="double" displayLabel="dX" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dY" typeName="double" displayLabel="dY" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Distance" typeName="double" displayLabel="Distance" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299500" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction" typeName="double" displayLabel="Direction" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299400" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="DirectionAsAngle" typeName="double" displayLabel="DirectionAsAngle" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299300" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToOnePnt2dTwoConstraintsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToOnePnt2dTwoConstraintsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToPnt2dAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Distance" typeName="double" displayLabel="&lt;- Pnt2dToPnt2d_Distance -&gt;" category="Pnt2dToPnt2dAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction" typeName="double" displayLabel="&lt;- Pnt2dToPnt2d_Direction -&gt;" category="Pnt2dToPnt2dAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:BEARING"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToPnt2dAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToPnt2dAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToPnt2dDirectionDistanceRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DirectionValue" typeName="double" displayLabel="DirectionValue" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299995" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="DistanceValue" typeName="double" displayLabel="DistanceValue" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToPnt2dDirectionDistanceRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToPnt2dDirectionDistanceRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToPnt2dIdentityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ReferencePoint" typeName="point3d" displayLabel="Reference Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToPnt2dIdentityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToPnt2dIdentityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToTwoLinElemTwoConstraintsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Offset1" typeName="double" displayLabel="Offset1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299200" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Offset2" typeName="double" displayLabel="Offset2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299400" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Station1" typeName="double" displayLabel="Station1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299600" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station1_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Station2" typeName="double" displayLabel="Station2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299800" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station2_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToTwoLinElemTwoConstraintsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToTwoLinElemTwoConstraintsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt2dToTwoPnt2dTwoConstraintsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="dX1" typeName="double" displayLabel="dX1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dX2" typeName="double" displayLabel="dX2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dY1" typeName="double" displayLabel="dY1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="dY2" typeName="double" displayLabel="dY2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299500" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Distance1" typeName="double" displayLabel="Distance1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299400" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Distance2" typeName="double" displayLabel="Distance2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299300" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction1" typeName="double" displayLabel="Direction1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299200" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="DirectionAsAngle1" typeName="double" displayLabel="DirectionAsAngle1" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299100" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Direction2" typeName="double" displayLabel="Direction2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299000" kindOfQuantity="cifu:BEARING"/>
+        <ECProperty propertyName="DirectionAsAngle2" typeName="double" displayLabel="DirectionAsAngle2" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="298900" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt2dToTwoPnt2dTwoConstraintsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt2dToTwoPnt2dTwoConstraintsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt3dToDTMEntityAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinVerticalOffset" typeName="double" displayLabel="&lt;- Pnt3dToDTM_MinVerticalOffset -&gt;" category="Pnt3dToDTMElementAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxVerticalOffset" typeName="double" displayLabel="&lt;- Pnt3dToDTM_MaxVerticalOffset -&gt;" category="Pnt3dToDTMElementAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt3dToDTMEntityAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt3dToDTMEntityAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pnt3dToPnt3dAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="&lt;- Pnt3dToPnt3d_VerticalOffset -&gt;" category="Pnt3dToPnt3dAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="&lt;- Pnt3dToPnt3d_Slope -&gt;" category="Pnt3dToPnt3dAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:SLOPE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPnt3dToPnt3dAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pnt3dToPnt3dAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PointEntity2dElevationByEntityOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeltaElevation" typeName="double" displayLabel="Delta Elevation" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ReferenceTerrain" typeName="string" displayLabel="Reference Terrain" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299990"/>
+        <ECProperty propertyName="ReferenceAlignment" typeName="string" displayLabel="Reference Alignment" category="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPointEntity2dElevationByEntityOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PointEntity2dElevationByEntityOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PortalRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="Portal_Portal" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Rotation" typeName="double" displayLabel="Rotation" category="Portal_Portal" priority="299998" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Elevation" typeName="double" displayLabel="Elevation" category="Portal_Portal" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPortalRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PortalRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileBy2LinearEnt3dTransitionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ProfileBy2LinearEnt3dTransitionRule_ProfileBy2LinearEnt3dTransitionRule_QuickTransitionMethod" typeName="ProfileBy2LinearEnt3dTransitionRuleAspect_ProfileBy2LinearEnt3dTransitionRule_ProfileBy2LinearEnt3dTransitionRule_QuickTransitionMethod_BoolEnum" displayLabel="Quick Transition Method" category="ProfileBy2LinearEnt3dTransitionRuleAttributes_Profile_By_Two_3D_Element_Transition_Rule" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileBy2LinearEnt3dTransitionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileBy2LinearEnt3dTransitionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByDTMOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HorizontalOffset" typeName="double" displayLabel="Horizontal Offset" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ProfileAdjustmentOption" typeName="ProfileByDTMOffsetRuleAspect_ProfileAdjustmentOption_Enum" displayLabel="Profile Adjustment" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299994"/>
+        <ECProperty propertyName="PointSelectionOnElement" typeName="ProfileByDTMOffsetRuleAspect_PointSelectionOnElement_Enum" displayLabel="Point Selection" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299993"/>
+        <ECProperty propertyName="DrapeOption" typeName="ProfileByDTMOffsetRuleAspect_DrapeOption_Enum" displayLabel="Drape Option" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299993"/>
+        <ECProperty propertyName="IntervalDistance" typeName="double" displayLabel="Distance of interval" category="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByDTMOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByDTMOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByPnt3dSlopeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeltaZ" typeName="double" displayLabel="Vertical Offset" category="ProfileByPnt3dSlopeRuleAttributes_Profile_By_3D_Point_Slope_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileByPnt3dSlopeRuleAttributes_Profile_By_3D_Point_Slope_Rule" priority="299998" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="PointSelectionOnDepending" typeName="ProfileByPnt3dSlopeRuleAspect_PointSelectionOnDepending_Enum" displayLabel="Point Selection" category="ProfileByPnt3dSlopeRuleAttributes_Profile_By_3D_Point_Slope_Rule" priority="299997"/>
+        <ECProperty propertyName="PointProjection" typeName="ProfileByPnt3dSlopeRuleAspect_PointProjection_Enum" displayLabel="Point Projection" category="ProfileByPnt3dSlopeRuleAttributes_Profile_By_3D_Point_Slope_Rule" priority="299996"/>
+        <ECProperty propertyName="ProfileAdjustment" typeName="ProfileByPnt3dSlopeRuleAspect_ProfileAdjustment_Enum" displayLabel="Profile Adjustment" category="ProfileByPnt3dSlopeRuleAttributes_Profile_By_3D_Point_Slope_Rule" priority="299995"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByPnt3dSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByPnt3dSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OffsetHeight" typeName="double" displayLabel="&lt;- OffsetHeight -&gt;" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Distance" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="StartDistanceValueManip" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299992" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Distance" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="EndDistanceValueManip" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299991" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartVerticalOffsetValue" typeName="double" displayLabel="Start Vertical Offset" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartOffsetValueManip" typeName="double" displayLabel="StartOffsetValueManip" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299990" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndVerticalOffsetValue" typeName="double" displayLabel="End Vertical Offset" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndOffsetValueManip" typeName="double" displayLabel="EndOffsetValueManip" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299989" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartSlopeValue" typeName="double" displayLabel="&lt;- StartCrossfall -&gt;" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299988" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="StartSlopeValueManip" typeName="double" displayLabel="StartSlopeValueManip" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299988" kindOfQuantity="cifu:SLOPE">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndSlopeValue" typeName="double" displayLabel="&lt;- EndCrossfall -&gt;" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299987" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="EndSlopeValueManip" typeName="double" displayLabel="EndSlopeValueManip" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299987" kindOfQuantity="cifu:SLOPE">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="FirstArcLength" typeName="double" displayLabel="&lt;- FirstArcLength -&gt;" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SecondArcLength" typeName="double" displayLabel="&lt;- SecondArcLength -&gt;" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProfileAdjustment" typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_ProfileAdjustment_Enum" displayLabel="Profile Adjustment" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299996"/>
+        <ECProperty propertyName="SlopeStyle" typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_SlopeStyle_Enum" displayLabel="Slope Style" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299994"/>
+        <ECProperty propertyName="SlopeMethod" typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_SlopeMethod_Enum" displayLabel="&lt;- SlopeMethod -&gt;" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299993"/>
+        <ECProperty propertyName="PointSelectionOnDepending" typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect_PointSelectionOnDepending_Enum" displayLabel="Point Selection On Depending" category="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" priority="299995"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByProjectingLinEnt3dComplexSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByProjectingLinEnt3dComplexSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByProjectingLinEnt3dRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="ProfileByProjectingLinEnt3dRuleAttributes_Profile_By_Projecting_3D_Element_Rule" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="ProfileByProjectingLinEnt3dRuleAttributes_Profile_By_Projecting_3D_Element_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="DeltaZ" typeName="double" displayLabel="Vertical Offset" category="ProfileByProjectingLinEnt3dRuleAttributes_Profile_By_Projecting_3D_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByProjectingLinEnt3dRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByProjectingLinEnt3dRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeltaZ" typeName="double" displayLabel="Vertical Offset" category="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Simple_Slope_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Simple_Slope_Rule" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="ProfileAdjustment" typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAspect_ProfileAdjustment_Enum" displayLabel="Profile Adjustment" category="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Simple_Slope_Rule" priority="299991"/>
+        <ECProperty propertyName="PointSelectionOnDepending" typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAspect_PointSelectionOnDepending_Enum" displayLabel="Point Selection On Depending" category="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Simple_Slope_Rule" priority="299990"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByProjectingLinEnt3dSimpleSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByProjectingLinEnt3dSimpleSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByProjectingLinEnt3dSlopeRuleAspect">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="DeltaZ" typeName="double" displayLabel="Vertical Offset" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Reference Distance" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Reference Distance" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="StartSlope" typeName="double" displayLabel="Start Slope" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299996" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="EndSlope" typeName="double" displayLabel="End Slope" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299995" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="StartVerticalOffset" typeName="double" displayLabel="Start Vertical Offset" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndVerticalOffset" typeName="double" displayLabel="End Vertical Offset" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SlopeRelativeToTarget" typeName="boolean" displayLabel="Slope relative to target" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299989"/>
+        <ECProperty propertyName="SlopeStyle" typeName="ProfileByProjectingLinEnt3dSlopeRuleAspect_SlopeStyle_Enum" displayLabel="Slope Style" category="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByProjectingLinEnt3dSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByProjectingLinEnt3dSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileCurveBetweenElementsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CurveType" typeName="string" displayLabel="Curve Type" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299999"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="VerticalCurveParameter" typeName="double" displayLabel="Vertical Curve Parameter" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrestSagSelection" typeName="ProfileCurveBetweenElementsRuleAspect_CrestSagSelection_Enum" displayLabel="Crest or Sag" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299992"/>
+        <ECProperty propertyName="Length1" typeName="double" displayLabel="Length 1" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length2" typeName="double" displayLabel="Length 2" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileCurveBetweenElementsRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299993"/>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileCurveBetweenElementsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileCurveBetweenElementsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileCurveFromElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CurveType" typeName="string" displayLabel="Curve Type" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299999"/>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="Offset" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndGrade" typeName="double" displayLabel="End Grade" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299996" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="VerticalCurveParameter" typeName="double" displayLabel="Vertical Curve Parameter" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileCurveFromElementRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299992"/>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileCurveFromElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileCurveFromElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileCurveRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Method" typeName="string" displayLabel="Placement Method" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299999"/>
+        <ECProperty propertyName="CurveType" typeName="string" displayLabel="Curve Type" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299998"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TrueLength" typeName="double" displayLabel="True Length" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299997" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="VerticalCurveParameter" typeName="double" displayLabel="Vertical Curve Parameter" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartSlope" typeName="double" displayLabel="Start Slope" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299995" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="EndSlope" typeName="double" displayLabel="End Slope" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="VPIPoint" typeName="point3d" displayLabel="VPI Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HighLowPoint" typeName="point3d" displayLabel="HighLow Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ProfileCurveRuleAttributes_Profile_Curve_Rule" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileCurveRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileCurveRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileCurveToElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CurveType" typeName="string" displayLabel="Curve Type" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299999"/>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="Offset" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndGrade" typeName="double" displayLabel="End Grade" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299996" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="VerticalCurveParameter" typeName="double" displayLabel="Vertical Curve Parameter" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ThruPoint" typeName="point3d" displayLabel="Through Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileCurveToElementRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299992"/>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileCurveToElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileCurveToElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileElemToProfileElemVariableOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SingleOffsetValue" typeName="double" displayLabel="Offset" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartOffsetValue" typeName="double" displayLabel="Start Offset" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartOffsetValueManip" typeName="double" displayLabel="StartOffsetValueManip" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299997" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Distance" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="StartDistanceValueManip" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299998" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndOffsetValue" typeName="double" displayLabel="End Offset" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndOffsetValueManip" typeName="double" displayLabel="EndOffsetValueManip" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299994" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="RatioValue" typeName="double" displayLabel="Ratio [Deprecated]" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299993" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new RatioValuePercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Distance" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndLengthValue" typeName="double" displayLabel="Length" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="EndDistanceValueManip" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299996" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="LengthValue" typeName="double" displayLabel="Length" category="GeometryAttributes_Geometry" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LengthAlongValue" typeName="double" displayLabel="Length Along" category="GeometryAttributes_Geometry" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PlacementMethod" typeName="ProfileElemToProfileElemVariableOffsetRuleAspect_PlacementMethod_Enum" displayLabel="Method" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="300000"/>
+        <ECProperty propertyName="RatioValuePercent" typeName="double" displayLabel="Ratio" category="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" priority="299993" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileElemToProfileElemVariableOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileElemToProfileElemVariableOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileEntityToProfileEntityAssociatorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinDistance" typeName="double" displayLabel="&lt;- ProfiledToProfiled_MinDistance -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxDistance" typeName="double" displayLabel="&lt;- ProfiledToProfiled_MaxDistance -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299800" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartStation" typeName="double" displayLabel="&lt;- ProfiledToProfiled_StartStation -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndStation" typeName="double" displayLabel="&lt;- ProfiledToProfiled_EndStation -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299600" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MinSlope" typeName="double" displayLabel="&lt;- ProfiledToProfiled_MinSlope -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299500" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="MaxSlope" typeName="double" displayLabel="&lt;- ProfiledToProfiled_MaxSlope -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299400" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="MinVerticalOffset" typeName="double" displayLabel="&lt;- ProfiledToProfiled_MinVerticalOffset -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299300" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxVerticalOffset" typeName="double" displayLabel="&lt;- ProfiledToProfiled_MaxVerticalOffset -&gt;" category="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" priority="299200" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileEntityToProfileEntityAssociatorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileEntityToProfileEntityAssociatorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileLineBetweenElementsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ProfileLineBetweenElementsRuleAttributes_Profile_Line_Between_Curves_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="ProfileLineBetweenElementsRuleAttributes_Profile_Line_Between_Curves_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProjectedLength" typeName="double" displayLabel="Projected Length" category="ProfileLineBetweenElementsRuleAttributes_Profile_Line_Between_Curves_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileLineBetweenElementsRuleAttributes_Profile_Line_Between_Curves_Rule" priority="299996" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileLineBetweenElementsRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileLineBetweenElementsRuleAttributes_Profile_Line_Between_Curves_Rule" priority="299995"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileLineBetweenElementsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileLineBetweenElementsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileLineFromElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeltaZ" typeName="double" displayLabel="Vertical Offset" category="ProfileLineFromElementRuleAttributes_Profile_Line_From_Element_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeltaSlope" typeName="double" displayLabel="Delta Slope" category="ProfileLineFromElementRuleAttributes_Profile_Line_From_Element_Rule" priority="299997" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileLineFromElementRuleAttributes_Profile_Line_From_Element_Rule" priority="299993" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileLineFromElementRuleAttributes_Profile_Line_From_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileLineFromElementRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileLineFromElementRuleAttributes_Profile_Line_From_Element_Rule" priority="299994"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileLineFromElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileLineFromElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileLineSegmentRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileLineSegmentRuleAttributes_Profile_Line_Between_Points_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TrueLength" typeName="double" displayLabel="True Length" category="ProfileLineSegmentRuleAttributes_Profile_Line_Between_Points_Rule" priority="299995" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileLineSegmentRuleAttributes_Profile_Line_Between_Points_Rule" priority="299998" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Elevation" typeName="double" displayLabel="Elevation" category="ProfileLineSegmentRuleAttributes_Profile_Line_Between_Points_Rule" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileLineSegmentRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileLineSegmentRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileLineToElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DeltaZ" typeName="double" displayLabel="Vertical Offset" category="ProfileLineToElementRuleAttributes_Profile_Line_To_Element_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DeltaSlope" typeName="double" displayLabel="Delta Slope" category="ProfileLineToElementRuleAttributes_Profile_Line_To_Element_Rule" priority="299997" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfileLineToElementRuleAttributes_Profile_Line_To_Element_Rule" priority="299993" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileLineToElementRuleAttributes_Profile_Line_To_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileLineToElementRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileLineToElementRuleAttributes_Profile_Line_To_Element_Rule" priority="299994"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileLineToElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileLineToElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfilePointbyStationDeltaElevationRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="ProfilePointbyStationDeltaElevationRuleAttributes_ProfilePointbyStationDeltaElevationDefinition" priority="299800" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'Station' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="DeltaElevation" typeName="double" displayLabel="DeltaElevation" category="ProfilePointbyStationDeltaElevationRuleAttributes_ProfilePointbyStationDeltaElevationDefinition" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfilePointbyStationDeltaElevationRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfilePointbyStationDeltaElevationRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfilePointbyStationElevationRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="ProfilePointbyStationElevationRuleAttributes_ProfilePointbyStationElevationDefinition" priority="299800" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'Station' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Elevation" typeName="double" displayLabel="Elevation" category="ProfilePointbyStationElevationRuleAttributes_ProfilePointbyStationElevationDefinition" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfilePointbyStationElevationRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfilePointbyStationElevationRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfilePointbyStationProfileOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="ProfilePointbyStationProfileOffsetRuleAttributes_ProfilePointbyStationProfileOffsetDefinition" priority="299800" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'Station' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="ProfileOffset" typeName="double" displayLabel="ProfileOffset" category="ProfilePointbyStationProfileOffsetRuleAttributes_ProfilePointbyStationProfileOffsetDefinition" priority="299700" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfilePointbyStationProfileOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfilePointbyStationProfileOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfilePointbyStationSlopeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="ProfilePointbyStationSlopeRuleAttributes_ProfilePointbyStationSlopeDefinition" priority="299800" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Station_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'Station' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="Slope" typeName="double" displayLabel="Slope" category="ProfilePointbyStationSlopeRuleAttributes_ProfilePointbyStationSlopeDefinition" priority="299700" kindOfQuantity="cifu:SLOPE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfilePointbyStationSlopeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfilePointbyStationSlopeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileReverseTransitionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearTransitionLength" typeName="double" displayLabel="Linear Transition Length" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearTransitionSlope" typeName="double" displayLabel="Linear Transition Slope" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299994" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="BackVCParameter" typeName="double" displayLabel="Back Curve Parameter" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadVCParameter" typeName="double" displayLabel="Ahead Curve Parameter" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="ProfileReverseTransitionRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" priority="299989"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileReverseTransitionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileReverseTransitionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProjectExtendedProfileRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Distance" typeName="double" displayLabel="Distance" category="ProjectExtendedProfileRuleAttributes_Project_Extended_Profile_Rule" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProjectExtendedProfileRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProjectExtendedProfileRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReverseTransitionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackRadius" typeName="double" displayLabel="Back Radius" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadRadius" typeName="double" displayLabel="Ahead Radius" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearTransitionLength" typeName="double" displayLabel="Linear Transition Length" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinearTransitionAngle" typeName="double" displayLabel="Linear Transition Angle" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299991" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartOffset" typeName="double" displayLabel="Start Offset" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndOffset" typeName="double" displayLabel="End Offset" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RadiusRatio" typeName="double" displayLabel="Radius Ratio" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Direction" typeName="ReverseTransitionRuleAspect_Direction_Enum" displayLabel="Direction" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299986"/>
+        <ECProperty propertyName="TransitionType" typeName="ReverseTransitionRuleAspect_TransitionType_Enum" displayLabel="Transition Type" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299985"/>
+        <ECProperty propertyName="LoopOption" typeName="ReverseTransitionRuleAspect_LoopOption_Enum" displayLabel="Loop Option" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299984"/>
+        <ECProperty propertyName="TruncateOption" typeName="ReverseTransitionRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" priority="299983"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReverseTransitionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReverseTransitionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RuledSurfaceBySlopeDTMRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartCutSlope" typeName="double" displayLabel="Start Cut Slope" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299910" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="StartFillSlope" typeName="double" displayLabel="Start Fill Slope" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299900" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="EndCutSlope" typeName="double" displayLabel="End Cut Slope" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299860" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="EndFillSlope" typeName="double" displayLabel="End Fill Slope" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299850" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="ElevationOrDistance" typeName="double" displayLabel="Elevation or Distance" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue" typeName="double" displayLabel="Start Distance" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip" typeName="double" displayLabel="StartDistanceValueManip" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299930" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="StartDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValue" typeName="double" displayLabel="End Distance" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299880" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistanceValue_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValue' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip" typeName="double" displayLabel="EndDistanceValueManip" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299880" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistanceValueManip_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistanceValueManip' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SlopeOption" typeName="RuledSurfaceBySlopeDTMRuleAspect_SlopeOption_Enum" displayLabel="Slope Method" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299990"/>
+        <ECProperty propertyName="CutFillOption" typeName="RuledSurfaceBySlopeDTMRuleAspect_CutFillOption_Enum" displayLabel="Cut Fill Option" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299970"/>
+        <ECProperty propertyName="Side" typeName="RuledSurfaceBySlopeDTMRuleAspect_Side_Enum" displayLabel="Side" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299960"/>
+        <ECProperty propertyName="CornerOption" typeName="RuledSurfaceBySlopeDTMRuleAspect_CornerOption_Enum" displayLabel="Corner Option" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299950"/>
+        <ECProperty propertyName="SlopeTransitionMethod" typeName="RuledSurfaceBySlopeDTMRuleAspect_SlopeTransitionMethod_Enum" displayLabel="Transition Type" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299940"/>
+        <ECProperty propertyName="StartSlopeUpOrDown" typeName="RuledSurfaceBySlopeDTMRuleAspect_StartSlopeUpOrDown_Enum" displayLabel="Start Slope Up or Down" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299890"/>
+        <ECProperty propertyName="EndSlopeUpOrDown" typeName="RuledSurfaceBySlopeDTMRuleAspect_EndSlopeUpOrDown_Enum" displayLabel="End Slope Up or Down" category="SideSlopeRuleAttributes_Side_Slope_Parameters" priority="299840"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRuledSurfaceBySlopeDTMRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RuledSurfaceBySlopeDTMRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SightVisibilitySectionNamedEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SettingsFile" typeName="string" displayLabel="Settings File" category="SightVisibility_Sight_Visibility" priority="299994"/>
+        <ECProperty propertyName="EquationSettingsName" typeName="string" displayLabel="Equation Settings Name" category="SightVisibility_Sight_Visibility" priority="299982"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Station" category="SightVisibility_Sight_Visibility" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Station" category="SightVisibility_Sight_Visibility" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'EndDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="EyeInterval" typeName="double" displayLabel="Eye Interval" category="SightVisibility_Sight_Visibility" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EyeOffset" typeName="double" displayLabel="Eye Offset" category="SightVisibility_Sight_Visibility" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EyeHeight" typeName="double" displayLabel="Eye Height" category="SightVisibility_Sight_Visibility" priority="299989" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ObjectInterval" typeName="double" displayLabel="Object Interval" category="SightVisibility_Sight_Visibility" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ObjectOffset" typeName="double" displayLabel="Object Offset" category="SightVisibility_Sight_Visibility" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ObjectHeight" typeName="double" displayLabel="Object Height" category="SightVisibility_Sight_Visibility" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SightDistanceRequired" typeName="double" displayLabel="Sight Distance Required" category="SightVisibility_Sight_Visibility" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SightDistanceRelaxed" typeName="double" displayLabel="Sight Distance Relaxed" category="SightVisibility_Sight_Visibility" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CalculationMethod" typeName="SightVisibilitySectionNamedEntityRuleAspect_CalculationMethod_Enum" displayLabel="Calculation Method" category="SightVisibility_Sight_Visibility" priority="299983"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSightVisibilitySectionNamedEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SightVisibilitySectionNamedEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SlopeMonitorRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinSlope" typeName="double" displayLabel="&lt;- MonitorSlope_MinSlope -&gt;" category="SlopeMonitorDefinition_General_Category" priority="299800" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="MaxSlope" typeName="double" displayLabel="&lt;- MonitorSlope_MaxSlope -&gt;" category="SlopeMonitorDefinition_General_Category" priority="299700" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Message" typeName="string" displayLabel="&lt;- Monitor_Message -&gt;" category="SlopeMonitorDefinition_General_Category" priority="299500"/>
+        <ECProperty propertyName="SlopeMonitorRule_MonitorType" typeName="SlopeMonitorRuleAspect_SlopeMonitorRule_MonitorType_Enum" displayLabel="&lt;- MonitorType -&gt;" category="SlopeMonitorDefinition_General_Category" priority="299900"/>
+        <ECProperty propertyName="SlopeMonitorRule_MonitorState" typeName="SlopeMonitorRuleAspect_SlopeMonitorRule_MonitorState_Enum" displayLabel="&lt;- MonitorState -&gt;" category="SlopeMonitorDefinition_General_Category" priority="299600"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSlopeMonitorRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SlopeMonitorRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SpiralBetweenElementsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadOffset" typeName="double" displayLabel="Ahead Offset" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethod" typeName="SpiralBetweenElementsRuleAspect_BackTransitionDefinitionMethod_Enum" displayLabel="Method" category="BackTransitionAttributes_Back_Transition" priority="299993"/>
+        <ECProperty propertyName="BackTransitionLength" typeName="double" displayLabel="Length" category="BackTransitionAttributes_Back_Transition" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionLink" typeName="double" displayLabel="A-Value" category="BackTransitionAttributes_Back_Transition" priority="299991" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionRL" typeName="double" displayLabel="RL" category="BackTransitionAttributes_Back_Transition" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDeflection" typeName="double" displayLabel="Deflection" category="BackTransitionAttributes_Back_Transition" priority="299989" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="BackTransitionAttributes_Back_Transition" priority="299988" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDefinitionMethod" typeName="SpiralBetweenElementsRuleAspect_AheadTransitionDefinitionMethod_Enum" displayLabel="Method" category="AheadTransitionAttributes_Ahead_Transition" priority="299987"/>
+        <ECProperty propertyName="AheadTransitionLength" typeName="double" displayLabel="Length" category="AheadTransitionAttributes_Ahead_Transition" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionLink" typeName="double" displayLabel="A-Value" category="AheadTransitionAttributes_Ahead_Transition" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionRL" typeName="double" displayLabel="RL" category="AheadTransitionAttributes_Ahead_Transition" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AheadTransitionDeflection" typeName="double" displayLabel="Deflection" category="AheadTransitionAttributes_Ahead_Transition" priority="299983" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="AheadTransitionDeltaR" typeName="double" displayLabel="DeltaR" category="AheadTransitionAttributes_Ahead_Transition" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SpiralRatio" typeName="double" displayLabel="Spiral Ratio [Deprecated]" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299994" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Replaced by the new SpiralRatioPercent property.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="CommonRadius" typeName="double" displayLabel="Common Radius" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="IntermediateElementLength" typeName="double" displayLabel="Intermediate element length" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TruncateOption" typeName="SpiralBetweenElementsRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299992"/>
+        <ECProperty propertyName="SpiralRatioPercent" typeName="double" displayLabel="Spiral Ratio" category="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" priority="299994" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSpiralBetweenElementsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SpiralBetweenElementsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SpiralFromElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="End Radius" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="GeometryPointsCategoryAttributes_Geometry_Points" priority="299954" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackOffset" typeName="double" displayLabel="Back Offset" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionDefinitionMethodSpiral" typeName="SpiralFromElementRuleAspect_BackTransitionDefinitionMethodSpiral_Enum" displayLabel="Method" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299985"/>
+        <ECProperty propertyName="BackTransitionSpiralLength" typeName="double" displayLabel="Length" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralParameter" typeName="double" displayLabel="A-Value" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299982" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralRL" typeName="double" displayLabel="RL" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299981" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BackTransitionSpiralDeflection" typeName="double" displayLabel="Deflection" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299980" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="BackTransitionSpiralDeltaR" typeName="double" displayLabel="DeltaR" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299979" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Hand" typeName="SpiralFromElementRuleAspect_Hand_Enum" displayLabel="Hand" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299952"/>
+        <ECProperty propertyName="TruncateOption" typeName="SpiralFromElementRuleAspect_TruncateOption_Enum" displayLabel="Trim\Extend" category="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" priority="299951"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSpiralFromElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SpiralFromElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SuperElevationControlLineNamedEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SuperElevationControlLineNamedEntityRule_CopyValues" typeName="SuperElevationControlLineNamedEntityRuleAspect_SuperElevationControlLineNamedEntityRule_CopyValues_BoolEnum" displayLabel="Copy Values" category="SuperElevationControlLine_Control_Line" priority="299989"/>
+        <ECProperty propertyName="SuperElevationControlLineNamedEntityRule_MirrorAll" typeName="SuperElevationControlLineNamedEntityRuleAspect_SuperElevationControlLineNamedEntityRule_MirrorAll_BoolEnum" displayLabel="Mirror All" category="SuperElevationControlLine_Control_Line" priority="299988"/>
+        <ECProperty propertyName="SuperElevationControlLineNamedEntityRule_ExcludeNormalCrown" typeName="SuperElevationControlLineNamedEntityRuleAspect_SuperElevationControlLineNamedEntityRule_ExcludeNormalCrown_BoolEnum" displayLabel="Exclude Normal Crown" category="SuperElevationControlLine_Control_Line" priority="299987"/>
+        <ECProperty propertyName="SuperElevationControlLineNamedEntityRule_NormalCrown" typeName="double" displayLabel="Normal Crown" category="SuperElevationControlLine_Control_Line" priority="299986" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SuperElevationControlLineNamedEntityRule_MaxCrossSlope" typeName="double" displayLabel="Max Cross Slope" category="SuperElevationControlLine_Control_Line" priority="299985" kindOfQuantity="cifu:SLOPE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSuperElevationControlLineNamedEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SuperElevationControlLineNamedEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SuperElevationNamedEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_InsideEdgeOffset" typeName="double" displayLabel="Inside Edge Offset" category="Superelevation_Superelevation" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_Width" typeName="double" displayLabel="Width" category="Superelevation_Superelevation" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_StartDistance" typeName="double" displayLabel="Start Station" category="Superelevation_Superelevation" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_StartDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'SuperElevationNamedEntityRule_StartDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_StopDistance" typeName="double" displayLabel="End Station" category="Superelevation_Superelevation" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_StopDistance_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'SuperElevationNamedEntityRule_StopDistance' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_NormalCrossSlope" typeName="double" displayLabel="Normal Cross Slope" category="Superelevation_Superelevation" priority="299993" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_SideOfCenterline" typeName="SuperElevationNamedEntityRuleAspect_SuperElevationNamedEntityRule_SideOfCenterline_Enum" displayLabel="Side Of Centerline" category="Superelevation_Superelevation" priority="299998"/>
+        <ECProperty propertyName="SuperElevationNamedEntityRule_SuperType" typeName="SuperElevationNamedEntityRuleAspect_SuperElevationNamedEntityRule_SuperType_Enum" displayLabel="Type" category="Superelevation_Superelevation" priority="299992"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSuperElevationNamedEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SuperElevationNamedEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SuperElevationSectionNamedEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SuperElevationSectionNamedEntity_HorizontalName" typeName="string" displayLabel="Horizontal Name" category="SuperElevationSection_Superelevation_Section" priority="299998"/>
+        <ECProperty propertyName="SuperElevationSectionNamedEntityRule_StandardsFile" typeName="string" displayLabel="Standards File" category="SuperElevationSection_Superelevation_Section" priority="299993"/>
+        <ECProperty propertyName="SuperElevationSectionNamedEntityRule_DesignSpeed" typeName="string" displayLabel="Design Speed" category="SuperElevationSection_Superelevation_Section" priority="299992"/>
+        <ECProperty propertyName="SuperElevationSectionNamedEntityRule_PivotMethod" typeName="string" displayLabel="Pivot Method" category="SuperElevationSection_Superelevation_Section" priority="299991"/>
+        <ECProperty propertyName="SuperElevationSectionNamedEntityRule_ESelection" typeName="string" displayLabel="e Selection" category="SuperElevationSection_Superelevation_Section" priority="299990"/>
+        <ECProperty propertyName="SuperElevationSectionNamedEntityRule_LSelection" typeName="string" displayLabel="L Selection" category="SuperElevationSection_Superelevation_Section" priority="299989"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSuperElevationSectionNamedEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SuperElevationSectionNamedEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SuperElevationShoulderNamedEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_HighDifference" typeName="double" displayLabel="High Difference" category="SuperElevationHighSide_High_Side" priority="299989" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_SetMaxSlope" typeName="SuperElevationShoulderNamedEntityRuleAspect_SuperElevationShoulderNamedEntityRule_SetMaxSlope_BoolEnum" displayLabel="Set Maximum Slope" category="SuperElevationHighSide_High_Side" priority="299988"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_MaxSlope" typeName="double" displayLabel="Maximum Slope" category="SuperElevationHighSide_High_Side" priority="299987" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_Length" typeName="double" displayLabel="Specified Length" category="SuperElevationHighSide_High_Side" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_Length_DistanceAlong" typeName="double" kindOfQuantity="cifu:STATION">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Unnecessary duplicate-property. Use 'SuperElevationShoulderNamedEntityRule_Length' directly</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_LowDifference" typeName="double" displayLabel="Low Difference" category="SuperElevationLowSide_Low_Side" priority="299984" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_SetMinSlope" typeName="SuperElevationShoulderNamedEntityRuleAspect_SuperElevationShoulderNamedEntityRule_SetMinSlope_BoolEnum" displayLabel="Set Minimum Slope" category="SuperElevationLowSide_Low_Side" priority="299983"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_MinSlope" typeName="double" displayLabel="Minimum Slope" category="SuperElevationLowSide_Low_Side" priority="299982" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="SuperElevationShoulderNamedEntityRule_TransitionMethod" typeName="SuperElevationShoulderNamedEntityRuleAspect_SuperElevationShoulderNamedEntityRule_TransitionMethod_Enum" displayLabel="Transition Method" category="SuperElevationHighSide_High_Side" priority="299986"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSuperElevationShoulderNamedEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SuperElevationShoulderNamedEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="AheadTaperAttributes_Ahead_Taper" description="AheadTaperAttributes" displayLabel="Ahead Taper" priority="0"/>
+    <PropertyCategory typeName="AheadTransitionAttributes_Ahead_Transition" description="AheadTransitionAttributes" displayLabel="Ahead Transition" priority="0"/>
+    <PropertyCategory typeName="AquaplaningAttributes_Aquaplaning_Model" description="AquaplaningAttributes" displayLabel="Aquaplaning Model" priority="0"/>
+    <PropertyCategory typeName="ArcBetweenElementArcRuleAttributes_Complex_Transition_between_Any_element_and_Arc_Rule" description="ArcBetweenElementArcRuleAttributes" displayLabel="Complex Transition between Any element and Arc Rule" priority="0"/>
+    <PropertyCategory typeName="ArcBetweenElementsRuleAttributes_Arc_Between_Arcs_Rule" description="ArcBetweenElementsRuleAttributes" displayLabel="Arc Between Arcs Rule" priority="0"/>
+    <PropertyCategory typeName="ArcFromElementRuleAttributes_Arc_From_Element_Rule" description="ArcFromElementRuleAttributes" displayLabel="Arc From Element Rule" priority="0"/>
+    <PropertyCategory typeName="ArcRuleAttributes_Arc_Rule" description="ArcRuleAttributes" displayLabel="Arc Rule" priority="0"/>
+    <PropertyCategory typeName="ArcRuleAttributes_Circle_Rule" description="ArcRuleAttributes" displayLabel="Circle Rule" priority="0"/>
+    <PropertyCategory typeName="ArcToElementRuleAttributes_Arc_To_Element_Rule" description="ArcToElementRuleAttributes" displayLabel="Arc To Element Rule" priority="0"/>
+    <PropertyCategory typeName="BackTaperAttributes_Back_Taper" description="BackTaperAttributes" displayLabel="Back Taper" priority="0"/>
+    <PropertyCategory typeName="BackTransitionAttributes_Back_Transition" description="BackTransitionAttributes" displayLabel="Back Transition" priority="0"/>
+    <PropertyCategory typeName="BestFitHorizontalRuleParamAttributes_Best_Fit_Parameters" description="BestFitHorizontalRuleParamAttributes" displayLabel="Best Fit Parameters" priority="0"/>
+    <PropertyCategory typeName="BestFitProfileRuleParamAttributes_Best_Fit_Parameters" description="BestFitProfileRuleParamAttributes" displayLabel="Best Fit Parameters" priority="0"/>
+    <PropertyCategory typeName="chamferBetweenElementsRuleAttributes_Chamfer_Between_Elements_Rule" description="chamferBetweenElementsRuleAttributes" displayLabel="Chamfer Between Elements Rule" priority="0"/>
+    <PropertyCategory typeName="ComplexDTMEntityDefinitionAttributes_Complex_Terrain_Model_Definition" description="ComplexDTMEntityDefinitionAttributes" displayLabel="Complex Terrain Model Definition" priority="0"/>
+    <PropertyCategory typeName="ConicSlope_ConicSlope" description="ConicSlope" displayLabel="ConicSlope" priority="199800"/>
+    <PropertyCategory typeName="Culvert_CulvertRule" description="Culvert" displayLabel="CulvertRule" priority="199800"/>
+    <PropertyCategory typeName="Design_Standard_Rule_Attributes_Design_Standard_To_Linear_Element_Rule" description="Design Standard Rule Attributes" displayLabel="Design Standard To Linear Element Rule" priority="299999"/>
+    <PropertyCategory typeName="DistanceMonitorDefinition_General_Category" description="DistanceMonitorDefinition" displayLabel="General Category" priority="0"/>
+    <PropertyCategory typeName="DTMEntityByClippedDTMEntityRuleAttributes_Clipping" description="DTMEntityByClippedDTMEntityRuleAttributes" displayLabel="Clipping" priority="0"/>
+    <PropertyCategory typeName="DTMEntityByDTMEntityRuleAttributes_Delta_Plane" description="DTMEntityByDTMEntityRuleAttributes" displayLabel="Delta Plane" priority="0"/>
+    <PropertyCategory typeName="DTMEntityByDTMEntityRuleAttributes_Delta_Terrain_Model" description="DTMEntityByDTMEntityRuleAttributes" displayLabel="Delta Terrain Model" priority="0"/>
+    <PropertyCategory typeName="DTMEntityToDTMEntityAssociatorRuleAttributes_AssociationCategory" description="DTMEntityToDTMEntityAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="DTMEntityVolumeByDTMEntitiesRuleAttributes_DTMEntityByDTMEntitiesVolumeDefinition" description="DTMEntityVolumeByDTMEntitiesRuleAttributes" displayLabel="&lt;- DTMEntityByDTMEntitiesVolumeDefinition -&gt;" priority="0"/>
+    <PropertyCategory typeName="DTMEntityVolumeByPlaneRuleAttributes_DTMEntityVolumeByPlaneRuleDefinition" description="DTMEntityVolumeByPlaneRuleAttributes" displayLabel="&lt;- DTMEntityVolumeByPlaneRuleDefinition -&gt;" priority="0"/>
+    <PropertyCategory typeName="DTMMeshByDTMEntityTemplateRuleAttributes_Mesh_Template" description="DTMMeshByDTMEntityTemplateRuleAttributes" displayLabel="Mesh Template" priority="299999"/>
+    <PropertyCategory typeName="DTMPondRuleAttributes_Pond_Definition" description="DTMPondRuleAttributes" displayLabel="Pond Definition" priority="0"/>
+    <PropertyCategory typeName="EqualSpacePointAlongElementRuleAttributes_Equal_Space_Point_Along_Element_Rule" description="EqualSpacePointAlongElementRuleAttributes" displayLabel="Equal Space Point Along Element Rule" priority="0"/>
+    <PropertyCategory typeName="EqualSpacePointRuleAttributes_Equal_Space_Point_Rule" description="EqualSpacePointRuleAttributes" displayLabel="Equal Space Point Rule" priority="0"/>
+    <PropertyCategory typeName="FilletRuleAttributes_Fillet_Rule" description="FilletRuleAttributes" displayLabel="Fillet Rule" priority="0"/>
+    <PropertyCategory typeName="GeometryAttributes_Geometry" description="GeometryAttributes" displayLabel="Geometry" priority="300000"/>
+    <PropertyCategory typeName="GeometryPointsCategoryAttributes_Geometry_Points" description="GeometryPointsCategoryAttributes" displayLabel="Geometry Points" priority="4294967096"/>
+    <PropertyCategory typeName="GeometryPointsConstraintsCategoryAttributes_Point_Constraints" description="GeometryPointsConstraintsCategoryAttributes" displayLabel="Point Constraints" priority="4294967096"/>
+    <PropertyCategory typeName="lineBetweenElementsRuleAttributes_Line_Between_Elements_Rule" description="lineBetweenElementsRuleAttributes" displayLabel="Line Between Elements Rule" priority="0"/>
+    <PropertyCategory typeName="LineFromElementRuleAttributes_Line_From_Element_Rule" description="LineFromElementRuleAttributes" displayLabel="Line From Element Rule" priority="0"/>
+    <PropertyCategory typeName="LinElemToLinElemStartEndDistanceRuleAttributes_Station_Range" description="LinElemToLinElemStartEndDistanceRuleAttributes" displayLabel="Station Range" priority="0"/>
+    <PropertyCategory typeName="LinElemToLinElemVariableOffsetRuleAttributes_Transition_Offset_Rule" description="LinElemToLinElemVariableOffsetRuleAttributes" displayLabel="Transition Offset Rule" priority="0"/>
+    <PropertyCategory typeName="LinEnt3dByDTMEntityTraceRule_Linear3d_ByTerrain_Trace_Rule" description="LinEnt3dByDTMEntityTraceRule" displayLabel="Linear3d ByTerrain Trace Rule" priority="0"/>
+    <PropertyCategory typeName="LinEnt3dByDTMEntityTraceRule_LinEnt3dByDTMEntityTraceRule" description="LinEnt3dByDTMEntityTraceRule" displayLabel="&lt;- LinEnt3dByDTMEntityTraceRule -&gt;" priority="0"/>
+    <PropertyCategory typeName="LinEnt3dByLinEnt3dRangeRuleAttributes_Station_Range" description="LinEnt3dByLinEnt3dRangeRuleAttributes" displayLabel="Station Range" priority="0"/>
+    <PropertyCategory typeName="LinEnt3dByPlanProfileRangeRuleAttributes_Station_Range" description="LinEnt3dByPlanProfileRangeRuleAttributes" displayLabel="Station Range" priority="0"/>
+    <PropertyCategory typeName="LinEnt3dByVolumeRuleAttributes_3D_Linear_by_Volume" description="LinEnt3dByVolumeRuleAttributes" displayLabel="3D Linear by Volume" priority="0"/>
+    <PropertyCategory typeName="LinEnt3dByVolumeRuleAttributes_Linear3d_by_Volume" description="LinEnt3dByVolumeRuleAttributes" displayLabel="Linear3d by Volume" priority="0"/>
+    <PropertyCategory typeName="LinEntityToLinEntityAssociatorRuleAttributes_AssociationCategory" description="LinEntityToLinEntityAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="LineSegmentRuleAttributes_Line_Between_Points_Rule" description="LineSegmentRuleAttributes" displayLabel="Line Between Points Rule" priority="0"/>
+    <PropertyCategory typeName="LineToElementRuleAttributes_Line_To_Element_Rule" description="LineToElementRuleAttributes" displayLabel="Line To Element Rule" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_LinElemToLinElemVariableOffsetRule_Presentation" description="Miscellaneous" displayLabel="LinElemToLinElemVariableOffsetRule_Presentation" priority="0"/>
+    <PropertyCategory typeName="Miscellaneous_Transition_Offset_Rule" description="Miscellaneous" displayLabel="Transition Offset Rule" priority="0"/>
+    <PropertyCategory typeName="Pnt2dToLinElemAssociatorRuleAttributes_AssociationCategory" description="Pnt2dToLinElemAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="Pnt2dToPnt2dAssociatorRuleAttributes_AssociationCategory" description="Pnt2dToPnt2dAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="Pnt3dToDTMElementAssociatorRuleAttributes_AssociationCategory" description="Pnt3dToDTMElementAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="Pnt3dToPnt3dAssociatorRuleAttributes_AssociationCategory" description="Pnt3dToPnt3dAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="PondAnalysisAttributes_Pond_Analysis" description="PondAnalysisAttributes" displayLabel="Pond Analysis" priority="0"/>
+    <PropertyCategory typeName="PondRuleAttributes_Pond_Rule" description="PondRuleAttributes" displayLabel="Pond Rule" priority="0"/>
+    <PropertyCategory typeName="Portal_Portal" description="Portal" displayLabel="Portal" priority="199800"/>
+    <PropertyCategory typeName="ProfileBy2LinearEnt3dTransitionRuleAttributes_Profile_By_Two_3D_Element_Transition_Rule" description="ProfileBy2LinearEnt3dTransitionRuleAttributes" displayLabel="Profile By Two 3D Element Transition Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileBy2LinearEnt3dTransitionRuleAttributes_Profile_By_Two_LinEnt3d_Transition_Rule" description="ProfileBy2LinearEnt3dTransitionRuleAttributes" displayLabel="Profile By Two LinEnt3d Transition Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByDTMOffsetRuleAttributes_Profile_From_Surface_Rule" description="ProfileByDTMOffsetRuleAttributes" displayLabel="Profile From Surface Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByPnt3dSlopeRuleAttributes_Profile_By_3D_Point_Slope_Rule" description="ProfileByPnt3dSlopeRuleAttributes" displayLabel="Profile By 3D Point Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByPnt3dSlopeRuleAttributes_Profile_By_Pnt3d_Slope_Rule" description="ProfileByPnt3dSlopeRuleAttributes" displayLabel="Profile By Pnt3d Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_Profile_By_Projecting_Element_Slope_Rule" description="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes" displayLabel="Profile By Projecting Element Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes_ProfileByProjectingLinEnt3dComplexSlopeRule" description="ProfileByProjectingLinEnt3dComplexSlopeRuleAttributes" displayLabel="&lt;- ProfileByProjectingLinEnt3dComplexSlopeRule -&gt;" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dRuleAttributes_Profile_By_Projecting_3D_Element_Rule" description="ProfileByProjectingLinEnt3dRuleAttributes" displayLabel="Profile By Projecting 3D Element Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dRuleAttributes_Profile_By_Projecting_LinEnt3d_Rule" description="ProfileByProjectingLinEnt3dRuleAttributes" displayLabel="Profile By Projecting LinEnt3d Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Simple_Slope_Rule" description="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes" displayLabel="Profile By Projecting 3D Element Simple Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes_Profile_By_Projecting_LinEnt3d_Simple_Slope_Rule" description="ProfileByProjectingLinEnt3dSimpleSlopeRuleAttributes" displayLabel="Profile By Projecting LinEnt3d Simple Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_3D_Element_Slope_Rule" description="ProfileByProjectingLinEnt3dSlopeRuleAttributes" displayLabel="Profile By Projecting 3D Element Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileByProjectingLinEnt3dSlopeRuleAttributes_Profile_By_Projecting_LinEnt3d_Slope_Rule" description="ProfileByProjectingLinEnt3dSlopeRuleAttributes" displayLabel="Profile By Projecting LinEnt3d Slope Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileCurveBetweenElementsRuleAttributes_Profile_Curve_Between_Elements_Rule" description="ProfileCurveBetweenElementsRuleAttributes" displayLabel="Profile Curve Between Elements Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileCurveFromElementRuleAttributes_Profile_Curve_From_Element_Rule" description="ProfileCurveFromElementRuleAttributes" displayLabel="Profile Curve From Element Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileCurveRuleAttributes_Profile_Curve_Rule" description="ProfileCurveRuleAttributes" displayLabel="Profile Curve Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileCurveToElementRuleAttributes_Profile_Curve_To_Element_Rule" description="ProfileCurveToElementRuleAttributes" displayLabel="Profile Curve To Element Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileElemToProfileElemVariableOffsetRuleAttributes_Profile_Offset_Rule" description="ProfileElemToProfileElemVariableOffsetRuleAttributes" displayLabel="Profile Offset Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileEntityToProfileEntityAssociatorRuleAttributes_AssociationCategory" description="ProfileEntityToProfileEntityAssociatorRuleAttributes" displayLabel="&lt;- AssociationCategory -&gt;" priority="0"/>
+    <PropertyCategory typeName="ProfileLineBetweenElementsRuleAttributes_Profile_Line_Between_Curves_Rule" description="ProfileLineBetweenElementsRuleAttributes" displayLabel="Profile Line Between Curves Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileLineFromElementRuleAttributes_Profile_Line_From_Element_Rule" description="ProfileLineFromElementRuleAttributes" displayLabel="Profile Line From Element Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileLineSegmentRuleAttributes_Profile_Line_Between_Points_Rule" description="ProfileLineSegmentRuleAttributes" displayLabel="Profile Line Between Points Rule" priority="0"/>
+    <PropertyCategory typeName="ProfileLineToElementRuleAttributes_Profile_Line_To_Element_Rule" description="ProfileLineToElementRuleAttributes" displayLabel="Profile Line To Element Rule" priority="0"/>
+    <PropertyCategory typeName="ProfilePointbyStationDeltaElevationRuleAttributes_ProfilePointbyStationDeltaElevationDefinition" description="ProfilePointbyStationDeltaElevationRuleAttributes" displayLabel="&lt;- ProfilePointbyStationDeltaElevationDefinition -&gt;" priority="0"/>
+    <PropertyCategory typeName="ProfilePointbyStationElevationRuleAttributes_ProfilePointbyStationElevationDefinition" description="ProfilePointbyStationElevationRuleAttributes" displayLabel="&lt;- ProfilePointbyStationElevationDefinition -&gt;" priority="0"/>
+    <PropertyCategory typeName="ProfilePointbyStationProfileOffsetRuleAttributes_ProfilePointbyStationProfileOffsetDefinition" description="ProfilePointbyStationProfileOffsetRuleAttributes" displayLabel="&lt;- ProfilePointbyStationProfileOffsetDefinition -&gt;" priority="0"/>
+    <PropertyCategory typeName="ProfilePointbyStationSlopeRuleAttributes_ProfilePointbyStationSlopeDefinition" description="ProfilePointbyStationSlopeRuleAttributes" displayLabel="&lt;- ProfilePointbyStationSlopeDefinition -&gt;" priority="0"/>
+    <PropertyCategory typeName="ProfileReverseTransitionRuleAttributes_Profile_Reverse_Transition_Rule" description="ProfileReverseTransitionRuleAttributes" displayLabel="Profile Reverse Transition Rule" priority="0"/>
+    <PropertyCategory typeName="ProjectExtendedProfileRuleAttributes_Project_Extended_Profile_Rule" description="ProjectExtendedProfileRuleAttributes" displayLabel="Project Extended Profile Rule" priority="0"/>
+    <PropertyCategory typeName="ProjectExtendedProfileRuleAttributes_ProjectExtendedProfileRule" description="ProjectExtendedProfileRuleAttributes" displayLabel="&lt;- ProjectExtendedProfileRule -&gt;" priority="0"/>
+    <PropertyCategory typeName="ReverseTransitionRuleAttributes_Reverse_Transition_Rule" description="ReverseTransitionRuleAttributes" displayLabel="Reverse Transition Rule" priority="0"/>
+    <PropertyCategory typeName="SideSlopeRuleAttributes_Side_Slope_Parameters" description="SideSlopeRuleAttributes" displayLabel="Side Slope Parameters" priority="0"/>
+    <PropertyCategory typeName="SightVisibility_Sight_Visibility" description="SightVisibility" displayLabel="Sight Visibility" priority="199800"/>
+    <PropertyCategory typeName="SlopeMonitorDefinition_General_Category" description="SlopeMonitorDefinition" displayLabel="General Category" priority="0"/>
+    <PropertyCategory typeName="SpiralBetweenElementsRuleAttributes_Spiral_Between_Elements_Rule" description="SpiralBetweenElementsRuleAttributes" displayLabel="Spiral Between Elements Rule" priority="0"/>
+    <PropertyCategory typeName="SpiralFromElementRuleAttributes_Spiral_From_Element_Rule" description="SpiralFromElementRuleAttributes" displayLabel="Spiral From Element Rule" priority="0"/>
+    <PropertyCategory typeName="StrokingDefinition_Stroking_Definition" description="StrokingDefinition" displayLabel="Stroking Definition" priority="0"/>
+    <PropertyCategory typeName="Superelevation_Superelevation" description="Superelevation" displayLabel="Superelevation" priority="199800"/>
+    <PropertyCategory typeName="SuperElevationControlLine_Control_Line" description="SuperElevationControlLine" displayLabel="Control Line" priority="199700"/>
+    <PropertyCategory typeName="SuperElevationHighSide_High_Side" description="SuperElevationHighSide" displayLabel="High Side" priority="199600"/>
+    <PropertyCategory typeName="SuperElevationLowSide_Low_Side" description="SuperElevationLowSide" displayLabel="Low Side" priority="199500"/>
+    <PropertyCategory typeName="SuperElevationSection_Superelevation_Section" description="SuperElevationSection" displayLabel="Superelevation Section" priority="199800"/>
+    <PropertyCategory typeName="TraceSlopeRuleAttributes_Trace_Slope_Rule" description="TraceSlopeRuleAttributes" displayLabel="Trace Slope Rule" priority="0"/>
+    <PropertyCategory typeName="WatershedRuleAttributes_Watershed_Definition" description="WatershedRuleAttributes" displayLabel="Watershed Definition" priority="0"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifHydraulicAnalysis.01.00.05.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifHydraulicAnalysis.01.00.05.ecschema.xml
@@ -1,0 +1,4896 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifHydraulicAnalysis" alias="cifhydan" version="01.00.05" description="iModel Connector schema containing aspect classes with input properties from the Subsurface Utilities Design and Analysis module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.02" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="BasePump_InitialSettingsAspect_PumpStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="On" value="0" displayLabel="On"/>
+        <ECEnumerator name="Off" value="1" displayLabel="Off"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BoundaryLine2D_SurfaceAspect_BoundaryFlowType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Hydrograph" value="2" displayLabel="Hydrograph"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BoundaryLine2D_SurfaceAspect_SurfaceBoundaryElevationType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Time_Elevation_Curve" value="2" displayLabel="Time-Elevation Curve"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BoundaryLine2D_SurfaceAspect_SurfaceBoundaryType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Flow" value="0" displayLabel="Flow"/>
+        <ECEnumerator name="Elevation" value="1" displayLabel="Elevation"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BoundaryPoint2D_SurfaceAspect_BoundaryFlowType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Hydrograph" value="2" displayLabel="Hydrograph"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CatchBasin_Physical_GutterShapeAspect_GutterShape_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Conventional" value="0" displayLabel="Conventional"/>
+        <ECEnumerator name="Trapezoidal" value="1" displayLabel="Trapezoidal"/>
+        <ECEnumerator name="Irregular" value="2" displayLabel="Irregular"/>
+        <ECEnumerator name="Parabolic" value="3" displayLabel="Parabolic"/>
+        <ECEnumerator name="V_Shaped" value="4" displayLabel="V-Shaped"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CatchBasin_Physical_InletGutterTypeAspect_InletGutterType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined" value="0" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog_Gutter" value="1" displayLabel="Catalog Gutter"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CatchBasin_Physical_InletLocationAspect_InletLocation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="On_Grade" value="0" displayLabel="On Grade"/>
+        <ECEnumerator name="In_Sag" value="1" displayLabel="In Sag"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CatchBasin_Physical_InletTypeAspect_InletType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Maximum_Capacity" value="0" displayLabel="Maximum Capacity"/>
+        <ECEnumerator name="Inflow_Capture_Curve" value="1" displayLabel="Inflow-Capture Curve"/>
+        <ECEnumerator name="Full_Capture" value="2" displayLabel="Full Capture"/>
+        <ECEnumerator name="Catalog_Inlet" value="3" displayLabel="Catalog Inlet"/>
+        <ECEnumerator name="Percent_Capture" value="4" displayLabel="Percent Capture"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CatchBasin_PhysicalAspect_Physical_GratingType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="P" value="0" displayLabel="P"/>
+        <ECEnumerator name="Q" value="1" displayLabel="Q"/>
+        <ECEnumerator name="R" value="2" displayLabel="R"/>
+        <ECEnumerator name="S" value="3" displayLabel="S"/>
+        <ECEnumerator name="T" value="4" displayLabel="T"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationAspect_Hydrologic_GwBottomElevationUseAquiferData_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Aquifer_Data" value="0" displayLabel="Use Aquifer Data"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeAspect_Hydrologic_GwHcbUseReceivingNodeInvert_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Receiving_Node_Invert_Elevation" value="0" displayLabel="Use Receiving Node Invert Elevation"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureAspect_Hydrologic_GwUnsatZoneMoistureUseAquiferData_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Aquifer_Data" value="0" displayLabel="Use Aquifer Data"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationAspect_Hydrologic_GwWaterTableElevationUseAquiferData_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Aquifer_Data" value="0" displayLabel="Use Aquifer Data"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_LossMethodTypeAspect_LossMethodType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant_Loss_Rate" value="0" displayLabel="Constant Loss Rate"/>
+        <ECEnumerator name="Green_and_Ampt" value="1" displayLabel="Green and Ampt"/>
+        <ECEnumerator name="SCS_CN" value="2" displayLabel="SCS CN"/>
+        <ECEnumerator name="Horton" value="3" displayLabel="Horton"/>
+        <ECEnumerator name="None" value="4" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="Initial_Loss_and_Constant_Loss_Rate" value="8" displayLabel="Initial Loss and Constant Loss Rate"/>
+        <ECEnumerator name="Initial_Loss_and_Constant_Fraction" value="9" displayLabel="Initial Loss and Constant Fraction"/>
+        <ECEnumerator name="Runoff_Coefficient" value="10" displayLabel="Runoff Coefficient"/>
+        <ECEnumerator name="Green_and_Ampt_Modified" value="11" displayLabel="Green and Ampt (Modified)"/>
+        <ECEnumerator name="Horton_Modified" value="12" displayLabel="Horton (Modified)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_RunoffMethod_EpaSwmmAspect_SubareaRouting_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pervious_To_Impervious" value="0" displayLabel="Pervious To Impervious"/>
+        <ECEnumerator name="Impervious_To_Pervious" value="1" displayLabel="Impervious To Pervious"/>
+        <ECEnumerator name="Both_to_Outlet" value="2" displayLabel="Both to Outlet"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_RunoffMethod_ILSAXMethodAspect_ILSAXPerviousCoverDefinitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pre_defined" value="1" displayLabel="Pre-defined"/>
+        <ECEnumerator name="User_Defined" value="2" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_RunoffMethod_ScsUnitHydrographAspect_ScsUnitHydrographMethodType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Default_Curvilinear" value="0" displayLabel="Default Curvilinear"/>
+        <ECEnumerator name="Triangular" value="1" displayLabel="Triangular"/>
+        <ECEnumerator name="Dimensionless_Unit_Hydrograph" value="2" displayLabel="Dimensionless Unit Hydrograph"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_RunoffMethod_TimeAreaMethodAspect_TimeAreaMethodType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined" value="0" displayLabel="User-Defined"/>
+        <ECEnumerator name="Linear" value="1" displayLabel="Linear"/>
+        <ECEnumerator name="Synthetic_Curve_HEC_1" value="2" displayLabel="Synthetic Curve (HEC-1)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_RunoffMethod_UnitHydrographAspect_UnitHydrographMethodType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Generic_Unit_Hydrograph" value="0" displayLabel="Generic Unit Hydrograph"/>
+        <ECEnumerator name="SCS_Unit_Hydrograph" value="1" displayLabel="SCS Unit Hydrograph"/>
+        <ECEnumerator name="RTK_Unit_Hydrograph" value="2" displayLabel="RTK Unit Hydrograph"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_Hydrologic_RunoffMethodTypeAspect_RunoffMethodType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Unit_Hydrograph" value="0" displayLabel="Unit Hydrograph"/>
+        <ECEnumerator name="EPA_SWMM_Runoff" value="1" displayLabel="EPA-SWMM Runoff"/>
+        <ECEnumerator name="User_Defined_Hydrograph" value="2" displayLabel="User Defined Hydrograph"/>
+        <ECEnumerator name="None" value="3" displayLabel="None"/>
+        <ECEnumerator name="Modified_Rational" value="5" displayLabel="Modified Rational"/>
+        <ECEnumerator name="Rational_Method" value="4" displayLabel="Rational Method"/>
+        <ECEnumerator name="Time_Area" value="6" displayLabel="Time-Area"/>
+        <ECEnumerator name="ILSAX" value="7" displayLabel="ILSAX"/>
+        <ECEnumerator name="Modified_Rational_United_Kingdom" value="1005" displayLabel="Modified Rational (United Kingdom)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_HydrologicAspect_AreaDefinitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Single_Area" value="0" displayLabel="Single Area"/>
+        <ECEnumerator name="Multiple_Subareas" value="1" displayLabel="Multiple Subareas"/>
+        <ECEnumerator name="Land_Cover_Areas" value="2" displayLabel="Land Cover Areas"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_HydrologicAspect_Hydrologic_GwEquationUnitSystem_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="US_Customary" value="2" displayLabel="US Customary"/>
+        <ECEnumerator name="SI" value="1" displayLabel="SI"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Catchment_HydrologicAspect_TcComputeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined_Tc" value="0" displayLabel="User Defined Tc"/>
+        <ECEnumerator name="Composite_Tc" value="1" displayLabel="Composite Tc"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Channel_OutputAspect_OutputOptionsType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Summary_Results" value="0" displayLabel="Summary Results"/>
+        <ECEnumerator name="Detailed_Results" value="1" displayLabel="Detailed Results"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Design_SpecifyLocalConstraint_TrueAspect_LocalMeasureCoverType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pipe_Soffit" value="0" displayLabel="Pipe Soffit"/>
+        <ECEnumerator name="Pipe_Crown" value="1" displayLabel="Pipe Crown"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_InfiltrationAndInflow_TypeAspect_InfiltrationLoadType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Pipe_Length" value="1" displayLabel="Pipe Length"/>
+        <ECEnumerator name="Pipe_Rise_Length" value="2" displayLabel="Pipe Rise-Length"/>
+        <ECEnumerator name="Pipe_Surface_Area" value="3" displayLabel="Pipe Surface Area"/>
+        <ECEnumerator name="Count_Based" value="4" displayLabel="Count Based"/>
+        <ECEnumerator name="Hydrograph" value="5" displayLabel="Hydrograph"/>
+        <ECEnumerator name="Pattern_Load" value="6" displayLabel="Pattern Load"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_OutputAspect_OutputOptionsType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Summary_Results" value="0" displayLabel="Summary Results"/>
+        <ECEnumerator name="Detailed_Results" value="1" displayLabel="Detailed Results"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Physical_ConduitTypeAspect_ConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined_Conduit" value="0" displayLabel="User Defined Conduit"/>
+        <ECEnumerator name="Catalog_Conduit" value="1" displayLabel="Catalog Conduit"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Physical_DiversionTypeAspect_DiversionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rating_Table" value="0" displayLabel="Rating Table"/>
+        <ECEnumerator name="Cutoff" value="1" displayLabel="Cutoff"/>
+        <ECEnumerator name="Capacity" value="2" displayLabel="Capacity"/>
+        <ECEnumerator name="Weir" value="3" displayLabel="Weir"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Physical_HasOvertoppingWeir_TrueAspect_OvertoppingWeir_RoadSurface_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Paved" value="0" displayLabel="Paved"/>
+        <ECEnumerator name="Gravel" value="1" displayLabel="Gravel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Physical_IsCulvertAspect_DownstreamEndwallDefinitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Stop_Node" value="0" displayLabel="Use Stop Node"/>
+        <ECEnumerator name="Use_Conduit" value="1" displayLabel="Use Conduit"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Physical_IsCulvertAspect_UpstreamHeadwallDefinitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Start_Node" value="0" displayLabel="Use Start Node"/>
+        <ECEnumerator name="Use_Conduit" value="1" displayLabel="Use Conduit"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Shape_ArchAspect_ArchDataType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Rise_and_Span" value="0" displayLabel="Rise and Span"/>
+        <ECEnumerator name="Standard_Arch_Code" value="1" displayLabel="Standard Arch Code"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Shape_EllipticalPipeAspect_EllipseOrientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Horizontal" value="0" displayLabel="Horizontal"/>
+        <ECEnumerator name="Vertical" value="1" displayLabel="Vertical"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_Shape_RectangularChannelAspect_RecSidewallRemove_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="One" value="1" displayLabel="One"/>
+        <ECEnumerator name="Both" value="2" displayLabel="Both"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Conduit_ShapeAspect_ConduitShape_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Irregular_Channel" value="0" displayLabel="Irregular Channel"/>
+        <ECEnumerator name="Trapezoidal_Channel" value="1" displayLabel="Trapezoidal Channel"/>
+        <ECEnumerator name="Circle" value="2" displayLabel="Circle"/>
+        <ECEnumerator name="Box" value="3" displayLabel="Box"/>
+        <ECEnumerator name="Basket_Handle" value="4" displayLabel="Basket-Handle"/>
+        <ECEnumerator name="Ellipse" value="5" displayLabel="Ellipse"/>
+        <ECEnumerator name="Horseshoe" value="6" displayLabel="Horseshoe"/>
+        <ECEnumerator name="Egg" value="7" displayLabel="Egg"/>
+        <ECEnumerator name="Semi_Ellipse" value="8" displayLabel="Semi-Ellipse"/>
+        <ECEnumerator name="Pipe_Arch" value="10" displayLabel="Pipe-Arch"/>
+        <ECEnumerator name="Semi_Circle" value="12" displayLabel="Semi-Circle"/>
+        <ECEnumerator name="Catenary" value="13" displayLabel="Catenary"/>
+        <ECEnumerator name="Gothic" value="14" displayLabel="Gothic"/>
+        <ECEnumerator name="Modified_Basket_Handle" value="15" displayLabel="Modified Basket-Handle"/>
+        <ECEnumerator name="Rectangular_Round" value="16" displayLabel="Rectangular-Round"/>
+        <ECEnumerator name="Rectangular_Triangle" value="17" displayLabel="Rectangular-Triangle"/>
+        <ECEnumerator name="Power_Channel" value="18" displayLabel="Power Channel"/>
+        <ECEnumerator name="Parabolic_Channel" value="19" displayLabel="Parabolic Channel"/>
+        <ECEnumerator name="Triangular_Channel" value="20" displayLabel="Triangular Channel"/>
+        <ECEnumerator name="Rectangular_Channel" value="21" displayLabel="Rectangular Channel"/>
+        <ECEnumerator name="Irregular_Closed_Section" value="22" displayLabel="Irregular Closed Section"/>
+        <ECEnumerator name="Virtual" value="11" displayLabel="Virtual"/>
+        <ECEnumerator name="Arch" value="30" displayLabel="Arch"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ConduitCxRoughness_PhysicalAspect_RoughnessType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Single_Roughness" value="0" displayLabel="Single Roughness"/>
+        <ECEnumerator name="Roughness_Depth" value="1" displayLabel="Roughness Depth"/>
+        <ECEnumerator name="Roughness_Flow" value="2" displayLabel="Roughness Flow"/>
+        <ECEnumerator name="Horizontal_Segment" value="3" displayLabel="Horizontal Segment"/>
+        <ECEnumerator name="Bank_Channel" value="4" displayLabel="Bank Channel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossSectionNode_PhysicalAspect_CrossSectionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined" value="0" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog_Cross_Section" value="1" displayLabel="Catalog Cross Section"/>
+        <ECEnumerator name="From_Surface" value="2" displayLabel="From Surface"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossSectionNode_PhysicalAspect_TransitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Gradual" value="0" displayLabel="Gradual"/>
+        <ECEnumerator name="Abrupt" value="1" displayLabel="Abrupt"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CxPhysical_CxDataTypeAspect_CxDataType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Trapezoidal_Cross_Section" value="0" displayLabel="Trapezoidal Cross Section"/>
+        <ECEnumerator name="Irregular_Channel" value="1" displayLabel="Irregular Channel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravityNode_Design_LocalPipeMatchingConstraints_TrueAspect_LocalPipeMatching_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inverts" value="0" displayLabel="Inverts"/>
+        <ECEnumerator name="Crowns" value="1" displayLabel="Crowns"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravityStructure_Headloss_AashtoAspect_AashtoShapingMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Full" value="1" displayLabel="Full"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravityStructure_Headloss_Hec22EnergyBaseAspect_Hec22BenchingMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Depressed" value="0" displayLabel="Depressed"/>
+        <ECEnumerator name="Flat" value="1" displayLabel="Flat"/>
+        <ECEnumerator name="Half" value="2" displayLabel="Half"/>
+        <ECEnumerator name="Full" value="3" displayLabel="Full"/>
+        <ECEnumerator name="Improved" value="4" displayLabel="Improved"/>
+        <ECEnumerator name="None" value="5" displayLabel="None"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravityStructure_HeadlossAspect_HeadlossMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Absolute" value="0" displayLabel="Absolute"/>
+        <ECEnumerator name="HEC_22_Energy_Second_Edition" value="1" displayLabel="HEC-22 Energy (Second Edition)"/>
+        <ECEnumerator name="Generic" value="2" displayLabel="Generic"/>
+        <ECEnumerator name="Standard" value="3" displayLabel="Standard"/>
+        <ECEnumerator name="AASHTO" value="4" displayLabel="AASHTO"/>
+        <ECEnumerator name="Flow_Headloss_Curve" value="5" displayLabel="Flow-Headloss Curve"/>
+        <ECEnumerator name="HEC_22_Energy_Third_Edition" value="7" displayLabel="HEC-22 Energy (Third Edition)"/>
+        <ECEnumerator name="HEC_22_Minor_Loss" value="8" displayLabel="HEC-22 Minor Loss"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravitySurfaceStructure_Physical_GravityStructureTypeAspect_GravityStructureType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Circular_Structure" value="0" displayLabel="Circular Structure"/>
+        <ECEnumerator name="Box_Structure" value="1" displayLabel="Box Structure"/>
+        <ECEnumerator name="Transition_Node" value="2" displayLabel="Transition Node"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect_SurfaceStorageType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Default_Storage_Equation" value="0" displayLabel="Default Storage Equation"/>
+        <ECEnumerator name="Surface_Depth_Area_Curve" value="1" displayLabel="Surface Depth-Area Curve"/>
+        <ECEnumerator name="No_Storage" value="2" displayLabel="No Storage"/>
+        <ECEnumerator name="Ponded_Area" value="3" displayLabel="Ponded Area"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GravitySurfaceStructure_PhysicalAspect_GridRimElevationMatching_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Adjust_Grid_To_Rim" value="0" displayLabel="Adjust Grid To Rim"/>
+        <ECEnumerator name="Adjust_Rim_To_Grid" value="1" displayLabel="Adjust Rim To Grid"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Grid2D_BoundaryConditionAspect_GridBoundaryType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Closed" value="0" displayLabel="Closed"/>
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Grid2D_InitialSettingsAspect_GridInitialValuesType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Depth" value="1" displayLabel="Depth"/>
+        <ECEnumerator name="Elevation" value="2" displayLabel="Elevation"/>
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Grid2D_SurfaceAspect_GridSurfaceInfiltrationMode_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="SCS_CN" value="1" displayLabel="SCS CN"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GutterLink_PhysicalAspect_GutterLinkGutterType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined" value="0" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog_Gutter" value="1" displayLabel="Catalog Gutter"/>
+        <ECEnumerator name="Same_as_Start_Node" value="2" displayLabel="Same as Start Node"/>
+        <ECEnumerator name="Use_Gutter_Sections" value="4" displayLabel="Use Gutter Sections"/>
+        <ECEnumerator name="Same_as_Stop_Node" value="3" displayLabel="Same as Stop Node"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GutterLink_PhysicalAspect_GutterShape_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Conventional" value="0" displayLabel="Conventional"/>
+        <ECEnumerator name="Trapezoidal" value="1" displayLabel="Trapezoidal"/>
+        <ECEnumerator name="Irregular" value="2" displayLabel="Irregular"/>
+        <ECEnumerator name="Parabolic" value="3" displayLabel="Parabolic"/>
+        <ECEnumerator name="V_Shaped" value="4" displayLabel="V-Shaped"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Headwall_BoundaryConditionAspect_BoundaryConditionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Free_Outfall" value="0" displayLabel="Free Outfall"/>
+        <ECEnumerator name="Time_Elevation_Curve" value="1" displayLabel="Time-Elevation Curve"/>
+        <ECEnumerator name="User_Defined_Tailwater" value="2" displayLabel="User Defined Tailwater"/>
+        <ECEnumerator name="Elevation_Flow_Curve" value="3" displayLabel="Elevation-Flow Curve"/>
+        <ECEnumerator name="Boundary_Element" value="4" displayLabel="Boundary Element"/>
+        <ECEnumerator name="Normal" value="5" displayLabel="Normal"/>
+        <ECEnumerator name="Tidal" value="6" displayLabel="Tidal"/>
+        <ECEnumerator name="Crown" value="10" displayLabel="Crown"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Headwall_DesignAspect_LocalPipeMatching_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inverts" value="0" displayLabel="Inverts"/>
+        <ECEnumerator name="Crowns" value="1" displayLabel="Crowns"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Headwall_PhysicalAspect_CrossSectionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="User_Defined" value="0" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog_Cross_Section" value="1" displayLabel="Catalog Cross Section"/>
+        <ECEnumerator name="From_Surface" value="2" displayLabel="From Surface"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Headwall_PhysicalAspect_TransitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Gradual" value="0" displayLabel="Gradual"/>
+        <ECEnumerator name="Abrupt" value="1" displayLabel="Abrupt"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="IrregularChannel_PhysicalAspect_OpenChannelWeightingMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pavlovskii_Method" value="0" displayLabel="Pavlovskii Method"/>
+        <ECEnumerator name="Horton_Method" value="1" displayLabel="Horton Method"/>
+        <ECEnumerator name="Colebatch_Method" value="2" displayLabel="Colebatch Method"/>
+        <ECEnumerator name="Cox_Method" value="3" displayLabel="Cox Method"/>
+        <ECEnumerator name="Lotter_Method" value="4" displayLabel="Lotter Method"/>
+        <ECEnumerator name="Improved_Lotter_Method" value="5" displayLabel="Improved Lotter Method"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="LID_OutputAspect_OutputOptionsType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Summary_Results" value="0" displayLabel="Summary Results"/>
+        <ECEnumerator name="Detailed_Results" value="1" displayLabel="Detailed Results"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Node_WaterQuality_TrueAspect_TreatmentUnits_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="US_Units___CFS__ft__sq_ft" value="27" displayLabel="US Units - CFS, ft, sq.ft"/>
+        <ECEnumerator name="US_Units___GPM__ft__sq_ft" value="84" displayLabel="US Units - GPM, ft, sq.ft"/>
+        <ECEnumerator name="US_Units___MGD__ft__sq_ft" value="158" displayLabel="US Units - MGD, ft, sq.ft"/>
+        <ECEnumerator name="SI_Units___CMS__m__sq_m" value="48" displayLabel="SI Units - CMS, m, sq.m"/>
+        <ECEnumerator name="SI_Units___LPS__m__sq_m" value="141" displayLabel="SI Units - LPS, m, sq.m"/>
+        <ECEnumerator name="SI_Units___MLD__m__sq_m" value="275" displayLabel="SI Units - MLD, m, sq.m"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Outfall_BoundaryConditionAspect_BoundaryConditionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Free_Outfall" value="0" displayLabel="Free Outfall"/>
+        <ECEnumerator name="Time_Elevation_Curve" value="1" displayLabel="Time-Elevation Curve"/>
+        <ECEnumerator name="User_Defined_Tailwater" value="2" displayLabel="User Defined Tailwater"/>
+        <ECEnumerator name="Elevation_Flow_Curve" value="3" displayLabel="Elevation-Flow Curve"/>
+        <ECEnumerator name="Boundary_Element" value="4" displayLabel="Boundary Element"/>
+        <ECEnumerator name="Normal" value="5" displayLabel="Normal"/>
+        <ECEnumerator name="Tidal" value="6" displayLabel="Tidal"/>
+        <ECEnumerator name="Crown" value="10" displayLabel="Crown"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Pond_InitialSettingsAspect_StartingWSType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Invert" value="0" displayLabel="Invert"/>
+        <ECEnumerator name="User_Defined_Initial_Elevation" value="1" displayLabel="User Defined Initial Elevation"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Pond_Physical_InfiltrationMethodAspect_PondInfiltrationMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant_Flow" value="0" displayLabel="Constant Flow"/>
+        <ECEnumerator name="Average_Seepage" value="1" displayLabel="Average Seepage"/>
+        <ECEnumerator name="None" value="2" displayLabel="None"/>
+        <ECEnumerator name="Green_Ampt" value="3" displayLabel="Green Ampt"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Pond_Physical_VolumeTypeAspect_VolumeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Elevation_Area" value="0" displayLabel="Elevation-Area"/>
+        <ECEnumerator name="Elevation_Volume" value="1" displayLabel="Elevation-Volume"/>
+        <ECEnumerator name="Pipe_Volume" value="2" displayLabel="Pipe Volume"/>
+        <ECEnumerator name="Depth_ft_to_Area_sq__ft_function" value="3" displayLabel="Depth (ft) to Area (sq. ft) function"/>
+        <ECEnumerator name="Storage_Chamber_System" value="6" displayLabel="Storage Chamber System"/>
+        <ECEnumerator name="Depth_m_to_Area_sq__m_function" value="7" displayLabel="Depth (m) to Area (sq. m) function"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PondOutletStructure_PhysicalAspect_PondOutletDataType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Yes" value="0" displayLabel="Yes"/>
+        <ECEnumerator name="No" value="1" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="PressurePipe_InitialSettingsAspect_PipeStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Open" value="0" displayLabel="Open"/>
+        <ECEnumerator name="Closed" value="1" displayLabel="Closed"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ScadaElement_ScadaAspect_TargetAttribute_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="none" value="0" displayLabel="&lt;none&gt;"/>
+        <ECEnumerator name="Flow" value="-44" displayLabel="Flow"/>
+        <ECEnumerator name="Hydraulic_Grade_In" value="-45" displayLabel="Hydraulic Grade (From/Suction)"/>
+        <ECEnumerator name="Hydraulic_Grade_Out" value="-46" displayLabel="Hydraulic Grade (To/Discharge)"/>
+        <ECEnumerator name="Pressure_Suction" value="-47" displayLabel="Pressure (From/Suction)"/>
+        <ECEnumerator name="Pressure_Discharge" value="-48" displayLabel="Pressure (To/Discharge)"/>
+        <ECEnumerator name="Pressure" value="-54" displayLabel="Pressure"/>
+        <ECEnumerator name="Pipe_Status" value="-56" displayLabel="Pipe Status"/>
+        <ECEnumerator name="Pump_Status" value="-57" displayLabel="Pump Status"/>
+        <ECEnumerator name="Concentration" value="-299" displayLabel="Concentration"/>
+        <ECEnumerator name="Depth" value="1" displayLabel="Depth"/>
+        <ECEnumerator name="Depth_In" value="2" displayLabel="Depth (In)"/>
+        <ECEnumerator name="Depth_Out" value="3" displayLabel="Depth (Out)"/>
+        <ECEnumerator name="Velocity_In" value="4" displayLabel="Velocity (In)"/>
+        <ECEnumerator name="Velocity_Out" value="5" displayLabel="Velocity (Out)"/>
+        <ECEnumerator name="Relative_Speed_Factor" value="-52" displayLabel="Relative Speed Factor"/>
+        <ECEnumerator name="Water_Surface_Elevation" value="-7" displayLabel="Water Surface Elevation"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StandardPump_PhysicalAspect_VSPType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pattern_Based" value="0" displayLabel="Pattern Based"/>
+        <ECEnumerator name="Fixed_Head" value="1" displayLabel="Target Head"/>
+        <ECEnumerator name="Fixed_Flow" value="2" displayLabel="Fixed Flow"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfaceLine_SurfaceAspect_RoadElevationAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="SetTo" value="1" displayLabel="SetTo"/>
+        <ECEnumerator name="Add" value="2" displayLabel="Add"/>
+        <ECEnumerator name="Subtract" value="3" displayLabel="Subtract"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfaceLine_SurfaceAspect_SurfacePolylineCNAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfaceLine_SurfaceAspect_SurfacePolylineImpAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfaceLine_SurfaceAspect_SurfacePolylineManningsAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfaceLine_SurfaceAspect_SurfacePolylineType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Breakline" value="0" displayLabel="Breakline"/>
+        <ECEnumerator name="Road_Centerline" value="1" displayLabel="Road Centerline"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePoint_SurfaceAspect_SurfacePointElevationAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="Add" value="2" displayLabel="Add"/>
+        <ECEnumerator name="Subtract" value="3" displayLabel="Subtract"/>
+        <ECEnumerator name="Set" value="1" displayLabel="Set"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePoint_SurfaceAspect_SurfacePointType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Reporting_Point" value="0" displayLabel="Reporting Point"/>
+        <ECEnumerator name="Spot_Elevation" value="1" displayLabel="Spot Elevation"/>
+        <ECEnumerator name="Void" value="2" displayLabel="Void"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonCAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonCNAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonElevationAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="Set_To" value="1" displayLabel="Set To"/>
+        <ECEnumerator name="Add" value="2" displayLabel="Add"/>
+        <ECEnumerator name="Subtract" value="3" displayLabel="Subtract"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonImpAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonManningsAdjustmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="User_Defined" value="1" displayLabel="User Defined"/>
+        <ECEnumerator name="Catalog" value="2" displayLabel="Catalog"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonPriorityType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="ZeroTen_Lowest_Auto" value="0" displayLabel="0: Lowest/Auto"/>
+        <ECEnumerator name="One" value="1" displayLabel="1"/>
+        <ECEnumerator name="Two" value="2" displayLabel="2"/>
+        <ECEnumerator name="Three" value="3" displayLabel="3"/>
+        <ECEnumerator name="Four" value="4" displayLabel="4"/>
+        <ECEnumerator name="Five" value="5" displayLabel="5"/>
+        <ECEnumerator name="Six" value="6" displayLabel="6"/>
+        <ECEnumerator name="Seven" value="7" displayLabel="7"/>
+        <ECEnumerator name="Eight" value="8" displayLabel="8"/>
+        <ECEnumerator name="NineTen_Highest" value="9" displayLabel="9: Highest"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Void" value="3" displayLabel="Void"/>
+        <ECEnumerator name="Building" value="2" displayLabel="Building"/>
+        <ECEnumerator name="Land_Use" value="0" displayLabel="Land Use"/>
+        <ECEnumerator name="Adjustment_Area" value="1" displayLabel="Adjustment Area"/>
+        <ECEnumerator name="Road" value="4" displayLabel="Road"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TapNode_PhysicalAspect_TapConnectsAt_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Invert_To_Center" value="0" displayLabel="Invert To Center"/>
+        <ECEnumerator name="Invert_To_Soffit" value="1" displayLabel="Invert To Soffit"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WetWell_Physical_TankSectionAspect_TankSection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant_Area___Circular" value="0" displayLabel="Circular"/>
+        <ECEnumerator name="Constant_Area___Non_Circular" value="1" displayLabel="Non-Circular"/>
+        <ECEnumerator name="Variable_Volume" value="2" displayLabel="Variable Area"/>
+        <ECEnumerator name="Depth_Area" value="3" displayLabel="Depth Area"/>
+        <ECEnumerator name="Depth_ft_to_Area_sq__ft_function" value="4" displayLabel="Depth (ft) to Area (sq. ft) function"/>
+        <ECEnumerator name="Depth_m_to_Area_sq__m_function" value="5" displayLabel="Depth (m) to Area (sq. m) function"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WetWell_PhysicalAspect_OperatingRangeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Elevation" value="0" displayLabel="Elevation"/>
+        <ECEnumerator name="Level" value="1" displayLabel="Level"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="AirValve_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_TreatAirValveAsJunction" typeName="boolean" displayLabel="Treat Air Valve as Junction?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_AirValveElevation" typeName="double" displayLabel="Elevation" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GlobalBase_Washington_Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElementID" typeName="int" displayLabel="ID" category="General_Drainage_General_Drainage" priority="0"/>
+        <ECProperty propertyName="Label" typeName="string" displayLabel="Label" category="General_Drainage_General_Drainage" priority="0"/>
+        <ECProperty propertyName="Notes" typeName="string" displayLabel="Notes" category="General_Drainage_General_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNodeAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+        <ECProperty propertyName="BaselineFeature" typeName="string" displayLabel="Baseline Feature" category="References_Drainage_References_Drainage" priority="0"/>
+        <ECProperty propertyName="BaselineOffset" typeName="double" displayLabel="Baseline Offset" category="References_Drainage_References_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaselineStation" typeName="double" displayLabel="Baseline Station" category="References_Drainage_References_Drainage" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="ElevationReference" typeName="string" displayLabel="Elevation Reference" category="References_Drainage_References_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="AirValveAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseDirectedNode_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseDirectedNode_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_GroundElevation" typeName="double" displayLabel="Elevation (Ground)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_InvertElevation" typeName="double" displayLabel="Elevation (Invert)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseDirectedNodeAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIGeometryScaledLength" typeName="double" displayLabel="Length (Scaled)" category="Physical_Hydraulic_Analysis_Physical_Hydraulic_Analysis" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_HMIUserDefinedExtensionsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ConstructionLength" typeName="double" displayLabel="Length (Construction)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ConstructionSlope" typeName="double" displayLabel="Slope (Construction)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_PhysicalBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_IsUserDefinedLength" typeName="boolean" displayLabel="Has User Defined Length?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_Physical_UserDefinedLengthAspect">
+        <BaseClass>BaseLink_PhysicalBaseAspect</BaseClass>
+        <ECProperty propertyName="Physical_UserDefinedLength" typeName="double" displayLabel="Length (User Defined)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_PhysicalAspect">
+        <BaseClass>BaseLink_PhysicalBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLinkAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_Conduit1Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Conduit1Label" typeName="string" displayLabel="Conduit 1 Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit1SectionType" typeName="string" displayLabel="Conduit 1 Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit1Material" typeName="string" displayLabel="Conduit 1 Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit1Size" typeName="double" displayLabel="Conduit 1 Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Conduit1Invert" typeName="double" displayLabel="Conduit 1 Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Conduit1Angle" typeName="double" displayLabel="Conduit 1 Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_Conduit2Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Conduit2Label" typeName="string" displayLabel="Conduit 2 Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit2SectionType" typeName="string" displayLabel="Conduit 2 Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit2Material" typeName="string" displayLabel="Conduit 2 Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit2Size" typeName="double" displayLabel="Conduit 2 Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Conduit2Invert" typeName="double" displayLabel="Conduit 2 Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Conduit2Angle" typeName="double" displayLabel="Conduit 2 Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_Conduit3Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Conduit3Label" typeName="string" displayLabel="Conduit 3 Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit3SectionType" typeName="string" displayLabel="Conduit 3 Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit3Material" typeName="string" displayLabel="Conduit 3 Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit3Size" typeName="double" displayLabel="Conduit 3 Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Conduit3Invert" typeName="double" displayLabel="Conduit 3 Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Conduit3Angle" typeName="double" displayLabel="Conduit 3 Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_Conduit4Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Conduit4Label" typeName="string" displayLabel="Conduit 4 Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit4SectionType" typeName="string" displayLabel="Conduit 4 Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit4Material" typeName="string" displayLabel="Conduit 4 Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit4Size" typeName="double" displayLabel="Conduit 4 Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Conduit4Invert" typeName="double" displayLabel="Conduit 4 Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Conduit4Angle" typeName="double" displayLabel="Conduit 4 Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_Conduit5Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Conduit5Label" typeName="string" displayLabel="Conduit 5 Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit5SectionType" typeName="string" displayLabel="Conduit 5 Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit5Material" typeName="string" displayLabel="Conduit 5 Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="Conduit5Size" typeName="double" displayLabel="Conduit 5 Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Conduit5Invert" typeName="double" displayLabel="Conduit 5 Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Conduit5Angle" typeName="double" displayLabel="Conduit 5 Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_DiversionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DiversionLabel" typeName="string" displayLabel="Diversion Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="DiversionSectionType" typeName="string" displayLabel="Diversion Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="DiversionMaterial" typeName="string" displayLabel="Diversion Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="DiversionSize" typeName="double" displayLabel="Diversion Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="DiversionInvert" typeName="double" displayLabel="Diversion Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="DiversionAngle" typeName="double" displayLabel="Diversion Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_Physical_OutgoingAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OutgoingLabel" typeName="string" displayLabel="Outgoing Label" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="OutgoingSectionType" typeName="string" displayLabel="Outgoing Section Type" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="OutgoingMaterial" typeName="string" displayLabel="Outgoing Material" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0"/>
+        <ECProperty propertyName="OutgoingSize" typeName="double" displayLabel="Outgoing Size" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="OutgoingInvert" typeName="double" displayLabel="Outgoing Invert" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="OutgoingAngle" typeName="double" displayLabel="Outgoing Angle" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_GroundElevation" typeName="double" displayLabel="Elevation (Ground)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="NodeRotation" typeName="double" displayLabel="Rotation" category="Physical_Hydraulic_Analysis_Physical_Hydraulic_Analysis" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="SetOutPointX" typeName="double" displayLabel="Set Out X" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SetOutPointY" typeName="double" displayLabel="Set Out Y" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SetOutPointElevation" typeName="double" displayLabel="Set Out Elevation" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="LargestSize" typeName="double" displayLabel="Largest Connected Conduit" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="SmallestSize" typeName="double" displayLabel="Smallest Connected Conduit" category="Connecting_Links_Drainage_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePolygon_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePolygon_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIGeometryScaledArea" typeName="double" displayLabel="Scaled Area" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePolygonAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePump_EnergyCostAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="EnergyCost_InlcudeInEnergyCalculation" typeName="boolean" displayLabel="Include in Energy Calculation?" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePump_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InitialSettings_RelativeSpeedFactor" typeName="double" displayLabel="Relative Speed Factor (Initial)" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="PumpStatus" typeName="BasePump_InitialSettingsAspect_PumpStatus_Enum" displayLabel="Status (Initial)" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePump_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="NodeMicroStationID" typeName="string" displayLabel="MicroStation 3D ID" category="General_Drainage_General_Drainage" priority="0"/>
+        <ECProperty propertyName="NodeMicroStation2dID" typeName="string" displayLabel="MicroStation 2D ID" category="General_Drainage_General_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasePumpAspect">
+        <BaseClass>BaseDirectedNodeAspect</BaseClass>
+        <ECProperty propertyName="BaselineFeature" typeName="string" displayLabel="Baseline Feature" category="References_Drainage_References_Drainage" priority="0"/>
+        <ECProperty propertyName="BaselineOffset" typeName="double" displayLabel="Baseline Offset" category="References_Drainage_References_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaselineStation" typeName="double" displayLabel="Baseline Station" category="References_Drainage_References_Drainage" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="ElevationReference" typeName="string" displayLabel="Elevation Reference" category="References_Drainage_References_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseSimplePolyline_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseSimplePolyline_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIGeometryScaledLength" typeName="double" displayLabel="Length (Scaled)" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseSimplePolylineAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundaryLine2D_SurfaceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfaceBoundaryType" typeName="BoundaryLine2D_SurfaceAspect_SurfaceBoundaryType_Enum" displayLabel="Boundary Type" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfaceBoundaryElevationType" typeName="BoundaryLine2D_SurfaceAspect_SurfaceBoundaryElevationType_Enum" displayLabel="Boundary Elevation Type" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="ConstantElevation" typeName="double" displayLabel="Water Surface Elevation (Boundary)" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="BoundaryFlowType" typeName="BoundaryLine2D_SurfaceAspect_BoundaryFlowType_Enum" displayLabel="Boundary Flow Type" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="Surface_BoundaryFlow" typeName="double" displayLabel="Flow" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundaryLine2DAspect">
+        <BaseClass>BaseSimplePolylineAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundaryPoint2D_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundaryPoint2D_SurfaceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundaryFlowType" typeName="BoundaryPoint2D_SurfaceAspect_BoundaryFlowType_Enum" displayLabel="Boundary Flow Type" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="Surface_BoundaryFlow" typeName="double" displayLabel="Flow" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundaryPoint2DAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Design_LocalConstraintsAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_SpecifyLocalInletConstraints" typeName="boolean" displayLabel="Specify Local Inlet Constraints?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Design_LocalConstraints_FalseAspect">
+        <BaseClass>CatchBasin_Design_LocalConstraintsAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Design_LocalConstraints_TrueAspect">
+        <BaseClass>CatchBasin_Design_LocalConstraintsAspect</BaseClass>
+        <ECProperty propertyName="Design_LocalMaximumSpreadInSag" typeName="double" displayLabel="Maximum Spread" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Design_LocalMaximumDepthInSag" typeName="double" displayLabel="Maximum Gutter Depth (Design)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Design_LocalMinimumEfficiencyGrade" typeName="double" displayLabel="Minimum Efficiency on Grade" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_DesignAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_DesignInletDesign" typeName="boolean" displayLabel="Design Inlet Opening?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_HydrologicAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Hydrologic_CarryoverFlow" typeName="double" displayLabel="Flow (Additional Carryover)" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_DepressedGutterAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_DepressedGutter" typeName="boolean" displayLabel="Depressed Gutter?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_DepressedGutter_FalseAspect">
+        <BaseClass>CatchBasin_Physical_DepressedGutterAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_DepressedGutter_TrueAspect">
+        <BaseClass>CatchBasin_Physical_DepressedGutterAspect</BaseClass>
+        <ECProperty propertyName="Physical_GutterCrossSlope" typeName="double" displayLabel="Gutter Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_GutterWidth" typeName="double" displayLabel="Gutter Width" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_GutterShapeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GutterShape" typeName="CatchBasin_Physical_GutterShapeAspect_GutterShape_Enum" displayLabel="Gutter Shape" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_GutterShape_ConventionalAspect">
+        <BaseClass>CatchBasin_Physical_GutterShapeAspect</BaseClass>
+        <ECProperty propertyName="Physical_RoadCrossSlope" typeName="double" displayLabel="Road Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_MaximumGutterDepth" typeName="double" displayLabel="Maximum Gutter Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_GutterShape_IrregularAspect">
+        <BaseClass>CatchBasin_Physical_GutterShapeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_GutterShape_ParabolicAspect">
+        <BaseClass>CatchBasin_Physical_GutterShapeAspect</BaseClass>
+        <ECProperty propertyName="ParabolicGutterType_Height" typeName="double" displayLabel="Height" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParabolicGutterType_Width" typeName="double" displayLabel="Width (Parabolic Gutter)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_GutterShape_TrapezoidalAspect">
+        <BaseClass>CatchBasin_Physical_GutterShapeAspect</BaseClass>
+        <ECProperty propertyName="GutterShapeType_RightSideSlope" typeName="double" displayLabel="Right Side Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="GutterShapeType_LeftSideSlope" typeName="double" displayLabel="Left Side Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="Physical_MaximumGutterDepth" typeName="double" displayLabel="Maximum Gutter Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Physical_DitchBottomWidth" typeName="double" displayLabel="Bottom Width (Ditch)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_GutterShape_VShapeAspect">
+        <BaseClass>CatchBasin_Physical_GutterShapeAspect</BaseClass>
+        <ECProperty propertyName="Physical_RoadCrossSlope" typeName="double" displayLabel="Road Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="VShapedGutterType_CurbCrossSlope" typeName="double" displayLabel="Curb Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_MaximumGutterDepth" typeName="double" displayLabel="Maximum Gutter Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletGutterTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InletGutterType" typeName="CatchBasin_Physical_InletGutterTypeAspect_InletGutterType_Enum" displayLabel="Gutter Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletGutterType_CatalogGutterAspect">
+        <BaseClass>CatchBasin_Physical_InletGutterTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletGutterType_UserDefinedAspect">
+        <BaseClass>CatchBasin_Physical_InletGutterTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletLocationAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InletLocation" typeName="CatchBasin_Physical_InletLocationAspect_InletLocation_Enum" displayLabel="Inlet Location" category="Inlet_Location_Drainage_Inlet_Location_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletLocation_InSagAspect">
+        <BaseClass>CatchBasin_Physical_InletLocationAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletLocation_OnGradeAspect">
+        <BaseClass>CatchBasin_Physical_InletLocationAspect</BaseClass>
+        <ECProperty propertyName="OnGradeType_LongitudinalSlope" typeName="double" displayLabel="Longitudinal Slope (Inlet)" category="Inlet_Location_Drainage_Inlet_Location_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="OnGradeType_ManningsN" typeName="double" displayLabel="Manning's n (Inlet)" category="Inlet_Location_Drainage_Inlet_Location_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InletType" typeName="CatchBasin_Physical_InletTypeAspect_InletType_Enum" displayLabel="Inlet Type" category="Inlet_Drainage_Inlet_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletType_CatalogInletAspect">
+        <BaseClass>CatchBasin_Physical_InletTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletType_FullCaptureAspect">
+        <BaseClass>CatchBasin_Physical_InletTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletType_HydrologicRatingCurveAspect">
+        <BaseClass>CatchBasin_Physical_InletTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletType_MaximumCapacityAspect">
+        <BaseClass>CatchBasin_Physical_InletTypeAspect</BaseClass>
+        <ECProperty propertyName="MaximumCapacityType_MaximumInflow" typeName="double" displayLabel="Flow (Maximum in)" category="Inlet_Drainage_Inlet_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_Physical_InletType_PercentCaptureAspect">
+        <BaseClass>CatchBasin_Physical_InletTypeAspect</BaseClass>
+        <ECProperty propertyName="PercentCaptureType_PercentCaptureEfficiency" typeName="double" displayLabel="Capture Efficiency" category="Inlet_Drainage_Inlet_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_CurbOpeningLength" typeName="double" displayLabel="Curb Opening Length" category="Inlet_Opening_Drainage_Inlet_Opening_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_GrateLength" typeName="double" displayLabel="Grate Length" category="Inlet_Opening_Drainage_Inlet_Opening_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_GrateCloggingFactor" typeName="double" displayLabel="Clogging Factor" category="Inlet_Opening_Drainage_Inlet_Opening_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="Physical_SlotLength" typeName="double" displayLabel="Slot Length" category="Inlet_Opening_Drainage_Inlet_Opening_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_MaintenanceFactor" typeName="double" displayLabel="Maintenance Factor (United Kingdom)" category="Inlet_Opening_Drainage_Inlet_Opening_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Physical_GratingType" typeName="CatchBasin_PhysicalAspect_Physical_GratingType_Enum" displayLabel="Grating Type" category="Inlet_Opening_Drainage_Inlet_Opening_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasin_SystemFlowsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SystemFlows_AdditionalFlow" typeName="double" displayLabel="Flow (Additional Subsurface)" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SystemFlows_ExternalCArea" typeName="double" displayLabel="External CA" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SystemFlows_ExternalTc" typeName="double" displayLabel="External Tc" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravityNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravityStructureAspect">
+        <BaseClass>GravityNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravitySurfaceStructureAspect">
+        <BaseClass>GravityStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasinAspect">
+        <BaseClass>GravitySurfaceStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWaterAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Hydrologic_ApplyGroundWater" typeName="boolean" displayLabel="Apply Groundwater" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_FalseAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWaterAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_TrueAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWaterAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_SurfaceElevation" typeName="double" displayLabel="Catchment Surface Elevation" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Hydrologic_GroundwaterFlowCoefficient" typeName="double" displayLabel="Groundwater Flow Coefficient (A1)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Hydrologic_GroundwaterFlowExponent" typeName="double" displayLabel="Groundwater Flow Exponent (B1)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Hydrologic_SurfWaterFlowCoefficient" typeName="double" displayLabel="Surface Water Flow Coefficient (A2)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Hydrologic_SurfWaterFlowExponent" typeName="double" displayLabel="Surface Water Flow Exponent (B2)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Hydrologic_SurfGwInteractionCoeff" typeName="double" displayLabel="Surface Groundwater Interaction Coefficient (A3)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Hydrologic_FixedSurfWaterDepth" typeName="double" displayLabel="Surface Water Height" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_TrueAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwBottomElevationUseAquiferData" typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationAspect_Hydrologic_GwBottomElevationUseAquiferData_Enum" displayLabel="Bottom Elevation Data" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationUseAquiferDataAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationUserDefinedAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwBottomElevation" typeName="double" displayLabel="Bottom Elevation" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_TrueAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwHcbUseReceivingNodeInvert" typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeAspect_Hydrologic_GwHcbUseReceivingNodeInvert_Enum" displayLabel="Channel Bottom Height Data" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeInvertAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeUserDefinedAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwChannelBottomHeight" typeName="double" displayLabel="Channel Bottom Height" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_TrueAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwUnsatZoneMoistureUseAquiferData" typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureAspect_Hydrologic_GwUnsatZoneMoistureUseAquiferData_Enum" displayLabel="Unsaturated Zone Moisture Data" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureUseAquiferDataAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureUserDefinedAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwUnsatZoneMoisture" typeName="double" displayLabel="Unsaturated Zone Moisture" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_TrueAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwWaterTableElevationUseAquiferData" typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationAspect_Hydrologic_GwWaterTableElevationUseAquiferData_Enum" displayLabel="Water Table Elevation Data" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationUseAquiferDataAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationUserDefinedAspect">
+        <BaseClass>Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_GwWaterTableElevation" typeName="double" displayLabel="Water Table Elevation" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_HydrologicAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Hydrologic_TimeOfConcentration" typeName="double" displayLabel="Time of Concentration" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="TcComputeType" typeName="Catchment_HydrologicAspect_TcComputeType_Enum" displayLabel="Tc Input Type" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_GwEquationUnitSystem" typeName="Catchment_HydrologicAspect_Hydrologic_GwEquationUnitSystem_Enum" displayLabel="Groundwater Equation Unit System" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_ApplyGwDeepwaterEqn" typeName="boolean" displayLabel="Apply Custom Deep Flow Equation?" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+        <ECProperty propertyName="CustomGwDeepwaterEqn" typeName="string" displayLabel="Custom Deep Flow Equation" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_ApplyGwLateralEqn" typeName="boolean" displayLabel="Apply Custom Lateral Flow Equation?" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+        <ECProperty propertyName="CustomGwLateralEqn" typeName="string" displayLabel="Custom Groundwater Lateral Equation" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_UseScaledArea" typeName="boolean" displayLabel="Use Scaled Area?" category="Geometry_Drainage_Geometry_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_Area" typeName="double" displayLabel="Area (User Defined)" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="AreaDefinitionType" typeName="Catchment_HydrologicAspect_AreaDefinitionType_Enum" displayLabel="Area Defined By" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LandCoverAreasAspect">
+        <BaseClass>Catchment_HydrologicAspect</BaseClass>
+        <ECProperty propertyName="LandCoverAreasType_ScsCNDefault" typeName="double" displayLabel="SCS CN (Default)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="LandCoverAreasType_RunoffCoefficientDefault" typeName="double" displayLabel="Runoff Coefficient (Default)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="LandCoverAreasType_RationalCDefault" typeName="double" displayLabel="Rational C (Default)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LossMethodType" typeName="Catchment_Hydrologic_LossMethodTypeAspect_LossMethodType_Enum" displayLabel="Loss Method" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_fLossAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="fLossType_fLoss" typeName="double" displayLabel="Constant Loss Rate (fLoss)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_GenericHortonAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="GenericHortonType_fc" typeName="double" displayLabel="fc" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GenericHortonType_fo" typeName="double" displayLabel="fo" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GenericHortonType_K" typeName="double" displayLabel="K" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:REACTION_RATE"/>
+        <ECProperty propertyName="GenericHortonType_InitialAbstraction" typeName="double" displayLabel="Initial Abstraction" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GenericHortonType_MaxVolume" typeName="double" displayLabel="Volume (Maximum)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="LossMethodType_DryingTime" typeName="double" displayLabel="Drying Time" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:TIME_MEDIUM"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_GreenAndAmptAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="GreenAndAmptType_MoistureDeficit" typeName="double" displayLabel="Moisture Deficit" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GreenAndAmptType_CapillarySuction" typeName="double" displayLabel="Capillary Suction" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GreenAndAmptType_Ks" typeName="double" displayLabel="Ks" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_InitialBaseAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="InitialLoss" typeName="double" displayLabel="Initial Loss" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_InitialThenConstantFractionAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodType_InitialBaseAspect</BaseClass>
+        <ECProperty propertyName="ConstantLossFraction" typeName="double" displayLabel="Constant Loss Fraction" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_InitialThenConstantRateAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodType_InitialBaseAspect</BaseClass>
+        <ECProperty propertyName="ConstantLossRate" typeName="double" displayLabel="Constant Loss Rate" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_NoneAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_RunoffCoefficientAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="RunoffCoefficientType_RunoffCoefficient" typeName="double" displayLabel="Runoff Coefficient (Time-Area)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_LossMethodType_ScsCnAspect">
+        <BaseClass>Catchment_Hydrologic_LossMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="ScsCnType_CN" typeName="double" displayLabel="SCS CN [Deprecated]" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Use 'ScsCnType_CNValue' instead</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="LossMethodType_DryingTime" typeName="double" displayLabel="Drying Time" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:TIME_MEDIUM"/>
+        <ECProperty propertyName="ScsCnType_CNValue" typeName="double" displayLabel="SCS CN" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethodTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RunoffMethodType" typeName="Catchment_Hydrologic_RunoffMethodTypeAspect_RunoffMethodType_Enum" displayLabel="Runoff Method" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_UnitHydrographAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="UnitHydrographMethodType" typeName="Catchment_Hydrologic_RunoffMethod_UnitHydrographAspect_UnitHydrographMethodType_Enum" displayLabel="Unit Hydrograph Method" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_ScsUnitHydrographAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_UnitHydrographAspect</BaseClass>
+        <ECProperty propertyName="ScsUnitHydrographMethodType" typeName="Catchment_Hydrologic_RunoffMethod_ScsUnitHydrographAspect_ScsUnitHydrographMethodType_Enum" displayLabel="SCS Unit Hydrograph Method" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_DefaultCurvilinearScsUnitHydrographAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_ScsUnitHydrographAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_DimensionlessScsUnitHydrographAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_ScsUnitHydrographAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_EpaSwmmAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_CharacteristicWidth" typeName="double" displayLabel="Characteristic Width" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_Slope" typeName="double" displayLabel="Slope" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_ManningsNImpervious" typeName="double" displayLabel="Manning's n (Impervious)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_ManningsNPervious" typeName="double" displayLabel="Manning's n (Pervious)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_DepressionStorageImpervious" typeName="double" displayLabel="Storage (Impervious Depression)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_DepressionStoragePervious" typeName="double" displayLabel="Storage (Pervious Depression)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_ZeroPercentImpervious" typeName="double" displayLabel="Percent Impervious Zero Storage" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_PercentRouted" typeName="double" displayLabel="Percent Routed" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="EpaSwmmRunoffMethodType_PercentImpervious" typeName="double" displayLabel="Percent Impervious" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="SubareaRouting" typeName="Catchment_Hydrologic_RunoffMethod_EpaSwmmAspect_SubareaRouting_Enum" displayLabel="Subarea Routing" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_GenericUnitHydrographAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_UnitHydrographAspect</BaseClass>
+        <ECProperty propertyName="GenericUnitHydrographType_ConvolutionTimeStep" typeName="double" displayLabel="Convolution Time Step" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_ILSAXMethodAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="ILSAXMethodType_MoistureCondition" typeName="double" displayLabel="Antecedent Moisture Condition" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="ILSAXPerviousCoverDefinitionType" typeName="Catchment_Hydrologic_RunoffMethod_ILSAXMethodAspect_ILSAXPerviousCoverDefinitionType_Enum" displayLabel="Soil Type" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_ILSAXMethod_NormalAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_ILSAXMethodAspect</BaseClass>
+        <ECProperty propertyName="NormalType_ILSAXSoilValue" typeName="double" displayLabel="ILSAX Soil Value" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_ILSAXMethod_UserDefinedAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_ILSAXMethodAspect</BaseClass>
+        <ECProperty propertyName="UserDefinedType_AMC1RainfallDepth" typeName="double" displayLabel="AMC1 Depth" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="UserDefinedType_AMC2RainfallDepth" typeName="double" displayLabel="AMC2 Depth" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="UserDefinedType_AMC3RainfallDepth" typeName="double" displayLabel="AMC3 Depth" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="UserDefinedType_AMC4RainfallDepth" typeName="double" displayLabel="AMC4 Depth" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="UserDefinedType_fc" typeName="double" displayLabel="fc (ILSAX)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="UserDefinedType_fo" typeName="double" displayLabel="fo (ILSAX)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="UserDefinedType_K" typeName="double" displayLabel="K (ILSAX)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:REACTION_RATE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_RationalMethodBaseAspect" modifier="Abstract">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="RationalMethodType_RationalCCoefficient" typeName="double" displayLabel="Runoff Coefficient (Rational)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_ModifiedRationalMethodAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_RationalMethodBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_ModifiedRationalUKAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_RationalMethodBaseAspect</BaseClass>
+        <ECProperty propertyName="Hydrologic_Cv" typeName="double" displayLabel="Volumetric Runoff Coefficient (Cv)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_NoneAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_RationalMethodAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_RationalMethodBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_RTKUnitHydrographAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_UnitHydrographAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_TimeAreaMethodAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+        <ECProperty propertyName="TimeAreaMethodType" typeName="Catchment_Hydrologic_RunoffMethod_TimeAreaMethodAspect_TimeAreaMethodType_Enum" displayLabel="Time-Area Diagram Type" category="Runoff_Drainage_Runoff_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_TriangularScsUnitHydrographAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethod_ScsUnitHydrographAspect</BaseClass>
+        <ECProperty propertyName="TriangularType_ShapeFactor" typeName="double" displayLabel="Shape Factor" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_Hydrologic_RunoffMethod_UserDefinedHydrographAspect">
+        <BaseClass>Catchment_Hydrologic_RunoffMethodTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_RainfallRunoffAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RainfallRunoff_UseLocalRainfall" typeName="boolean" displayLabel="Use Local Rainfall?" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+        <ECProperty propertyName="RainfallRunoff_StormEventID" typeName="string" displayLabel="Local Storm Event" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+        <ECProperty propertyName="RainfallRunoff_HasSnowPack" typeName="boolean" displayLabel="Has Snow Pack?" category="Snow_Parameters_Drainage_Snow_Parameters_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Catchment_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_CurbLength" typeName="double" displayLabel="Curb Length Normalizer" category="SWMM_Extended_Data_Water_Quality_Drainage_SWMM_Extended_Data_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchmentAspect">
+        <BaseClass>BasePolygonAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Channel_OutputAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OutputOptionsType" typeName="Channel_OutputAspect_OutputOptionsType_Enum" displayLabel="Output Options" category="Output_Drainage_Output_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Channel_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_HasFlapGate" typeName="boolean" displayLabel="Flap Gate?" category="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_HasStartControlStructure" typeName="boolean" displayLabel="Has Start Control Structure?" category="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_HasStopControlStructure" typeName="boolean" displayLabel="Has Stop Control Structure?" category="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="PhysicalLinkAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ChannelAspect">
+        <BaseClass>PhysicalLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_DesignAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_DesignConduit" typeName="boolean" displayLabel="Design Conduit?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Design_FalseAspect">
+        <BaseClass>Conduit_DesignAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Design_SpecifyLocalConstraintAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_SpecifyLocalConduitConstraint" typeName="boolean" displayLabel="Specify Local Pipe Constraint?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Design_SpecifyLocalConstraint_FalseAspect">
+        <BaseClass>Conduit_Design_SpecifyLocalConstraintAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Design_SpecifyLocalConstraint_TrueAspect">
+        <BaseClass>Conduit_Design_SpecifyLocalConstraintAspect</BaseClass>
+        <ECProperty propertyName="Design_LocalMinVelocity" typeName="double" displayLabel="Velocity (Minimum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="Design_LocalMaxVelocity" typeName="double" displayLabel="Velocity (Maximum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="Design_LocalMinCover" typeName="double" displayLabel="Cover (Constraint, Minimum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Design_LocalMaxCover" typeName="double" displayLabel="Cover (Constraint, Maximum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Design_LocalMinSlope" typeName="double" displayLabel="Slope (Minimum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Design_LocalMaxSlope" typeName="double" displayLabel="Slope (Maximum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Design_LocalPerformPartFullDesign" typeName="boolean" displayLabel="Part Full Design?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalDesignPercentFull" typeName="double" displayLabel="Design Percent Full" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="Design_LocalAllowMultipleBarrels" typeName="boolean" displayLabel="Allow Multiple Barrels?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalMaxBarrels" typeName="int" displayLabel="Barrels (Maximum)" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalLimitSectionSize" typeName="boolean" displayLabel="Limit Section Size?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalMaxRise" typeName="double" displayLabel="Rise (Maximum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Design_LocalUseVariableCover" typeName="boolean" displayLabel="Consider Cover Along Pipe Length?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalIncludeTractiveStressDesign" typeName="boolean" displayLabel="Include Tractive Stress Design?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalMinTractiveStress" typeName="double" displayLabel="Tractive Stress (Design Minimum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:STRESS"/>
+        <ECProperty propertyName="LocalMeasureCoverType" typeName="Conduit_Design_SpecifyLocalConstraint_TrueAspect_LocalMeasureCoverType_Enum" displayLabel="Measure Cover To" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Design_TrueAspect">
+        <BaseClass>Conduit_DesignAspect</BaseClass>
+        <ECProperty propertyName="Design_DesignStartInvert" typeName="boolean" displayLabel="Design Start Invert?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_DesignStopInvert" typeName="boolean" displayLabel="Design Stop Invert?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_HeadlossAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Headloss_ExpansionLossCoefficient" typeName="double" displayLabel="Expansion Loss Coefficient" category="Headlosses_Drainage_Headlosses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Headloss_ContractionLossCoefficient" typeName="double" displayLabel="Contraction Loss Coefficient" category="Headlosses_Drainage_Headlosses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Headloss_EntranceLossCoefficient" typeName="double" displayLabel="Entrance Loss Coefficient" category="Headlosses_Drainage_Headlosses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Headloss_ExitLossCoefficient" typeName="double" displayLabel="Exit Loss Coefficient" category="Headlosses_Drainage_Headlosses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Headloss_AverageLossCoefficient" typeName="double" displayLabel="Average Loss Coefficient" category="Headlosses_Drainage_Headlosses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_TypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InfiltrationLoadType" typeName="Conduit_InfiltrationAndInflow_TypeAspect_InfiltrationLoadType_Enum" displayLabel="Infiltration Load Type" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_LinkTypeAspect" modifier="Abstract">
+        <BaseClass>Conduit_InfiltrationAndInflow_TypeAspect</BaseClass>
+        <ECProperty propertyName="InfiltrationRatePerLoadingUnit" typeName="double" displayLabel="Infiltration Rate per Loading Unit" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_ConduitRiseLengthAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_LinkTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_ConduitSurfaceAreaAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_LinkTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_HydrographAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_TypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_InfCountBasedAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_TypeAspect</BaseClass>
+        <ECProperty propertyName="InfCountBasedType_InfiltrationUnitNumber" typeName="double" displayLabel="Infiltration Unit Count" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="InfiltrationRatePerLoadingUnit" typeName="double" displayLabel="Infiltration Rate per Loading Unit" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_InfNoneAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_TypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_LinkLengthAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_LinkTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflow_PatternLoadAspect">
+        <BaseClass>Conduit_InfiltrationAndInflow_TypeAspect</BaseClass>
+        <ECProperty propertyName="InfPatternLoadType_infBaseFlow" typeName="double" displayLabel="Infiltration Base Flow" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_InfiltrationAndInflowAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InfiltrationAndInflow_InfiltrationFlow" typeName="double" displayLabel="Flow (Additional Infiltration)" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="InfiltrationAndInflow_ConduitSeepRate" typeName="double" displayLabel="Seepage Loss Rate" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:RAINFALL_INTENSITY"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_OutputAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OutputOptionsType" typeName="Conduit_OutputAspect_OutputOptionsType_Enum" displayLabel="Output Options" category="Output_Drainage_Output_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_DiversionTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DiversionType" typeName="Conduit_Physical_DiversionTypeAspect_DiversionType_Enum" displayLabel="Diversion Type" category="Diversion_Drainage_Diversion_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_CapacityDiversionAspect">
+        <BaseClass>Conduit_Physical_DiversionTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_ConduitTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ConduitType" typeName="Conduit_Physical_ConduitTypeAspect_ConduitType_Enum" displayLabel="Conduit Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_CatalogTypeAspect">
+        <BaseClass>Conduit_Physical_ConduitTypeAspect</BaseClass>
+        <ECProperty propertyName="CatalogPipeType_CatalogPipeSize" typeName="string" displayLabel="Size" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_CutoffDiversionAspect">
+        <BaseClass>Conduit_Physical_DiversionTypeAspect</BaseClass>
+        <ECProperty propertyName="CutoffType_CutoffFlow" typeName="double" displayLabel="Cutoff Flow" category="Diversion_Drainage_Diversion_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasOvertoppingWeirAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_HasOvertoppingWeir" typeName="boolean" displayLabel="Has Overtopping Weir?" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasOvertoppingWeir_FalseAspect">
+        <BaseClass>Conduit_Physical_HasOvertoppingWeirAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasOvertoppingWeir_TrueAspect">
+        <BaseClass>Conduit_Physical_HasOvertoppingWeirAspect</BaseClass>
+        <ECProperty propertyName="Physical_RoadwayCrestElevation" typeName="double" displayLabel="Elevation (Roadway Crest)" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_MaximumOvertoppingDepth" typeName="double" displayLabel="Depth (Maximum Overtopping)" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Physical_CulvertDepthIncrement" typeName="double" displayLabel="Increment" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Physical_RoadwayCrossSectionLength" typeName="double" displayLabel="Roadway Cross Section Length" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_UserDefinedTailwater" typeName="boolean" displayLabel="User Defined Tailwater?" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_MaximumTailwaterElevation" typeName="double" displayLabel="Elevation (Maximum Tailwater)" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_UseWeirDepthTable" typeName="boolean" displayLabel="Use Weir C-Depth Table?" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_RoadwayWeirCoefficient" typeName="double" displayLabel="Roadway Weir Coefficient" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:WEIR_COEFFICIENT"/>
+        <ECProperty propertyName="Physical_CrestDistanceFromStart" typeName="double" displayLabel="Roadway Distance from Start" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="OvertoppingWeir_RoadSurface" typeName="Conduit_Physical_HasOvertoppingWeir_TrueAspect_OvertoppingWeir_RoadSurface_Enum" displayLabel="Road Surface" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasStartControlStructureAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_HasStartControlStructure" typeName="boolean" displayLabel="Has Start Control Structure?" category="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_HasUserDefinedBendAngle" typeName="boolean" displayLabel="Has User Defined Bend Angle?" category="Physical_Drainage_Physical_Drainage" priority="0">
+            <ECCustomAttributes>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Duplicated by mistake. Use Conduit_Physical_HasUserDefinedBendAngleAspect.Physical_HasUserDefinedBendAngle instead.</Description>
+                </Deprecated>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasStartControlStructure_FalseAspect">
+        <BaseClass>Conduit_Physical_HasStartControlStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasStartControlStructure_TrueAspect">
+        <BaseClass>Conduit_Physical_HasStartControlStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasStopControlStructureAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_HasStopControlStructure" typeName="boolean" displayLabel="Has Stop Control Structure?" category="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasStopControlStructure_FalseAspect">
+        <BaseClass>Conduit_Physical_HasStopControlStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasStopControlStructure_TrueAspect">
+        <BaseClass>Conduit_Physical_HasStopControlStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasUserDefinedBendAngleAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_HasUserDefinedBendAngle" typeName="boolean" displayLabel="Has User Defined Bend Angle?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasUserDefinedBendAngle_FalseAspect">
+        <BaseClass>Conduit_Physical_HasUserDefinedBendAngleAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_HasUserDefinedBendAngle_TrueAspect">
+        <BaseClass>Conduit_Physical_HasUserDefinedBendAngleAspect</BaseClass>
+        <ECProperty propertyName="Physical_UserDefinedBendAngle" typeName="double" displayLabel="Bend Angle (User Defined)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_IsCulvertBaseAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="isCulvert" typeName="boolean" displayLabel="Is Culvert?" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_IsCulvertAspect">
+        <BaseClass>Conduit_Physical_IsCulvertBaseAspect</BaseClass>
+        <ECProperty propertyName="CulvertKe" typeName="double" displayLabel="Ke" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="CulvertKr" typeName="double" displayLabel="Kr" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="UpstreamHeadwallDefinitionType" typeName="Conduit_Physical_IsCulvertAspect_UpstreamHeadwallDefinitionType_Enum" displayLabel="Upstream Headwall Definition Type" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+        <ECProperty propertyName="DownstreamEndwallDefinitionType" typeName="Conduit_Physical_IsCulvertAspect_DownstreamEndwallDefinitionType_Enum" displayLabel="Downstream Endwall Definition Type" category="Physical_Culvert_Drainage_Physical_Culvert_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_IsDivertedLinkAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_IsDivertedLink" typeName="boolean" displayLabel="Is Diversion Link?" category="Diversion_Drainage_Diversion_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_IsDivertedLink_FalseAspect">
+        <BaseClass>Conduit_Physical_IsDivertedLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_IsDivertedLink_TrueAspect">
+        <BaseClass>Conduit_Physical_IsDivertedLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_IsNotCulvertAspect">
+        <BaseClass>Conduit_Physical_IsCulvertBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_PseudoWeirDiversionAspect">
+        <BaseClass>Conduit_Physical_DiversionTypeAspect</BaseClass>
+        <ECProperty propertyName="PseudoWeirType_MinimumFlow" typeName="double" displayLabel="Minimum Flow" category="Diversion_Drainage_Diversion_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PseudoWeirType_MaximumDepth" typeName="double" displayLabel="Maximum Depth" category="Diversion_Drainage_Diversion_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="PseudoWeirType_WeirLength" typeName="double" displayLabel="Weir Length" category="Diversion_Drainage_Diversion_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PseudoWeirType_WeirCoefficient" typeName="double" displayLabel="Weir Coefficient" category="Diversion_Drainage_Diversion_Drainage" priority="0" kindOfQuantity="cifu:WEIR_COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_RatingTableDiversionAspect">
+        <BaseClass>Conduit_Physical_DiversionTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_UseLocalMinimumTractiveStressAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_UseLocalMinimumTractiveStress" typeName="boolean" displayLabel="Use Local Minimum Tractive Stress?" category="Tractive_Stress_Drainage_Tractive_Stress_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_UseLocalMinimumTractiveStress_FalseAspect">
+        <BaseClass>Conduit_Physical_UseLocalMinimumTractiveStressAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_UseLocalMinimumTractiveStress_TrueAspect">
+        <BaseClass>Conduit_Physical_UseLocalMinimumTractiveStressAspect</BaseClass>
+        <ECProperty propertyName="Physical_LocalMinimumTractiveStress" typeName="double" displayLabel="Tractive Stress (Local Minimum)" category="Tractive_Stress_Drainage_Tractive_Stress_Drainage" priority="0" kindOfQuantity="cifu:STRESS"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Physical_UserDefinedTypeAspect">
+        <BaseClass>Conduit_Physical_ConduitTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_HasFlapGate" typeName="boolean" displayLabel="Flap Gate?" category="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_NumberOfBarrels" typeName="int" displayLabel="Number of Barrels" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_ConduitShapeLabel" typeName="string" displayLabel="Conduit Description" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_UseLocalConduitShapeLabel" typeName="boolean" displayLabel="Use Local Conduit Description?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="MultiBarrelGapDistance" typeName="double" displayLabel="Multiple Barrel Gap Distance" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_ShapeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ConduitShape" typeName="Conduit_ShapeAspect_ConduitShape_Enum" displayLabel="Section Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_ChannelWithRiseBaseAspect" modifier="Abstract">
+        <BaseClass>Conduit_ShapeAspect</BaseClass>
+        <ECProperty propertyName="ConduitRise" typeName="double" displayLabel="Rise" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_ChannelWithRiseSpanBaseAspect" modifier="Abstract">
+        <BaseClass>Conduit_Shape_ChannelWithRiseBaseAspect</BaseClass>
+        <ECProperty propertyName="ConduitSpan" typeName="double" displayLabel="Span" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_ArchAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+        <ECProperty propertyName="ConduitThickness" typeName="double" displayLabel="Wall Thickness" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="StandardArchCodeType_ArchCode" typeName="int" displayLabel="Arch Code" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="ArchDataType" typeName="Conduit_Shape_ArchAspect_ArchDataType_Enum" displayLabel="Arch Data Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_PipeBaseAspect" modifier="Abstract">
+        <BaseClass>Conduit_ShapeAspect</BaseClass>
+        <ECProperty propertyName="ConduitThickness" typeName="double" displayLabel="Wall Thickness" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_PipeWithRiseBaseAspect" modifier="Abstract">
+        <BaseClass>Conduit_Shape_PipeBaseAspect</BaseClass>
+        <ECProperty propertyName="ConduitRise" typeName="double" displayLabel="Rise" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_BasketHandlePipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_PipeWithRiseSpanBaseAspect" modifier="Abstract">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+        <ECProperty propertyName="ConduitSpan" typeName="double" displayLabel="Span" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_BoxPipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseSpanBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_CatenaryPipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_CircularPipeAspect">
+        <BaseClass>Conduit_Shape_PipeBaseAspect</BaseClass>
+        <ECProperty propertyName="CircularPipeType_CircularFillDepth" typeName="double" displayLabel="Fill Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="ConduitDiameter" typeName="double" displayLabel="Diameter" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_EggPipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_EllipticalPipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseSpanBaseAspect</BaseClass>
+        <ECProperty propertyName="EllipseOrientation" typeName="Conduit_Shape_EllipticalPipeAspect_EllipseOrientation_Enum" displayLabel="Ellipse Orientation" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_GothicPipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_HorseshoePipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_IrregularChannelAspect">
+        <BaseClass>Conduit_ShapeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_IrregularClosedSectionAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_ModBasketHandlePipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseSpanBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_ParabolicChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_PipeArchAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseSpanBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_PowerChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+        <ECProperty propertyName="PowerChannelType_PowerExponenet" typeName="double" displayLabel="Power Exponent" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_RectangularChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+        <ECProperty propertyName="RecSidewallRemove" typeName="Conduit_Shape_RectangularChannelAspect_RecSidewallRemove_Enum" displayLabel="Sidewalls Removed" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_RectRoundChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+        <ECProperty propertyName="RectRoundChannelType_RectBottomRadius" typeName="double" displayLabel="Bottom Radius (Rectangular-Round)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_RectTriangleChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+        <ECProperty propertyName="RectTriangleChannelType_RectTriangleTriangleHeight" typeName="double" displayLabel="Triangle Height (Rectangular-Triangle)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_SemiCircularPipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_SemiEllipsePipeAspect">
+        <BaseClass>Conduit_Shape_PipeWithRiseBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_TrapezoidalChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseBaseAspect</BaseClass>
+        <ECProperty propertyName="TrapezoidalChannelType_BaseWidth" typeName="double" displayLabel="Bottom Width" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TrapezoidalChannelType_RightSideSlope" typeName="double" displayLabel="Side Slope (Right)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="TrapezoidalChannelType_LeftSideSlope" typeName="double" displayLabel="Side Slope (Left)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Conduit_Shape_TriangularChannelAspect">
+        <BaseClass>Conduit_Shape_ChannelWithRiseSpanBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravityLinkBaseAspect">
+        <BaseClass>PhysicalLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitAspect">
+        <BaseClass>GravityLinkBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitCxRoughness_PhysicalAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RoughnessType" typeName="ConduitCxRoughness_PhysicalAspect_RoughnessType_Enum" displayLabel="Roughness Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitCxRoughness_Physical_BankChannelAspect">
+        <BaseClass>ConduitCxRoughness_PhysicalAspect</BaseClass>
+        <ECProperty propertyName="BankChannelType_LeftManningsN" typeName="double" displayLabel="Manning's n (Left Bank)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="BankChannelType_ChannelManningsN" typeName="double" displayLabel="Manning's n (Channel)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="BankChannelType_RightManningsN" typeName="double" displayLabel="Manning's n (Right Bank)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="BankChannelType_LeftHazenWilliamsC" typeName="double" displayLabel="Left Bank C" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_HAZENWILLIAMS"/>
+        <ECProperty propertyName="BankChannelType_ChannelHazenWilliamsC" typeName="double" displayLabel="Channel C" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_HAZENWILLIAMS"/>
+        <ECProperty propertyName="BankChannelType_RightHazenWilliamsC" typeName="double" displayLabel="Right Bank C" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_HAZENWILLIAMS"/>
+        <ECProperty propertyName="BankChannelType_LeftDarcyWeisbachE" typeName="double" displayLabel="Left Bank e" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_DARCYWEISBACH"/>
+        <ECProperty propertyName="BankChannelType_ChannelDarcyWeisbachE" typeName="double" displayLabel="Channel e" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_DARCYWEISBACH"/>
+        <ECProperty propertyName="BankChannelType_RightDarcyWeisbachE" typeName="double" displayLabel="Right Bank e" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_DARCYWEISBACH"/>
+        <ECProperty propertyName="BankChannelType_LeftKuttersN" typeName="double" displayLabel="Left Bank Kutter's n" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_KUTTERS"/>
+        <ECProperty propertyName="BankChannelType_ChannelKuttersN" typeName="double" displayLabel="Channel Kutter's n" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_KUTTERS"/>
+        <ECProperty propertyName="BankChannelType_RightKuttersN" typeName="double" displayLabel="Right Bank Kutter's n" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_KUTTERS"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitCxRoughness_Physical_HorizontalSegmentAspect">
+        <BaseClass>ConduitCxRoughness_PhysicalAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitCxRoughness_Physical_RoughnessDepthAspect">
+        <BaseClass>ConduitCxRoughness_PhysicalAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitCxRoughness_Physical_RoughnessFlowAspect">
+        <BaseClass>ConduitCxRoughness_PhysicalAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConduitCxRoughness_Physical_SingleRoughnessAspect">
+        <BaseClass>ConduitCxRoughness_PhysicalAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossSectionNode_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InitialSettings_InitialDepth" typeName="double" displayLabel="Depth (Initial)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossSectionNode_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TransitionType" typeName="CrossSectionNode_PhysicalAspect_TransitionType_Enum" displayLabel="Transition Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="GradualType_TransitionLength" typeName="double" displayLabel="Transition Length" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossSectionType" typeName="CrossSectionNode_PhysicalAspect_CrossSectionType_Enum" displayLabel="Cross Section Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="CatalogCrossSectionType_CatalogConduitSIze" typeName="string" displayLabel="Size" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_InvertElevation" typeName="double" displayLabel="Elevation (Invert)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossSectionNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CxPhysical_CxDataTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CxDataType" typeName="CxPhysical_CxDataTypeAspect_CxDataType_Enum" displayLabel="Section Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CxPhysical_CxDataType_GenericAspect">
+        <BaseClass>CxPhysical_CxDataTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CxPhysical_CxDataType_TrapizoidalAspect">
+        <BaseClass>CxPhysical_CxDataTypeAspect</BaseClass>
+        <ECProperty propertyName="TrapizoidalCxType_CxChannelDepth" typeName="double" displayLabel="Height" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="TrapizoidalCxType_CxRightSideSlope" typeName="double" displayLabel="Slope (Right Side)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="TrapizoidalCxType_CxLeftSideSlope" typeName="double" displayLabel="Slope (Left Side)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="TrapizoidalCxType_CxBottomWidth" typeName="double" displayLabel="Bottom Width" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsAirValve_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AirValve_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsAirValveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AirValveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseDirectedNode_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseDirectedNode_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseDirectedNode_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseDirectedNode_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseDirectedNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseDirectedNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_HMIUserDefinedExtensionsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_HMIUserDefinedExtensionsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_Physical_UserDefinedLengthAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_Physical_UserDefinedLengthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLinkAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLinkAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_Conduit1Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_Conduit1Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_Conduit2Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_Conduit2Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_Conduit3Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_Conduit3Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_Conduit4Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_Conduit4Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_Conduit5Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_Conduit5Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_DiversionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_DiversionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_Physical_OutgoingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_Physical_OutgoingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePolygon_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePolygon_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePolygon_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePolygon_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePolygonAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePolygonAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePump_EnergyCostAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePump_EnergyCostAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePump_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePump_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePump_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePump_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasePumpAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasePumpAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseSimplePolyline_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseSimplePolyline_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseSimplePolyline_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseSimplePolyline_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseSimplePolylineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseSimplePolylineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundaryLine2D_SurfaceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundaryLine2D_SurfaceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundaryLine2DAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundaryLine2DAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundaryPoint2D_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundaryPoint2D_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundaryPoint2D_SurfaceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundaryPoint2D_SurfaceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundaryPoint2DAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundaryPoint2DAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Design_LocalConstraints_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Design_LocalConstraints_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Design_LocalConstraints_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Design_LocalConstraints_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_DesignAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_DesignAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_HydrologicAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_HydrologicAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_DepressedGutter_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_DepressedGutter_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_DepressedGutter_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_DepressedGutter_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_GutterShape_ConventionalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_GutterShape_ConventionalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_GutterShape_IrregularAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_GutterShape_IrregularAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_GutterShape_ParabolicAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_GutterShape_ParabolicAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_GutterShape_TrapezoidalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_GutterShape_TrapezoidalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_GutterShape_VShapeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_GutterShape_VShapeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletGutterType_CatalogGutterAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletGutterType_CatalogGutterAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletGutterType_UserDefinedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletGutterType_UserDefinedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletLocation_InSagAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletLocation_InSagAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletLocation_OnGradeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletLocation_OnGradeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletType_CatalogInletAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletType_CatalogInletAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletType_FullCaptureAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletType_FullCaptureAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletType_HydrologicRatingCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletType_HydrologicRatingCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletType_MaximumCapacityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletType_MaximumCapacityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_Physical_InletType_PercentCaptureAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_Physical_InletType_PercentCaptureAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasin_SystemFlowsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasin_SystemFlowsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasinAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasinAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationUseAquiferDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationUseAquiferDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationUserDefinedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwBottomElevationUserDefinedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeInvertAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeInvertAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeUserDefinedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwHcbUseReceivingNodeUserDefinedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureUseAquiferDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureUseAquiferDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureUserDefinedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwUnsatZoneMoistureUserDefinedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationUseAquiferDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationUseAquiferDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationUserDefinedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_ApplyGroundWater_True_GwWaterTableElevationUserDefinedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LandCoverAreasAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LandCoverAreasAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_fLossAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_fLossAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_GenericHortonAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_GenericHortonAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_GreenAndAmptAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_GreenAndAmptAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_InitialThenConstantFractionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_InitialThenConstantFractionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_InitialThenConstantRateAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_InitialThenConstantRateAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_NoneAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_NoneAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_RunoffCoefficientAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_RunoffCoefficientAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_LossMethodType_ScsCnAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_LossMethodType_ScsCnAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_DefaultCurvilinearScsUnitHydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_DefaultCurvilinearScsUnitHydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_DimensionlessScsUnitHydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_DimensionlessScsUnitHydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_EpaSwmmAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_EpaSwmmAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_GenericUnitHydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_GenericUnitHydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_ILSAXMethod_NormalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_ILSAXMethod_NormalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_ILSAXMethod_UserDefinedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_ILSAXMethod_UserDefinedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_ModifiedRationalMethodAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_ModifiedRationalMethodAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_ModifiedRationalUKAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_ModifiedRationalUKAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_NoneAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_NoneAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_RationalMethodAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_RationalMethodAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_RTKUnitHydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_RTKUnitHydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_TimeAreaMethodAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_TimeAreaMethodAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_TriangularScsUnitHydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_TriangularScsUnitHydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_Hydrologic_RunoffMethod_UserDefinedHydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_Hydrologic_RunoffMethod_UserDefinedHydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_HydrologicAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_HydrologicAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_RainfallRunoffAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_RainfallRunoffAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchment_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Catchment_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsChannel_OutputAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Channel_OutputAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsChannel_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Channel_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Design_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Design_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Design_SpecifyLocalConstraint_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Design_SpecifyLocalConstraint_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Design_SpecifyLocalConstraint_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Design_SpecifyLocalConstraint_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Design_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Design_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_HeadlossAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_HeadlossAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_ConduitRiseLengthAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_ConduitRiseLengthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_ConduitSurfaceAreaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_ConduitSurfaceAreaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_HydrographAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_HydrographAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_InfCountBasedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_InfCountBasedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_InfNoneAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_InfNoneAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_LinkLengthAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_LinkLengthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflow_PatternLoadAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflow_PatternLoadAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_InfiltrationAndInflowAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_InfiltrationAndInflowAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_OutputAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_OutputAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_CapacityDiversionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_CapacityDiversionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_CatalogTypeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_CatalogTypeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_CutoffDiversionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_CutoffDiversionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasOvertoppingWeir_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasOvertoppingWeir_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasOvertoppingWeir_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasOvertoppingWeir_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasStartControlStructure_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasStartControlStructure_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasStartControlStructure_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasStartControlStructure_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasStopControlStructure_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasStopControlStructure_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasStopControlStructure_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasStopControlStructure_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasUserDefinedBendAngle_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasUserDefinedBendAngle_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_hasUserDefinedBendAngle_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_HasUserDefinedBendAngle_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_IsCulvertAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_IsCulvertAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_IsDivertedLink_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_IsDivertedLink_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_IsDivertedLink_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_IsDivertedLink_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_IsNotCulvertAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_IsNotCulvertAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_PseudoWeirDiversionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_PseudoWeirDiversionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_RatingTableDiversionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_RatingTableDiversionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_UseLocalMinimumTractiveStress_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_UseLocalMinimumTractiveStress_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_UseLocalMinimumTractiveStress_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_UseLocalMinimumTractiveStress_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Physical_UserDefinedTypeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Physical_UserDefinedTypeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_ArchAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_ArchAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_BasketHandlePipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_BasketHandlePipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_BoxPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_BoxPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_CatenaryPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_CatenaryPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_CircularPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_CircularPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_EggPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_EggPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_EllipticalPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_EllipticalPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_GothicPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_GothicPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_HorseshoePipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_HorseshoePipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_IrregularChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_IrregularChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_IrregularClosedSectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_IrregularClosedSectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_ModBasketHandlePipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_ModBasketHandlePipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_ParabolicChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_ParabolicChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_PipeArchAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_PipeArchAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_PowerChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_PowerChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_RectangularChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_RectangularChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_RectRoundChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_RectRoundChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_RectTriangleChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_RectTriangleChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_SemiCircularPipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_SemiCircularPipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_SemiEllipsePipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_SemiEllipsePipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_TrapezoidalChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_TrapezoidalChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduit_Shape_TriangularChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Conduit_Shape_TriangularChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduitAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConduitAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduitCxRoughness_Physical_BankChannelAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConduitCxRoughness_Physical_BankChannelAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduitCxRoughness_Physical_HorizontalSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConduitCxRoughness_Physical_HorizontalSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduitCxRoughness_Physical_RoughnessDepthAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConduitCxRoughness_Physical_RoughnessDepthAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduitCxRoughness_Physical_RoughnessFlowAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConduitCxRoughness_Physical_RoughnessFlowAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConduitCxRoughness_Physical_SingleRoughnessAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConduitCxRoughness_Physical_SingleRoughnessAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossSectionNode_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossSectionNode_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossSectionNode_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossSectionNode_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossSectionNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossSectionNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCxPhysical_CxDataType_GenericAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CxPhysical_CxDataType_GenericAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCxPhysical_CxDataType_TrapizoidalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CxPhysical_CxDataType_TrapizoidalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGlobalBase_Washington_Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GlobalBase_Washington_Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityLinkBase_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_ManningsN" typeName="double" displayLabel="Manning's n" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="Physical_DarcyWeisbachE" typeName="double" displayLabel="Darcy-Weisbach e" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_DARCYWEISBACH"/>
+        <ECProperty propertyName="Physical_HazenWilliamsC" typeName="double" displayLabel="Hazen-Williams C" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_HAZENWILLIAMS"/>
+        <ECProperty propertyName="Physical_KuttersN" typeName="double" displayLabel="Kutter's n" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_KUTTERS"/>
+        <ECProperty propertyName="Physical_Material" typeName="string" displayLabel="Material" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityLinkBase_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityLinkBase_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityLinkBaseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityLinkBaseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityNode_Design_LocalPipeMatchingConstraintsAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_LocalPipeMatchingConstraints" typeName="boolean" displayLabel="Local Pipe Matching Constraints?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravityNode_Design_LocalPipeMatchingConstraints_FalseAspect">
+        <BaseClass>GravityNode_Design_LocalPipeMatchingConstraintsAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityNode_Design_LocalPipeMatchingConstraints_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityNode_Design_LocalPipeMatchingConstraints_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityNode_Design_LocalPipeMatchingConstraints_TrueAspect">
+        <BaseClass>GravityNode_Design_LocalPipeMatchingConstraintsAspect</BaseClass>
+        <ECProperty propertyName="Design_LocalMatchlineOffset" typeName="double" displayLabel="Matchline Offset" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Design_LocalAllowDropStructure" typeName="boolean" displayLabel="Allow Drop Structure?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalUseDropStructureToMinimizeCover" typeName="boolean" displayLabel="Use Drop Structure to Minimize Cover?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalMinimumDropDepth" typeName="double" displayLabel="Minimum Drop Depth" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="LocalPipeMatching" typeName="GravityNode_Design_LocalPipeMatchingConstraints_TrueAspect_LocalPipeMatching_Enum" displayLabel="Pipe Matching?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityNode_Design_LocalPipeMatchingConstraints_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityNode_Design_LocalPipeMatchingConstraints_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityNode_DesignAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_DesignStructureElevation" typeName="boolean" displayLabel="Design Structure Elevation?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_DesiredSumpDepth" typeName="double" displayLabel="Sump Depth" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityNode_DesignAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityNode_DesignAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityNode_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_InvertElevation" typeName="double" displayLabel="Elevation (Invert)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityNode_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityNode_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_HeadlossAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HeadlossMethod" typeName="GravityStructure_HeadlossAspect_HeadlossMethod_Enum" displayLabel="Headloss Method" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_AashtoAspect">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+        <ECProperty propertyName="AashtoShapingMethod" typeName="GravityStructure_Headloss_AashtoAspect_AashtoShapingMethod_Enum" displayLabel="AASHTO Shaping Method" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_AashtoAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_AashtoAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_AbsoluteAspect">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+        <ECProperty propertyName="AbsoluteType_AbsoluteHeadloss" typeName="double" displayLabel="Absolute Headloss" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_AbsoluteAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_AbsoluteAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_FlowCurveAspect">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_FlowCurveAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_FlowCurveAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_GenericAspect">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+        <ECProperty propertyName="GenericType_DownstreamHeadlossCoefficient" typeName="double" displayLabel="Headloss Coefficient (Downstream)" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GenericType_UpstreamHeadlossCoefficient" typeName="double" displayLabel="Headloss Coefficient (Upstream)" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_GenericAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_GenericAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_Hec22EnergyBaseAspect" modifier="Abstract">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+        <ECProperty propertyName="Hec22BenchingMethod" typeName="GravityStructure_Headloss_Hec22EnergyBaseAspect_Hec22BenchingMethod_Enum" displayLabel="HEC-22 Benching Method" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_Hec22Energy3rdEditionAspect">
+        <BaseClass>GravityStructure_Headloss_Hec22EnergyBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_Hec22Energy3rdEditionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_Hec22Energy3rdEditionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_Hec22EnergyAspect">
+        <BaseClass>GravityStructure_Headloss_Hec22EnergyBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_Hec22EnergyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_Hec22EnergyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_Hec22MomentumBasedAspect">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_Hec22MomentumBasedAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_Hec22MomentumBasedAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_Headloss_StandardAspect">
+        <BaseClass>GravityStructure_HeadlossAspect</BaseClass>
+        <ECProperty propertyName="StandardType_StandardHeadlossCoefficient" typeName="double" displayLabel="Headloss Coefficient (Standard)" category="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_Headloss_StandardAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_Headloss_StandardAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_HeadlossAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_HeadlossAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructure_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InitialSettings_InitialDepth" typeName="double" displayLabel="Depth (Initial)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructure_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructure_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructureAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructureAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_DesignAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_RequiredFreeboard" typeName="double" displayLabel="Freeboard (Required)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_DesignAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_DesignAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_OutputAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HasTwoDTimeSeriesResults" typeName="boolean" displayLabel="Has 2D Detailed Results?" category="Output_2D_Drainage_Output_2D_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_OutputAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_OutputAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_GravityStructureTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityStructureType" typeName="GravitySurfaceStructure_Physical_GravityStructureTypeAspect_GravityStructureType_Enum" displayLabel="Structure Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_GravityStructureType_BoxAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_GravityStructureTypeAspect</BaseClass>
+        <ECProperty propertyName="BoxStructureType_Length" typeName="double" displayLabel="Length" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+        <ECProperty propertyName="BoxStructureType_Width" typeName="double" displayLabel="Width" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_GravityStructureType_BoxAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_GravityStructureType_BoxAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_GravityStructureType_CircularAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_GravityStructureTypeAspect</BaseClass>
+        <ECProperty propertyName="CircularStructureType_Diameter" typeName="double" displayLabel="Diameter" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_GravityStructureType_CircularAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_GravityStructureType_CircularAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_GravityStructureType_TransitionNodeAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_GravityStructureTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_GravityStructureType_TransitionNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_GravityStructureType_TransitionNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfaceStorageType" typeName="GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect_SurfaceStorageType_Enum" displayLabel="Surface Storage Type" category="Physical_Surface_Storage_Drainage_Physical_Surface_Storage_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_SurfaceStorageType_DefaultStorageEquationAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_SurfaceStorageType_DefaultStorageEquationAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_SurfaceStorageType_DefaultStorageEquationAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_SurfaceStorageType_NoStorageAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_SurfaceStorageType_NoStorageAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_SurfaceStorageType_NoStorageAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_SurfaceStorageType_SurfaceConstantAreaAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect</BaseClass>
+        <ECProperty propertyName="SurfaceConstantAreaType_SurfaceConstantArea" typeName="double" displayLabel="Area (Constant Surface)" category="Physical_Surface_Storage_Drainage_Physical_Surface_Storage_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_SurfaceStorageType_SurfaceConstantAreaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_SurfaceStorageType_SurfaceConstantAreaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_Physical_SurfaceStorageType_SurfaceDepthAreaAspect">
+        <BaseClass>GravitySurfaceStructure_Physical_SurfaceStorageTypeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_Physical_SurfaceStorageType_SurfaceDepthAreaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_Physical_SurfaceStorageType_SurfaceDepthAreaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_SetRimToGroundElevation" typeName="boolean" displayLabel="Set Rim to Ground Elevation?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_RimElevation" typeName="double" displayLabel="Elevation (Rim)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GridRimElevationMatching" typeName="GravitySurfaceStructure_PhysicalAspect_GridRimElevationMatching_Enum" displayLabel="2D Surface Elevation Matching" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_SystemFlowsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SystemFlows_KnownFlow" typeName="double" displayLabel="Flow (Known)" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_SystemFlowsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_SystemFlowsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravitySurfaceStructure_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_H2S" typeName="double" displayLabel="H2S (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="WaterQuality_BOD" typeName="double" displayLabel="BOD (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructure_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructure_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGravitySurfaceStructureAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravitySurfaceStructureAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Grid2D_BoundaryConditionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridBoundaryType" typeName="Grid2D_BoundaryConditionAspect_GridBoundaryType_Enum" displayLabel="Grid Boundary Type" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0"/>
+        <ECProperty propertyName="BoundaryElevation" typeName="double" displayLabel="Water Surface Elevation (Boundary)" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGrid2D_BoundaryConditionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Grid2D_BoundaryConditionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Grid2D_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridInitialValuesType" typeName="Grid2D_InitialSettingsAspect_GridInitialValuesType_Enum" displayLabel="Initial Depth Mode" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0"/>
+        <ECProperty propertyName="Grid_InitialDepth" typeName="double" displayLabel="Depth (Initial)" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Grid_InitialElevation" typeName="double" displayLabel="Elevation (Initial)" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGrid2D_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Grid2D_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Grid2D_SurfaceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Surface_GridCellSize" typeName="double" displayLabel="Grid Cell Size" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+        <ECProperty propertyName="Surface_GridAngle" typeName="double" displayLabel="Angle" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="Surface_DefaultManningsN" typeName="double" displayLabel="Manning's n (Default)" category="Defaults_2D_Drainage_Defaults_2D_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="GridSurfaceInfiltrationMode" typeName="Grid2D_SurfaceAspect_GridSurfaceInfiltrationMode_Enum" displayLabel="Infiltration Mode" category="Defaults_2D_Drainage_Defaults_2D_Drainage" priority="0"/>
+        <ECProperty propertyName="Surface_DefaultCN" typeName="double" displayLabel="SCS CN (Default)" category="Defaults_2D_Drainage_Defaults_2D_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="Surface_DefaultImpermeabilityFraction" typeName="double" displayLabel="Impermeability Fraction (Default)" category="Defaults_2D_Drainage_Defaults_2D_Drainage" priority="0" kindOfQuantity="cifu:FRACTION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGrid2D_SurfaceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Grid2D_SurfaceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Grid2DAspect">
+        <BaseClass>BasePolygonAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGrid2DAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Grid2DAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GutterLink_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_GutterManningsN" typeName="double" displayLabel="Manning's n (Gutter)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="Physical_GutterMaterial" typeName="string" displayLabel="Gutter Material" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="GutterLinkGutterType" typeName="GutterLink_PhysicalAspect_GutterLinkGutterType_Enum" displayLabel="Gutter Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="GutterShape" typeName="GutterLink_PhysicalAspect_GutterShape_Enum" displayLabel="Gutter Shape" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="GutterShapeType_RightSideSlope" typeName="double" displayLabel="Right Side Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="GutterShapeType_LeftSideSlope" typeName="double" displayLabel="Left Side Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="VShapedGutterType_CurbCrossSlope" typeName="double" displayLabel="Curb Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_MaximumGutterDepth" typeName="double" displayLabel="Maximum Gutter Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Physical_DitchBottomWidth" typeName="double" displayLabel="Bottom Width (Ditch)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_RoadCrossSlope" typeName="double" displayLabel="Road Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_DepressedGutter" typeName="boolean" displayLabel="Depressed Gutter?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_GutterCrossSlope" typeName="double" displayLabel="Gutter Cross Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_GutterWidth" typeName="double" displayLabel="Gutter Width" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParabolicGutterType_Height" typeName="double" displayLabel="Height" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ParabolicGutterType_Width" typeName="double" displayLabel="Width (Parabolic Gutter)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGutterLink_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GutterLink_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GutterLinkAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGutterLinkAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GutterLinkAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Headwall_BoundaryConditionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundaryConditionType" typeName="Headwall_BoundaryConditionAspect_BoundaryConditionType_Enum" displayLabel="Boundary Condition Type" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0"/>
+        <ECProperty propertyName="UserDefinedTwType_UserDefinedTailwater" typeName="double" displayLabel="Elevation (User Defined Tailwater)" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHeadwall_BoundaryConditionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Headwall_BoundaryConditionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Headwall_DesignAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Design_DesignStructureElevation" typeName="boolean" displayLabel="Design Structure Elevation?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_DesiredSumpDepth" typeName="double" displayLabel="Sump Depth" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Design_NodeMinimumCover" typeName="double" displayLabel="Conduit Cover at Node (Minimum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Design_NodeMaximumCover" typeName="double" displayLabel="Conduit Cover at Node (Maximum)" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Design_LocalPipeMatchingConstraints" typeName="boolean" displayLabel="Local Pipe Matching Constraints?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalMatchlineOffset" typeName="double" displayLabel="Matchline Offset" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Design_LocalAllowDropStructure" typeName="boolean" displayLabel="Allow Drop Structure?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalUseDropStructureToMinimizeCover" typeName="boolean" displayLabel="Use Drop Structure to Minimize Cover?" category="Design_Drainage_Design_Drainage" priority="0"/>
+        <ECProperty propertyName="Design_LocalMinimumDropDepth" typeName="double" displayLabel="Minimum Drop Depth" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Design_LocalMinimumStandPipeHeight" typeName="double" displayLabel="Minimum Standpipe Height" category="Design_Drainage_Design_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="LocalPipeMatching" typeName="Headwall_DesignAspect_LocalPipeMatching_Enum" displayLabel="Pipe Matching?" category="Design_Drainage_Design_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHeadwall_DesignAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Headwall_DesignAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Headwall_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TransitionType" typeName="Headwall_PhysicalAspect_TransitionType_Enum" displayLabel="Transition Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="GradualType_TransitionLength" typeName="double" displayLabel="Transition Length" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CrossSectionType" typeName="Headwall_PhysicalAspect_CrossSectionType_Enum" displayLabel="Cross Section Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="CatalogCrossSectionType_CatalogConduitSIze" typeName="string" displayLabel="Size" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_InvertElevation" typeName="double" displayLabel="Elevation (Invert)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_HeadwallHasCrossSection" typeName="boolean" displayLabel="Has Cross Section?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHeadwall_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Headwall_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Headwall_SystemFlowsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SystemFlows_KnownFlow" typeName="double" displayLabel="Flow (Known)" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHeadwall_SystemFlowsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Headwall_SystemFlowsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="HeadwallAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHeadwallAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="HeadwallAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpStationAspect">
+        <BaseClass>BasePolygonAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpStationAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpStationAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IrregularChannel_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IrregularChannelType_LeftBankStation" typeName="double" displayLabel="Station (Left Bank)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="IrregularChannelType_RightBankStation" typeName="double" displayLabel="Station (Right Bank)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="IrregularChannelType_StationsModifier" typeName="double" displayLabel="Stations Modifier" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="IrregularChannelType_ElevationsModifier" typeName="double" displayLabel="Elevations Modifier" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="IrregularChannelType_MeanderModifier" typeName="double" displayLabel="Meander Modifier" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="OpenChannelWeightingMethod" typeName="IrregularChannel_PhysicalAspect_OpenChannelWeightingMethod_Enum" displayLabel="Channel Weighting Method" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIrregularChannel_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IrregularChannel_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="JunctionChamber_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_TransitionLength" typeName="double" displayLabel="Transition Length" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_SetTopToGroundElevation" typeName="boolean" displayLabel="Set Top to Ground Elevation?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_TopElevation" typeName="double" displayLabel="Elevation (Top)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsJunctionChamber_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="JunctionChamber_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="JunctionChamber_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_H2S" typeName="double" displayLabel="H2S (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="WaterQuality_BOD" typeName="double" displayLabel="BOD (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsJunctionChamber_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="JunctionChamber_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="JunctionChamberAspect">
+        <BaseClass>GravityStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsJunctionChamberAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="JunctionChamberAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LateralLink_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_SetInvertToUpstream" typeName="boolean" displayLabel="Set Invert to Start?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_UpstreamInvert" typeName="double" displayLabel="Invert (Start)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_SetInvertToDownstream" typeName="boolean" displayLabel="Set Invert to Stop?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_DownstreamInvert" typeName="double" displayLabel="Invert (Stop)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_LateralDiameter" typeName="double" displayLabel="Diameter" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Physical_LateralMaterial" typeName="string" displayLabel="Material" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_LateralManningsN" typeName="double" displayLabel="Manning's n" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLateralLink_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LateralLink_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LateralLinkAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLateralLinkAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LateralLinkAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LID_HydrologicAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Hydrologic_TopWidthOverlandFlow" typeName="double" displayLabel="Top Width of Overland Flow Surface of Each Unit" category="Hydrology_Drainage_Hydrology_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Hydrologic_PercentInitiallySaturated" typeName="double" displayLabel="Percent Initially Saturated" category="Hydrology_Drainage_Hydrology_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="Hydrologic_LIDControlNumber" typeName="int" displayLabel="Number of Replicate Units" category="Hydrology_Drainage_Hydrology_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_OccupiesFullSubcatchment" typeName="boolean" displayLabel="Occupies Full Catchment?" category="Hydrology_Drainage_Hydrology_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_LIDControlArea" typeName="double" displayLabel="Area of Each Unit" category="Hydrology_Drainage_Hydrology_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Hydrologic_PercentImpArea" typeName="double" displayLabel="Percent Impervious Area Treated" category="Hydrology_Drainage_Hydrology_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="Hydrologic_SendOutflowToPervious" typeName="boolean" displayLabel="Send Outflow To Pervious Area?" category="Hydrology_Drainage_Hydrology_Drainage" priority="0"/>
+        <ECProperty propertyName="Hydrologic_PercentPervArea" typeName="double" displayLabel="Percent Pervious Area Treated" category="Hydrology_Drainage_Hydrology_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLID_HydrologicAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LID_HydrologicAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LID_OutputAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OutputOptionsType" typeName="LID_OutputAspect_OutputOptionsType_Enum" displayLabel="Output Options" category="Output_Drainage_Output_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLID_OutputAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LID_OutputAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LIDAspect">
+        <BaseClass>BasePolygonAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLIDAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LIDAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Manhole_InfiltrationAndInflowAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InfiltrationAndInflow_ApplySWMMRTKUnitHydrographSet" typeName="boolean" displayLabel="Apply SWMM RTK Unit Hydrograph Set?" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Manhole_InfiltrationAndInflow_FalseAspect">
+        <BaseClass>Manhole_InfiltrationAndInflowAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsManhole_InfiltrationAndInflow_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Manhole_InfiltrationAndInflow_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Manhole_InfiltrationAndInflow_TrueAspect">
+        <BaseClass>Manhole_InfiltrationAndInflowAspect</BaseClass>
+        <ECProperty propertyName="InfiltrationAndInflow_SewershedArea" typeName="double" displayLabel="Sewershed Area" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsManhole_InfiltrationAndInflow_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Manhole_InfiltrationAndInflow_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Manhole_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_IsBolted" typeName="boolean" displayLabel="Bolted Cover?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_SurchargedDepth" typeName="double" displayLabel="Depth (Surcharged)" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsManhole_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Manhole_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Manhole_RainfallRunoffAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RainfallRunoff_UseLocalRainfall" typeName="boolean" displayLabel="Use Local Rainfall?" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+        <ECProperty propertyName="RainfallRunoff_StormEventID" typeName="string" displayLabel="Local Storm Event" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsManhole_RainfallRunoffAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Manhole_RainfallRunoffAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ManholeAspect">
+        <BaseClass>GravitySurfaceStructureAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsManholeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ManholeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Node_WaterQualityAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_ApplyTreatment" typeName="boolean" displayLabel="Apply Treatment?" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Node_WaterQuality_FalseAspect">
+        <BaseClass>Node_WaterQualityAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNode_WaterQuality_FalseAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Node_WaterQuality_FalseAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Node_WaterQuality_TrueAspect">
+        <BaseClass>Node_WaterQualityAspect</BaseClass>
+        <ECProperty propertyName="TreatmentUnits" typeName="Node_WaterQuality_TrueAspect_TreatmentUnits_Enum" displayLabel="Treatment Units" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNode_WaterQuality_TrueAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Node_WaterQuality_TrueAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Outfall_BoundaryConditionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundaryConditionType" typeName="Outfall_BoundaryConditionAspect_BoundaryConditionType_Enum" displayLabel="Boundary Condition Type" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0"/>
+        <ECProperty propertyName="UserDefinedTwType_UserDefinedTailwater" typeName="double" displayLabel="Elevation (User Defined Tailwater)" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="BoundaryCondition_HasTidalGate" typeName="boolean" displayLabel="Tidal Gate?" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOutfall_BoundaryConditionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Outfall_BoundaryConditionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Outfall_InfiltrationAndInflowAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InfiltrationAndInflow_ApplySWMMRTKUnitHydrographSet" typeName="boolean" displayLabel="Apply SWMM RTK Unit Hydrograph Set?" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0"/>
+        <ECProperty propertyName="InfiltrationAndInflow_SewershedArea" typeName="double" displayLabel="Sewershed Area" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOutfall_InfiltrationAndInflowAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Outfall_InfiltrationAndInflowAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Outfall_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_SetRimToGroundElevation" typeName="boolean" displayLabel="Set Rim to Ground Elevation?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_RimElevation" typeName="double" displayLabel="Elevation (Rim)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOutfall_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Outfall_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Outfall_RainfallRunoffAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RainfallRunoff_UseLocalRainfall" typeName="boolean" displayLabel="Use Local Rainfall?" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+        <ECProperty propertyName="RainfallRunoff_StormEventID" typeName="string" displayLabel="Local Storm Event" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOutfall_RainfallRunoffAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Outfall_RainfallRunoffAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="OutfallAspect">
+        <BaseClass>GravityNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOutfallAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="OutfallAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PhysicalLink_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InitialSettings_InitialFlow" typeName="double" displayLabel="Flow (Initial)" category="Simulation_Initial_Condition_Drainage_Simulation_Initial_Condition_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPhysicalLink_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PhysicalLink_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PhysicalLink_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_SetInvertToUpstream" typeName="boolean" displayLabel="Set Invert to Start?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_UpstreamInvert" typeName="double" displayLabel="Invert (Start)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_SetInvertToDownstream" typeName="boolean" displayLabel="Set Invert to Stop?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_DownstreamInvert" typeName="double" displayLabel="Invert (Stop)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_MaximumFlow" typeName="double" displayLabel="Flow (Maximum User Defined)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPhysicalLink_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PhysicalLink_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PhysicalLink_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_H2STemperature" typeName="double" displayLabel="Temperature (H2S)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:TEMPERATURE"/>
+        <ECProperty propertyName="WaterQuality_H2SFluxCoefficient" typeName="double" displayLabel="H2S Flux Coefficient" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="WaterQuality_H2SLossFactor" typeName="double" displayLabel="H2S Loss Factor " category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPhysicalLink_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PhysicalLink_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsPhysicalLinkAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PhysicalLinkAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartingWSType" typeName="Pond_InitialSettingsAspect_StartingWSType_Enum" displayLabel="Initial Elevation Type" category="Simulation_Initial_Condition_Drainage_Simulation_Initial_Condition_Drainage" priority="0"/>
+        <ECProperty propertyName="UserDefinedWSElevationType_InitialElevation" typeName="double" displayLabel="Elevation (Initial)" category="Simulation_Initial_Condition_Drainage_Simulation_Initial_Condition_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_InfiltrationMethodAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PondInfiltrationMethod" typeName="Pond_Physical_InfiltrationMethodAspect_PondInfiltrationMethod_Enum" displayLabel="Pond Seepage Method" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Pond_Physical_InfiltrationMethod_WithAverageAspect" modifier="Abstract">
+        <BaseClass>Pond_Physical_InfiltrationMethodAspect</BaseClass>
+        <ECProperty propertyName="AverageInfiltrationType_AverageInfiltration" typeName="double" displayLabel="Seepage Rate (Average)" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Pond_Physical_InfiltrationMethod_AverageAspect">
+        <BaseClass>Pond_Physical_InfiltrationMethod_WithAverageAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_InfiltrationMethod_AverageAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_InfiltrationMethod_AverageAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_InfiltrationMethod_ConstantAspect">
+        <BaseClass>Pond_Physical_InfiltrationMethod_WithAverageAspect</BaseClass>
+        <ECProperty propertyName="ConstantFlowType_Flow" typeName="double" displayLabel="Constant Flow" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_InfiltrationMethod_ConstantAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_InfiltrationMethod_ConstantAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_InfiltrationMethod_GreenAmptAspect">
+        <BaseClass>Pond_Physical_InfiltrationMethodAspect</BaseClass>
+        <ECProperty propertyName="GreenAmptType_SuctionHead" typeName="double" displayLabel="Suction Head" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GreenAmptType_Conductivity" typeName="double" displayLabel="Conductivity" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:RAINFALL_INTENSITY"/>
+        <ECProperty propertyName="GreenAmptType_InitialDeficit" typeName="double" displayLabel="Initial Deficit" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Pond_ElevationVolumeIncrement" typeName="double" displayLabel="Chamber System Elevation-Volume Increment" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_InfiltrationMethod_GreenAmptAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_InfiltrationMethod_GreenAmptAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_InfiltrationMethod_NoneAspect">
+        <BaseClass>Pond_Physical_InfiltrationMethodAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_InfiltrationMethod_NoneAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_InfiltrationMethod_NoneAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VolumeType" typeName="Pond_Physical_VolumeTypeAspect_VolumeType_Enum" displayLabel="Volume Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeTypeWithMaxCurveDepthAspect" modifier="Abstract">
+        <BaseClass>Pond_Physical_VolumeTypeAspect</BaseClass>
+        <ECProperty propertyName="VolumeType_MaximumCurveDepth" typeName="double" displayLabel="Depth (Maximum Curve)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_ElevationAreaAspect">
+        <BaseClass>Pond_Physical_VolumeTypeWithMaxCurveDepthAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_VolumeType_ElevationAreaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_VolumeType_ElevationAreaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_ElevationVolumeAspect">
+        <BaseClass>Pond_Physical_VolumeTypeWithMaxCurveDepthAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_VolumeType_ElevationVolumeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_VolumeType_ElevationVolumeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_PipeVolumeAspect">
+        <BaseClass>Pond_Physical_VolumeTypeAspect</BaseClass>
+        <ECProperty propertyName="Physical_UseVoidSpace" typeName="boolean" displayLabel="Use Void Space?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_VoidSpace" typeName="double" displayLabel="Void Space" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="PipeVolumeType_UpstreamInvert" typeName="double" displayLabel="Invert (Start)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PipeVolumeType_DownstreamInvert" typeName="double" displayLabel="Invert (Stop)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PipeVolumeType_PipeDiameter" typeName="double" displayLabel="Pipe Diameter" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="PipeVolumeType_Length" typeName="double" displayLabel="Length" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PipeVolumeType_NumberOfBarrels" typeName="int" displayLabel="Number of Barrels" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="PipeVolumeType_SliceWidth" typeName="double" displayLabel="Slice Width (Pipe)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+        <ECProperty propertyName="PipeVolumeType_VeritcalIncrement" typeName="double" displayLabel="Vertical Increment (Pipe)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_WIDTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_VolumeType_PipeVolumeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_VolumeType_PipeVolumeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_StorageChamberSystemAspect">
+        <BaseClass>Pond_Physical_VolumeTypeAspect</BaseClass>
+        <ECProperty propertyName="StorageChamberSystemType_StorageSystemElevation" typeName="double" displayLabel="Chamber System Invert" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="StorageChamberSystemType_NumberOfRows" typeName="int" displayLabel="Chamber System Rows" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="StorageChamberSystemType_ChambersPerRow" typeName="int" displayLabel="Chambers per Row" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="StorageChamberSystemType_FillVoidSpace" typeName="double" displayLabel="Chamber System Fill Void Space" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="StorageChamberSystemType_RowSpacing" typeName="double" displayLabel="Chamber System Row Spacing" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="StorageChamberSystemType_SideFill" typeName="double" displayLabel="Chamber System Side Fill" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="StorageChamberSystemType_FillCoverDepth" typeName="double" displayLabel="Chamber System Fill Cover Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="StorageChamberSystemType_FillBaseDepth" typeName="double" displayLabel="Chamber System Fill Base Depth" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="StorageChamberSystemType_FillSideSlope" typeName="double" displayLabel="Chamber System Fill Side Slope" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SIDESLOPE"/>
+        <ECProperty propertyName="StorageChamberSystemType_EndFill" typeName="double" displayLabel="Chamber System End Fill" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="StorageChamberSystemType_IncludeHeader" typeName="boolean" displayLabel="Chamber System Includes Header?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="StorageChamberSystemType_ChambersInHeader" typeName="int" displayLabel="Chambers In Header " category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="StorageChamberSystemType_HeaderDistance" typeName="double" displayLabel="Chamber System Header Distance" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_VolumeType_StorageChamberSystemAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_VolumeType_StorageChamberSystemAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_VolumeFunctionBaseAspect" modifier="Abstract">
+        <BaseClass>Pond_Physical_VolumeTypeAspect</BaseClass>
+        <ECProperty propertyName="VolumeFunctionType_PondInvertElevation" typeName="double" displayLabel="Elevation (Invert)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="VolumeFunctionType_PondMaxDepth" typeName="double" displayLabel="Depth (Maximum Function)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="VolumeFunctionType_PondCoeff" typeName="double" displayLabel="Pond Coefficient" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="VolumeFunctionType_PondExponent" typeName="double" displayLabel="Pond Exponent" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="VolumeFunctionType_PondConstant" typeName="double" displayLabel="Pond Constant" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_VolumeFunctionSIAspect">
+        <BaseClass>Pond_Physical_VolumeType_VolumeFunctionBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_VolumeType_VolumeFunctionSIAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_VolumeType_VolumeFunctionSIAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_Physical_VolumeType_VolumeFunctionUSAspect">
+        <BaseClass>Pond_Physical_VolumeType_VolumeFunctionBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_Physical_VolumeType_VolumeFunctionUSAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_Physical_VolumeType_VolumeFunctionUSAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_RainfallRunoffAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RainfallRunoff_EvapFactor" typeName="double" displayLabel="Evaporation Factor" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_RainfallRunoffAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_RainfallRunoffAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Pond_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_H2S" typeName="double" displayLabel="H2S (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="WaterQuality_BOD" typeName="double" displayLabel="BOD (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="WaterQuality_H2SRrate" typeName="double" displayLabel="Reaction Rate (H2S)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:REACTION_RATE"/>
+        <ECProperty propertyName="WaterQuality_H2SNodeTemperature" typeName="double" displayLabel="Temperature (H2S)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:TEMPERATURE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPond_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Pond_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PondAspect">
+        <BaseClass>BasePolygonAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPondAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PondAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PondOutletStructure_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PondOutletDataType" typeName="PondOutletStructure_PhysicalAspect_PondOutletDataType_Enum" displayLabel="Has Control Structure?" category="Pond_Outlet_Drainage_Pond_Outlet_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPondOutletStructure_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PondOutletStructure_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PondOutletStructureAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPondOutletStructureAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PondOutletStructureAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureJunction_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_PressureJunctionElevation" typeName="double" displayLabel="Elevation" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureJunction_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureJunction_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureSystemNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="PressureJunctionAspect">
+        <BaseClass>PressureSystemNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureJunctionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureJunctionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressurePipe_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PipeStatus" typeName="PressurePipe_InitialSettingsAspect_PipeStatus_Enum" displayLabel="Status (Initial)" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressurePipe_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressurePipe_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressurePipe_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_PipeDiameter" typeName="double" displayLabel="Diameter" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="Physical_HasCheckValve" typeName="boolean" displayLabel="Has Check Valve?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_IsVirtual" typeName="boolean" displayLabel="Is Virtual?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_SpecifyLocalMinorLoss" typeName="boolean" displayLabel="Specify Local Minor Loss?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_CompositeMinorLoss" typeName="double" displayLabel="Minor Loss Coefficient (Local)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Physical_CalculatedMinorLossCoefficient" typeName="double" displayLabel="Minor Loss Coefficient (Derived)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressurePipe_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressurePipe_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressurePipeAspect">
+        <BaseClass>GravityLinkBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressurePipeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressurePipeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureSystemNode_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_H2S" typeName="double" displayLabel="H2S (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="WaterQuality_BOD" typeName="double" displayLabel="BOD (Local Inflow)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureSystemNode_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureSystemNode_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureSystemNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureSystemNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PropertyConnection_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_InvertElevation" typeName="double" displayLabel="Elevation (Invert)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPropertyConnection_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PropertyConnection_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PropertyConnection_SanitaryLoadingAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PropertyConnectionSanitaryPatternLoadType_BaseFlow" typeName="double" displayLabel="Base Flow" category="Sanitary_Pattern_Load_Drainage_Sanitary_Pattern_Load_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PropertyConnectionSanitaryUnitLoadType_LoadingUnitNumber" typeName="double" displayLabel="Loading Unit Count" category="Sanitary_Unit_Loads_Drainage_Sanitary_Unit_Loads_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPropertyConnection_SanitaryLoadingAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PropertyConnection_SanitaryLoadingAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PropertyConnectionAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPropertyConnectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PropertyConnectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ScadaElement_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsScadaElement_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ScadaElement_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ScadaElement_ScadaAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Scada_TargetElementStorageUnit" typeName="int" displayLabel="Model Element (Storage Unit)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="TargetAttribute" typeName="ScadaElement_ScadaAspect_TargetAttribute_Enum" displayLabel="Field" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsScadaElement_ScadaAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ScadaElement_ScadaAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ScadaElementAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsScadaElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ScadaElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardPump_OperationalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Operational_OnElevation" typeName="double" displayLabel="Elevation (On)" category="Operational_Drainage_Operational_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Operational_OffElevation" typeName="double" displayLabel="Elevation (Off)" category="Operational_Drainage_Operational_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Operational_IgnoreOnOffElevations" typeName="boolean" displayLabel="Ignore On and Off Elevations?" category="Operational_Drainage_Operational_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardPump_OperationalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardPump_OperationalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardPump_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VSPType" typeName="StandardPump_PhysicalAspect_VSPType_Enum" displayLabel="VSP Type" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="FixedFlowType_PumpFlowTarget" typeName="double" displayLabel="Flow (Target)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="FixedHeadType_MaximumRelativeSpeedFactor" typeName="double" displayLabel="Relative Speed Factor (Maximum)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="FixedHeadType_TargetHead" typeName="double" displayLabel="Hydraulic Grade (Target)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="FixedHeadType_IsSuctionSideVsp" typeName="boolean" displayLabel="Control Node on Suction Side?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_IsVariableSpeedPump" typeName="boolean" displayLabel="Is Variable Speed Pump?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardPump_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardPump_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardPumpAspect">
+        <BaseClass>BasePumpAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardPumpAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardPumpAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfaceLine_SurfaceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfacePolylineType" typeName="SurfaceLine_SurfaceAspect_SurfacePolylineType_Enum" displayLabel="Type" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolylineRoadWidth" typeName="double" displayLabel="Road Width" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RoadElevationAdjustmentType" typeName="SurfaceLine_SurfaceAspect_RoadElevationAdjustmentType_Enum" displayLabel="Elevation Adjustment Operation" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="RoadElevationAdjustment" typeName="double" displayLabel="Elevation Adjustment" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="SurfacePolylineCNAdjustmentType" typeName="SurfaceLine_SurfaceAspect_SurfacePolylineCNAdjustmentType_Enum" displayLabel="SCS CN Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolylineSCSCN" typeName="double" displayLabel="SCS CN (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="SurfacePolylineImpAdjustmentType" typeName="SurfaceLine_SurfaceAspect_SurfacePolylineImpAdjustmentType_Enum" displayLabel="Impermeability Fraction Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolylineImpermeabilityFraction" typeName="double" displayLabel="Impermeability Fraction (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:FRACTION"/>
+        <ECProperty propertyName="SurfacePolylineManningsAdjustmentType" typeName="SurfaceLine_SurfaceAspect_SurfacePolylineManningsAdjustmentType_Enum" displayLabel="Manning's n Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolylineManningsN" typeName="double" displayLabel="Manning's n (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfaceLine_SurfaceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfaceLine_SurfaceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfaceLineAspect">
+        <BaseClass>BaseSimplePolylineAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfaceLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfaceLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfacePoint_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfacePoint_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfacePoint_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfacePoint_SurfaceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfacePointType" typeName="SurfacePoint_SurfaceAspect_SurfacePointType_Enum" displayLabel="Type" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePointElevationAdjustmentType" typeName="SurfacePoint_SurfaceAspect_SurfacePointElevationAdjustmentType_Enum" displayLabel="Elevation Adjustment Operation" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePointElevationRelativeAdjustment" typeName="double" displayLabel="Elevation Adjustment" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfacePoint_SurfaceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfacePoint_SurfaceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfacePointAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfacePointAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfacePointAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfacePolygon_SurfaceAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfacePolygonType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonType_Enum" displayLabel="Type" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonElevationAdjustmentType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonElevationAdjustmentType_Enum" displayLabel="Elevation Adjustment Operation" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonElevationAdjustment" typeName="double" displayLabel="Elevation Adjustment" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="SurfacePolygonCNAdjustmentType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonCNAdjustmentType_Enum" displayLabel="SCS CN Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonCN" typeName="double" displayLabel="SCS CN (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="SurfacePolygonImpAdjustmentType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonImpAdjustmentType_Enum" displayLabel="Impermeability Fraction Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonImpermeabilityFraction" typeName="double" displayLabel="Impermeability Fraction (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:FRACTION"/>
+        <ECProperty propertyName="SurfacePolygonManningsAdjustmentType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonManningsAdjustmentType_Enum" displayLabel="Manning's n Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonMannings" typeName="double" displayLabel="Manning's n (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="SurfacePolygonPriorityType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonPriorityType_Enum" displayLabel="Priority" category="Type_Operations_Drainage_Type_Operations_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonCAdjustmentType" typeName="SurfacePolygon_SurfaceAspect_SurfacePolygonCAdjustmentType_Enum" displayLabel="Rational C Adjustment Type" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0"/>
+        <ECProperty propertyName="SurfacePolygonC" typeName="double" displayLabel="Rational C (User Defined)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfacePolygon_SurfaceAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfacePolygon_SurfaceAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfacePolygonAspect">
+        <BaseClass>BasePolygonAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfacePolygonAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfacePolygonAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfaceProfilePolylineAspect">
+        <BaseClass>BaseSimplePolylineAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfaceProfilePolylineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfaceProfilePolylineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TapNode_HMIActiveTopologyAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIActiveTopologyIsActive" typeName="boolean" displayLabel="Is Active?" category="Active_Topology_Drainage_Active_Topology_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTapNode_HMIActiveTopologyAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TapNode_HMIActiveTopologyAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TapNode_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIGeometryReferenceNodeIsFixed" typeName="boolean" displayLabel="Is coordinate fixed?" category="Geometry_Drainage_Geometry_Drainage" priority="0"/>
+        <ECProperty propertyName="HMIGeometryReferenceNodeDistanceFromEndPoint" typeName="double" displayLabel="Distance from End Point (Scaled)" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HMIGeometryReferenceNodeIsLeft" typeName="boolean" displayLabel="Is offset to the left of referenced link?" category="Geometry_Drainage_Geometry_Drainage" priority="0"/>
+        <ECProperty propertyName="HMIGeometryReferenceNodeOffsetDistance" typeName="double" displayLabel="Offset distance" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HMIGeometryReferenceNodeIsRefStartPoint" typeName="boolean" displayLabel="Is distance measured from start point of referenced link?" category="Geometry_Drainage_Geometry_Drainage" priority="0"/>
+        <ECProperty propertyName="HmiDataSetGeometry_NodeRotation" typeName="double" displayLabel="Node Rotation" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTapNode_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TapNode_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TapNode_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TapConnectsAt" typeName="TapNode_PhysicalAspect_TapConnectsAt_Enum" displayLabel="Lateral Connects From" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="TapElevationOffset" typeName="double" displayLabel="Elevation Offset" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTapNode_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TapNode_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TapNodeAspect">
+        <BaseClass>GlobalBase_Washington_Aspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTapNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TapNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VariableSpeedPumpBattery_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_VspbTargetHead" typeName="double" displayLabel="Hydraulic Grade (Target)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_MaximumRelativeSpeedFactor" typeName="double" displayLabel="Relative Speed Factor (Maximum)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Physical_NumberOfLagPumps" typeName="int" displayLabel="Lag Pump Count" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_IsSuctionSideVSPB" typeName="boolean" displayLabel="Control Node on Suction Side?" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVariableSpeedPumpBattery_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VariableSpeedPumpBattery_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VariableSpeedPumpBatteryAspect">
+        <BaseClass>BasePumpAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVariableSpeedPumpBatteryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VariableSpeedPumpBatteryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_InfiltrationAndInflowAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InfiltrationAndInflow_ApplySWMMRTKUnitHydrographSet" typeName="boolean" displayLabel="Apply SWMM RTK Unit Hydrograph Set?" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0"/>
+        <ECProperty propertyName="InfiltrationAndInflow_SewershedArea" typeName="double" displayLabel="Sewershed Area" category="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_InfiltrationAndInflowAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_InfiltrationAndInflowAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_InitialSettingsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InitialSettings_TankInitialElevation" typeName="double" displayLabel="Elevation (Initial)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="InitialSettings_TankInitialLevel" typeName="double" displayLabel="Level (Initial)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="InitialSettings_IsFixedLevel" typeName="boolean" displayLabel="Is Fixed Level in Steady State?" category="Initial_Settings_Drainage_Initial_Settings_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_InitialSettingsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_InitialSettingsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_Physical_TankSectionAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TankSection" typeName="WetWell_Physical_TankSectionAspect_TankSection_Enum" displayLabel="Section" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="WetWell_Physical_CircularTankSectionAspect">
+        <BaseClass>WetWell_Physical_TankSectionAspect</BaseClass>
+        <ECProperty propertyName="CircularTankSectionType_TankDiameter" typeName="double" displayLabel="Diameter" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_Physical_CircularTankSectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_Physical_CircularTankSectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_Physical_DepthAreaTankSectionAspect">
+        <BaseClass>WetWell_Physical_TankSectionAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_Physical_DepthAreaTankSectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_Physical_DepthAreaTankSectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_Physical_NonCircularTankSectionAspect">
+        <BaseClass>WetWell_Physical_TankSectionAspect</BaseClass>
+        <ECProperty propertyName="NonCircularTankSectionType_TankAverageArea" typeName="double" displayLabel="Area (Average)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Physical_InactiveVolume" typeName="double" displayLabel="Volume (Inactive)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_Physical_NonCircularTankSectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_Physical_NonCircularTankSectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_Physical_VariableAreaTankSectionAspect">
+        <BaseClass>WetWell_Physical_TankSectionAspect</BaseClass>
+        <ECProperty propertyName="VariableAreaTankSectionType_TotalActiveVolume" typeName="double" displayLabel="Volume Full (Input)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="Physical_InactiveVolume" typeName="double" displayLabel="Volume (Inactive)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_Physical_VariableAreaTankSectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_Physical_VariableAreaTankSectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_Physical_VolumeFunctionTankSectionBaseAspect" modifier="Abstract">
+        <BaseClass>WetWell_Physical_TankSectionAspect</BaseClass>
+        <ECProperty propertyName="VolumeFunctionTankSectionType_Coefficient" typeName="double" displayLabel="Coefficient" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="VolumeFunctionTankSectionType_Exponent" typeName="double" displayLabel="Exponent" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="VolumeFunctionTankSectionType_Constant" typeName="double" displayLabel="Constant" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="WetWell_Physical_VolumeFunctionTankSectionSIAspect">
+        <BaseClass>WetWell_Physical_VolumeFunctionTankSectionBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_Physical_VolumeFunctionTankSectionSIAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_Physical_VolumeFunctionTankSectionSIAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_Physical_VolumeFunctionTankSectionUSAspect">
+        <BaseClass>WetWell_Physical_VolumeFunctionTankSectionBaseAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_Physical_VolumeFunctionTankSectionUSAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_Physical_VolumeFunctionTankSectionUSAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_TankBaseElevation" typeName="double" displayLabel="Elevation (Base)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TankMaximumElevation" typeName="double" displayLabel="Elevation (Maximum)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TankMaximumLevel" typeName="double" displayLabel="Level (Maximum)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="OperatingRangeType" typeName="WetWell_PhysicalAspect_OperatingRangeType_Enum" displayLabel="Operating Range Type" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_TankMinimumElevation" typeName="double" displayLabel="Elevation (Minimum)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TankMinimumLevel" typeName="double" displayLabel="Level (Minimum)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_UseLowAlarm" typeName="boolean" displayLabel="Use Low Alarm?" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_UseHighAlarm" typeName="boolean" displayLabel="Use High Alarm?" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0"/>
+        <ECProperty propertyName="Physical_TankLowAlarmLevel" typeName="double" displayLabel="Level (Low Alarm)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TankLowAlarmElevation" typeName="double" displayLabel="Elevation (Low Alarm)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TankAlarmLevel" typeName="double" displayLabel="Level (High Alarm)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TankAlarmElevation" typeName="double" displayLabel="Elevation (High Alarm)" category="Operating_Range_Drainage_Operating_Range_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_WetWellPondedArea" typeName="double" displayLabel="Ponded Area" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_RainfallRunoffAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RainfallRunoff_UseLocalRainfall" typeName="boolean" displayLabel="Use Local Rainfall?" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+        <ECProperty propertyName="RainfallRunoff_StormEventID" typeName="string" displayLabel="Local Storm Event" category="Rainfall_Drainage_Rainfall_Drainage" priority="0"/>
+        <ECProperty propertyName="RainfallRunoff_EvapFactor" typeName="double" displayLabel="Evaporation Factor" category="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_RainfallRunoffAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_RainfallRunoffAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_SystemFlowsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SystemFlows_KnownFlow" typeName="double" displayLabel="Flow (Known)" category="Flows_Drainage_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_SystemFlowsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_SystemFlowsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWell_WaterQualityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterQuality_H2SRrate" typeName="double" displayLabel="Reaction Rate (H2S)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:REACTION_RATE"/>
+        <ECProperty propertyName="WaterQuality_H2SNodeTemperature" typeName="double" displayLabel="Temperature (H2S)" category="Water_Quality_Drainage_Water_Quality_Drainage" priority="0" kindOfQuantity="cifu:TEMPERATURE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWell_WaterQualityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWell_WaterQualityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWellAspect">
+        <BaseClass>PressureSystemNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWellAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWellAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="Active_Topology_Drainage_Active_Topology_Drainage" description="Active Topology [Drainage]" displayLabel="Active Topology [Drainage]" priority="4294891236"/>
+    <PropertyCategory typeName="Active_Topology_Hydraulic_Analysis_Active_Topology_Hydraulic_Analysis" description="Active Topology [Hydraulic Analysis]" displayLabel="Active Topology [Hydraulic Analysis]" priority="4294891236"/>
+    <PropertyCategory typeName="Boundary_Condition_Drainage_Boundary_Condition_Drainage" description="Boundary Condition [Drainage]" displayLabel="Boundary Condition [Drainage]" priority="4294889026"/>
+    <PropertyCategory typeName="Boundary_Condition_Hydraulic_Analysis_Boundary_Condition_Hydraulic_Analysis" description="Boundary Condition [Hydraulic Analysis]" displayLabel="Boundary Condition [Hydraulic Analysis]" priority="4294889026"/>
+    <PropertyCategory typeName="Connecting_Links_Drainage_Connecting_Links_Drainage" description="Connecting Links [Drainage]" displayLabel="Connecting Links [Drainage]" priority="4294888096"/>
+    <PropertyCategory typeName="Defaults_2D_Drainage_Defaults_2D_Drainage" description="Defaults (2D) [Drainage]" displayLabel="Defaults (2D) [Drainage]" priority="4294888176"/>
+    <PropertyCategory typeName="Design_Drainage_Design_Drainage" description="Design [Drainage]" displayLabel="Design [Drainage]" priority="4294888046"/>
+    <PropertyCategory typeName="Design_Hydraulic_Analysis_Design_Hydraulic_Analysis" description="Design [Hydraulic Analysis]" displayLabel="Design [Hydraulic Analysis]" priority="4294888046"/>
+    <PropertyCategory typeName="Diversion_Drainage_Diversion_Drainage" description="Diversion [Drainage]" displayLabel="Diversion [Drainage]" priority="4294887616"/>
+    <PropertyCategory typeName="Diversion_Hydraulic_Analysis_Diversion_Hydraulic_Analysis" description="Diversion [Hydraulic Analysis]" displayLabel="Diversion [Hydraulic Analysis]" priority="4294887616"/>
+    <PropertyCategory typeName="Flows_Drainage_Flows_Drainage" description="Flows [Drainage]" displayLabel="Flows [Drainage]" priority="4294885386"/>
+    <PropertyCategory typeName="Flows_Hydraulic_Analysis_Flows_Hydraulic_Analysis" description="Flows [Hydraulic Analysis]" displayLabel="Flows [Hydraulic Analysis]" priority="4294885386"/>
+    <PropertyCategory typeName="General_Drainage_General_Drainage" description="&lt;General&gt; [Drainage]" displayLabel="&lt;General&gt; [Drainage]" priority="4294899186"/>
+    <PropertyCategory typeName="General_Hydraulic_Analysis_General_Hydraulic_Analysis" description="&lt;General&gt; [Hydraulic Analysis]" displayLabel="&lt;General&gt; [Hydraulic Analysis]" priority="4294899186"/>
+    <PropertyCategory typeName="Geometry_Drainage_Geometry_Drainage" description="&lt;Geometry&gt; [Drainage]" displayLabel="&lt;Geometry&gt; [Drainage]" priority="4294899186"/>
+    <PropertyCategory typeName="Geometry_Hydraulic_Analysis_Geometry_Hydraulic_Analysis" description="&lt;Geometry&gt; [Hydraulic Analysis]" displayLabel="&lt;Geometry&gt; [Hydraulic Analysis]" priority="4294899186"/>
+    <PropertyCategory typeName="Headlosses_Drainage_Headlosses_Drainage" description="Headlosses [Drainage]" displayLabel="Headlosses [Drainage]" priority="4294884226"/>
+    <PropertyCategory typeName="Headlosses_Hydraulic_Analysis_Headlosses_Hydraulic_Analysis" description="Headlosses [Hydraulic Analysis]" displayLabel="Headlosses [Hydraulic Analysis]" priority="4294884226"/>
+    <PropertyCategory typeName="Hydrology_Drainage_Hydrology_Drainage" description="Hydrology [Drainage]" displayLabel="Hydrology [Drainage]" priority="4294882196"/>
+    <PropertyCategory typeName="Hydrology_Hydraulic_Analysis_Hydrology_Hydraulic_Analysis" description="Hydrology [Hydraulic Analysis]" displayLabel="Hydrology [Hydraulic Analysis]" priority="4294882196"/>
+    <PropertyCategory typeName="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" description="ILSAX Hydrologic Model [Drainage]" displayLabel="ILSAX Hydrologic Model [Drainage]" priority="4294885866"/>
+    <PropertyCategory typeName="ILSAX_Hydrologic_Model_Hydraulic_Analysis_ILSAX_Hydrologic_Model_Hydraulic_Analysis" description="ILSAX Hydrologic Model [Hydraulic Analysis]" displayLabel="ILSAX Hydrologic Model [Hydraulic Analysis]" priority="4294885866"/>
+    <PropertyCategory typeName="Infiltration_Inflow_And_Seepage__Drainage_Infiltration_Inflow_And_Seepage__Drainage" description="Infiltration/Inflow &amp; Seepage  [Drainage]" displayLabel="Infiltration/Inflow &amp; Seepage  [Drainage]" priority="4294882276"/>
+    <PropertyCategory typeName="Infiltration_Inflow_And_Seepage__Hydraulic_Analysis_Infiltration_Inflow_And_Seepage__Hydraulic_Analysis" description="Infiltration/Inflow &amp; Seepage  [Hydraulic Analysis]" displayLabel="Infiltration/Inflow &amp; Seepage  [Hydraulic Analysis]" priority="4294882276"/>
+    <PropertyCategory typeName="Initial_Settings_Drainage_Initial_Settings_Drainage" description="Initial Settings [Drainage]" displayLabel="Initial Settings [Drainage]" priority="4294882246"/>
+    <PropertyCategory typeName="Initial_Settings_Hydraulic_Analysis_Initial_Settings_Hydraulic_Analysis" description="Initial Settings [Hydraulic Analysis]" displayLabel="Initial Settings [Hydraulic Analysis]" priority="4294882246"/>
+    <PropertyCategory typeName="Inlet_Drainage_Inlet_Drainage" description="Inlet [Drainage]" displayLabel="Inlet [Drainage]" priority="4294882216"/>
+    <PropertyCategory typeName="Inlet_Hydraulic_Analysis_Inlet_Hydraulic_Analysis" description="Inlet [Hydraulic Analysis]" displayLabel="Inlet [Hydraulic Analysis]" priority="4294882216"/>
+    <PropertyCategory typeName="Inlet_Location_Drainage_Inlet_Location_Drainage" description="Inlet Location [Drainage]" displayLabel="Inlet Location [Drainage]" priority="4294882216"/>
+    <PropertyCategory typeName="Inlet_Location_Hydraulic_Analysis_Inlet_Location_Hydraulic_Analysis" description="Inlet Location [Hydraulic Analysis]" displayLabel="Inlet Location [Hydraulic Analysis]" priority="4294882216"/>
+    <PropertyCategory typeName="Inlet_Opening_Drainage_Inlet_Opening_Drainage" description="Inlet Opening [Drainage]" displayLabel="Inlet Opening [Drainage]" priority="4294882216"/>
+    <PropertyCategory typeName="Inlet_Opening_Hydraulic_Analysis_Inlet_Opening_Hydraulic_Analysis" description="Inlet Opening [Hydraulic Analysis]" displayLabel="Inlet Opening [Hydraulic Analysis]" priority="4294882216"/>
+    <PropertyCategory typeName="Land_Cover_Drainage_Land_Cover_Drainage" description="Land Cover [Drainage]" displayLabel="Land Cover [Drainage]" priority="4294880496"/>
+    <PropertyCategory typeName="Operating_Range_Drainage_Operating_Range_Drainage" description="Operating Range [Drainage]" displayLabel="Operating Range [Drainage]" priority="4294876086"/>
+    <PropertyCategory typeName="Operating_Range_Hydraulic_Analysis_Operating_Range_Hydraulic_Analysis" description="Operating Range [Hydraulic Analysis]" displayLabel="Operating Range [Hydraulic Analysis]" priority="4294876086"/>
+    <PropertyCategory typeName="Operational_Drainage_Operational_Drainage" description="Operational [Drainage]" displayLabel="Operational [Drainage]" priority="4294876086"/>
+    <PropertyCategory typeName="Operational_Hydraulic_Analysis_Operational_Hydraulic_Analysis" description="Operational [Hydraulic Analysis]" displayLabel="Operational [Hydraulic Analysis]" priority="4294876086"/>
+    <PropertyCategory typeName="Output_2D_Drainage_Output_2D_Drainage" description="Output (2D) [Drainage]" displayLabel="Output (2D) [Drainage]" priority="4294875436"/>
+    <PropertyCategory typeName="Output_Drainage_Output_Drainage" description="Output [Drainage]" displayLabel="Output [Drainage]" priority="4294875436"/>
+    <PropertyCategory typeName="Output_Hydraulic_Analysis_Output_Hydraulic_Analysis" description="Output [Hydraulic Analysis]" displayLabel="Output [Hydraulic Analysis]" priority="4294875436"/>
+    <PropertyCategory typeName="Physical_Control_Structure_Drainage_Physical_Control_Structure_Drainage" description="Physical (Control Structure) [Drainage]" displayLabel="Physical (Control Structure) [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Control_Structure_Hydraulic_Analysis_Physical_Control_Structure_Hydraulic_Analysis" description="Physical (Control Structure) [Hydraulic Analysis]" displayLabel="Physical (Control Structure) [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Culvert_Drainage_Physical_Culvert_Drainage" description="Physical (Culvert) [Drainage]" displayLabel="Physical (Culvert) [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Culvert_Hydraulic_Analysis_Physical_Culvert_Hydraulic_Analysis" description="Physical (Culvert) [Hydraulic Analysis]" displayLabel="Physical (Culvert) [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Drainage_Physical_Drainage" description="Physical [Drainage]" displayLabel="Physical [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Hydraulic_Analysis_Physical_Hydraulic_Analysis" description="Physical [Hydraulic Analysis]" displayLabel="Physical [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Structure_Losses_Drainage_Physical_Structure_Losses_Drainage" description="Physical (Structure Losses) [Drainage]" displayLabel="Physical (Structure Losses) [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Structure_Losses_Hydraulic_Analysis_Physical_Structure_Losses_Hydraulic_Analysis" description="Physical (Structure Losses) [Hydraulic Analysis]" displayLabel="Physical (Structure Losses) [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Surface_Storage_Drainage_Physical_Surface_Storage_Drainage" description="Physical (Surface Storage) [Drainage]" displayLabel="Physical (Surface Storage) [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Surface_Storage_Hydraulic_Analysis_Physical_Surface_Storage_Hydraulic_Analysis" description="Physical (Surface Storage) [Hydraulic Analysis]" displayLabel="Physical (Surface Storage) [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Pond_Outlet_Drainage_Pond_Outlet_Drainage" description="Pond Outlet [Drainage]" displayLabel="Pond Outlet [Drainage]" priority="4294875096"/>
+    <PropertyCategory typeName="Pond_Outlet_Hydraulic_Analysis_Pond_Outlet_Hydraulic_Analysis" description="Pond Outlet [Hydraulic Analysis]" displayLabel="Pond Outlet [Hydraulic Analysis]" priority="4294875096"/>
+    <PropertyCategory typeName="Rainfall_Drainage_Rainfall_Drainage" description="Rainfall [Drainage]" displayLabel="Rainfall [Drainage]" priority="4294874546"/>
+    <PropertyCategory typeName="Rainfall_Hydraulic_Analysis_Rainfall_Hydraulic_Analysis" description="Rainfall [Hydraulic Analysis]" displayLabel="Rainfall [Hydraulic Analysis]" priority="4294874546"/>
+    <PropertyCategory typeName="References_Drainage_References_Drainage" description="References [Drainage]" displayLabel="References [Drainage]" priority="4294874176"/>
+    <PropertyCategory typeName="References_Hydraulic_Analysis_References_Hydraulic_Analysis" description="References [Hydraulic Analysis]" displayLabel="References [Hydraulic Analysis]" priority="4294874176"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" description="Results (Energy Costs) [Drainage]" displayLabel="Results (Energy Costs) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Hydraulic_Analysis_Results_Energy_Costs_Hydraulic_Analysis" description="Results (Energy Costs) [Hydraulic Analysis]" displayLabel="Results (Energy Costs) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Runoff_Drainage_Runoff_Drainage" description="Runoff [Drainage]" displayLabel="Runoff [Drainage]" priority="4294872496"/>
+    <PropertyCategory typeName="Runoff_Hydraulic_Analysis_Runoff_Hydraulic_Analysis" description="Runoff [Hydraulic Analysis]" displayLabel="Runoff [Hydraulic Analysis]" priority="4294872496"/>
+    <PropertyCategory typeName="Sanitary_Pattern_Load_Drainage_Sanitary_Pattern_Load_Drainage" description="Sanitary (Pattern Load) [Drainage]" displayLabel="Sanitary (Pattern Load) [Drainage]" priority="4294873496"/>
+    <PropertyCategory typeName="Sanitary_Pattern_Load_Hydraulic_Analysis_Sanitary_Pattern_Load_Hydraulic_Analysis" description="Sanitary (Pattern Load) [Hydraulic Analysis]" displayLabel="Sanitary (Pattern Load) [Hydraulic Analysis]" priority="4294873496"/>
+    <PropertyCategory typeName="Sanitary_Unit_Loads_Drainage_Sanitary_Unit_Loads_Drainage" description="Sanitary (Unit Loads) [Drainage]" displayLabel="Sanitary (Unit Loads) [Drainage]" priority="4294873496"/>
+    <PropertyCategory typeName="Sanitary_Unit_Loads_Hydraulic_Analysis_Sanitary_Unit_Loads_Hydraulic_Analysis" description="Sanitary (Unit Loads) [Hydraulic Analysis]" displayLabel="Sanitary (Unit Loads) [Hydraulic Analysis]" priority="4294873496"/>
+    <PropertyCategory typeName="SCADA_Drainage_SCADA_Drainage" description="SCADA [Drainage]" displayLabel="SCADA [Drainage]" priority="4294876946"/>
+    <PropertyCategory typeName="SCADA_Hydraulic_Analysis_SCADA_Hydraulic_Analysis" description="SCADA [Hydraulic Analysis]" displayLabel="SCADA [Hydraulic Analysis]" priority="4294876946"/>
+    <PropertyCategory typeName="Simulation_Initial_Condition_Drainage_Simulation_Initial_Condition_Drainage" description="Simulation Initial Condition [Drainage]" displayLabel="Simulation Initial Condition [Drainage]" priority="4294872706"/>
+    <PropertyCategory typeName="Simulation_Initial_Condition_Hydraulic_Analysis_Simulation_Initial_Condition_Hydraulic_Analysis" description="Simulation Initial Condition [Hydraulic Analysis]" displayLabel="Simulation Initial Condition [Hydraulic Analysis]" priority="4294872706"/>
+    <PropertyCategory typeName="Snow_Parameters_Drainage_Snow_Parameters_Drainage" description="Snow Parameters [Drainage]" displayLabel="Snow Parameters [Drainage]" priority="4294872186"/>
+    <PropertyCategory typeName="Snow_Parameters_Hydraulic_Analysis_Snow_Parameters_Hydraulic_Analysis" description="Snow Parameters [Hydraulic Analysis]" displayLabel="Snow Parameters [Hydraulic Analysis]" priority="4294872186"/>
+    <PropertyCategory typeName="SWMM_Extended_Data_Drainage_SWMM_Extended_Data_Drainage" description="SWMM Extended Data [Drainage]" displayLabel="SWMM Extended Data [Drainage]" priority="4294874826"/>
+    <PropertyCategory typeName="SWMM_Extended_Data_Hydraulic_Analysis_SWMM_Extended_Data_Hydraulic_Analysis" description="SWMM Extended Data [Hydraulic Analysis]" displayLabel="SWMM Extended Data [Hydraulic Analysis]" priority="4294874826"/>
+    <PropertyCategory typeName="SWMM_Extended_Data_Water_Quality_Drainage_SWMM_Extended_Data_Water_Quality_Drainage" description="SWMM Extended Data (Water Quality) [Drainage]" displayLabel="SWMM Extended Data (Water Quality) [Drainage]" priority="4294874826"/>
+    <PropertyCategory typeName="SWMM_Extended_Data_Water_Quality_Hydraulic_Analysis_SWMM_Extended_Data_Water_Quality_Hydraulic_Analysis" description="SWMM Extended Data (Water Quality) [Hydraulic Analysis]" displayLabel="SWMM Extended Data (Water Quality) [Hydraulic Analysis]" priority="4294874826"/>
+    <PropertyCategory typeName="Tractive_Stress_Drainage_Tractive_Stress_Drainage" description="Tractive Stress [Drainage]" displayLabel="Tractive Stress [Drainage]" priority="4294870926"/>
+    <PropertyCategory typeName="Tractive_Stress_Hydraulic_Analysis_Tractive_Stress_Hydraulic_Analysis" description="Tractive Stress [Hydraulic Analysis]" displayLabel="Tractive Stress [Hydraulic Analysis]" priority="4294870926"/>
+    <PropertyCategory typeName="TwoD_Solver_Drainage_2D_Solver_Drainage" description="2D Solver [Drainage]" displayLabel="2D Solver [Drainage]" priority="4294910176"/>
+    <PropertyCategory typeName="Type_Operations_Drainage_Type_Operations_Drainage" description="Type/Operations [Drainage]" displayLabel="Type/Operations [Drainage]" priority="4294870076"/>
+    <PropertyCategory typeName="Water_Quality_Drainage_Water_Quality_Drainage" description="Water Quality [Drainage]" displayLabel="Water Quality [Drainage]" priority="4294869436"/>
+    <PropertyCategory typeName="Water_Quality_Hydraulic_Analysis_Water_Quality_Hydraulic_Analysis" description="Water Quality [Hydraulic Analysis]" displayLabel="Water Quality [Hydraulic Analysis]" priority="4294869436"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifHydraulicResults.01.00.05.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifHydraulicResults.01.00.05.ecschema.xml
@@ -1,0 +1,2840 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifHydraulicResults" alias="cifhydrs" version="01.00.05" description="iModel Connector schema containing aspect classes with result properties from the Subsurface Utilities Design and Analysis module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.02" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="CulvertResultsAspect_CulvertControlType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inlet_Control" value="0" displayLabel="Inlet Control"/>
+        <ECEnumerator name="Outlet_Control" value="1" displayLabel="Outlet Control"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DerivedPumpResultsAspect_PumpDefinitionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Constant_Power_GVF" value="0" displayLabel="Constant Power"/>
+        <ECEnumerator name="Design_Point_1_Point__GVF" value="1" displayLabel="Design Point (1 Point)"/>
+        <ECEnumerator name="Standard_3_Point__GVF" value="2" displayLabel="Standard (3 Point)"/>
+        <ECEnumerator name="Standard_Extended__GVF" value="3" displayLabel="Standard Extended"/>
+        <ECEnumerator name="Custom_Extended__GVF" value="4" displayLabel="Custom Extended"/>
+        <ECEnumerator name="Multiple_Point_Type_3" value="5" displayLabel="Multiple Point"/>
+        <ECEnumerator name="Volume_vs__Flow_Type_1" value="6" displayLabel="Volume vs. Flow (Type 1)"/>
+        <ECEnumerator name="Depth_vs__Flow_Type_2" value="7" displayLabel="Depth vs. Flow (Type 2)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GVFGravityStructureDownstreamResultsAspect_DownstreamPipeFlowType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Free_Surface" value="0" displayLabel="Free Surface"/>
+        <ECEnumerator name="Pressure" value="1" displayLabel="Pressure"/>
+        <ECEnumerator name="Transitional" value="2" displayLabel="Transitional"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GVFHec22PipeResultsAspect_DownConduitFlowType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Free_Surface" value="0" displayLabel="Free Surface"/>
+        <ECEnumerator name="Pressure" value="1" displayLabel="Pressure"/>
+        <ECEnumerator name="Transitional" value="2" displayLabel="Transitional"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GVFHec22PipeResultsAspect_DownStructBenching_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Depressed" value="0" displayLabel="Depressed"/>
+        <ECEnumerator name="Flat" value="1" displayLabel="Flat"/>
+        <ECEnumerator name="Half" value="2" displayLabel="Half"/>
+        <ECEnumerator name="Full" value="3" displayLabel="Full"/>
+        <ECEnumerator name="Improved" value="4" displayLabel="Improved"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="HeadwallNodeDerivedResultsAspect_HeadwallBoundaryType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inlet" value="0" displayLabel="Inlet"/>
+        <ECEnumerator name="Discharge_to_Pond" value="1" displayLabel="Discharge to Pond"/>
+        <ECEnumerator name="Pond_Outlet" value="2" displayLabel="Pond Outlet"/>
+        <ECEnumerator name="Intermediate" value="3" displayLabel="Intermediate"/>
+        <ECEnumerator name="Outlet" value="4" displayLabel="Outlet"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="Hec22ThirdEditionNodeResultsAspect_EntranceLossControlType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Outlet_Control" value="0" displayLabel="Outlet Control"/>
+        <ECEnumerator name="Inlet_Control_Submerged" value="1" displayLabel="Inlet Control (Submerged)"/>
+        <ECEnumerator name="Inlet_Control_Unsubmerged" value="2" displayLabel="Inlet Control (Unsubmerged)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="HMIStandardResultRecordAspect_FlowDirection_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="flowdirection_noflow" value="0" displayLabel="#flowdirection_noflow"/>
+        <ECEnumerator name="flowdirection_positive" value="1" displayLabel="#flowdirection_positive"/>
+        <ECEnumerator name="flowdirection_negative" value="-1" displayLabel="#flowdirection_negative"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="IdahoPipeResultsAspect_PipeResultControlStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Open" value="0" displayLabel="Open"/>
+        <ECEnumerator name="Closed" value="1" displayLabel="Closed"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="IdahoPumpResultsAspect_PumpResultControlStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="On" value="0" displayLabel="On"/>
+        <ECEnumerator name="Off" value="1" displayLabel="Off"/>
+        <ECEnumerator name="Pump_Cannot_Deliver_Head_Closed" value="2" displayLabel="Pump Cannot Deliver Head (Closed)"/>
+        <ECEnumerator name="Pump_Result_Cannot_Deliver_Flow_Open" value="3" displayLabel="Pump Result Cannot Deliver Flow (Open)"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="InfiltrationResultsAspect_InfiltrationMethodResult_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="No_Infiltration" value="0" displayLabel="No Infiltration"/>
+        <ECEnumerator name="Constant" value="1" displayLabel="Constant"/>
+        <ECEnumerator name="Average_Infiltration_Rate" value="2" displayLabel="Average Infiltration Rate"/>
+        <ECEnumerator name="Infiltration___Head_Depth" value="3" displayLabel="Infiltration / Head Depth"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ScadaElementDataAspect_ScadaSignalQualityHistoricalType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Bad" value="0" displayLabel="Bad"/>
+        <ECEnumerator name="Bad___Configuration_Error" value="4" displayLabel="Bad - Configuration Error"/>
+        <ECEnumerator name="Bad___Not_Connected" value="8" displayLabel="Bad - Not Connected"/>
+        <ECEnumerator name="Bad___Device_Failure_" value="12" displayLabel="Bad - Device Failure "/>
+        <ECEnumerator name="Bad___Sensor_Failure_" value="16" displayLabel="Bad - Sensor Failure "/>
+        <ECEnumerator name="Bad___Last_Known_Value_" value="20" displayLabel="Bad - Last Known Value "/>
+        <ECEnumerator name="Bad___Communication_Failure" value="24" displayLabel="Bad - Communication Failure"/>
+        <ECEnumerator name="Bad___Out_Of_Service" value="28" displayLabel="Bad - Out Of Service"/>
+        <ECEnumerator name="Bad___Waiting_For_Initial_Data_" value="32" displayLabel="Bad - Waiting For Initial Data "/>
+        <ECEnumerator name="Uncertain" value="64" displayLabel="Uncertain"/>
+        <ECEnumerator name="Uncertain___Last_Usable_Value_" value="68" displayLabel="Uncertain - Last Usable Value "/>
+        <ECEnumerator name="Uncertain___Sensor_Not_Accurate_" value="80" displayLabel="Uncertain - Sensor Not Accurate "/>
+        <ECEnumerator name="Uncertain___EU_Exceeded_" value="84" displayLabel="Uncertain - EU Exceeded "/>
+        <ECEnumerator name="Uncertain___Sub_Normal_" value="88" displayLabel="Uncertain - Sub Normal "/>
+        <ECEnumerator name="Good" value="192" displayLabel="Good"/>
+        <ECEnumerator name="Good___Local_Override_" value="216" displayLabel="Good - Local Override "/>
+        <ECEnumerator name="Low_Limit" value="1" displayLabel="Low Limit"/>
+        <ECEnumerator name="High_Limit" value="2" displayLabel="High Limit"/>
+        <ECEnumerator name="Constant" value="3" displayLabel="Constant"/>
+        <ECEnumerator name="None" value="255" displayLabel="None"/>
+        <ECEnumerator name="No_License" value="99999" displayLabel="No License"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ScadaElementDataAspect_ScadaSignalQualityRealtimeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Bad" value="0" displayLabel="Bad"/>
+        <ECEnumerator name="Bad___Configuration_Error" value="4" displayLabel="Bad - Configuration Error"/>
+        <ECEnumerator name="Bad___Not_Connected" value="8" displayLabel="Bad - Not Connected"/>
+        <ECEnumerator name="Bad___Device_Failure_" value="12" displayLabel="Bad - Device Failure "/>
+        <ECEnumerator name="Bad___Sensor_Failure_" value="16" displayLabel="Bad - Sensor Failure "/>
+        <ECEnumerator name="Bad___Last_Known_Value_" value="20" displayLabel="Bad - Last Known Value "/>
+        <ECEnumerator name="Bad___Communication_Failure" value="24" displayLabel="Bad - Communication Failure"/>
+        <ECEnumerator name="Bad___Out_Of_Service" value="28" displayLabel="Bad - Out Of Service"/>
+        <ECEnumerator name="Bad___Waiting_For_Initial_Data_" value="32" displayLabel="Bad - Waiting For Initial Data "/>
+        <ECEnumerator name="Uncertain" value="64" displayLabel="Uncertain"/>
+        <ECEnumerator name="Uncertain___Last_Usable_Value_" value="68" displayLabel="Uncertain - Last Usable Value "/>
+        <ECEnumerator name="Uncertain___Sensor_Not_Accurate_" value="80" displayLabel="Uncertain - Sensor Not Accurate "/>
+        <ECEnumerator name="Uncertain___EU_Exceeded_" value="84" displayLabel="Uncertain - EU Exceeded "/>
+        <ECEnumerator name="Uncertain___Sub_Normal_" value="88" displayLabel="Uncertain - Sub Normal "/>
+        <ECEnumerator name="Good" value="192" displayLabel="Good"/>
+        <ECEnumerator name="Good___Local_Override_" value="216" displayLabel="Good - Local Override "/>
+        <ECEnumerator name="Low_Limit" value="1" displayLabel="Low Limit"/>
+        <ECEnumerator name="High_Limit" value="2" displayLabel="High Limit"/>
+        <ECEnumerator name="Constant" value="3" displayLabel="Constant"/>
+        <ECEnumerator name="None" value="255" displayLabel="None"/>
+        <ECEnumerator name="No_License" value="99999" displayLabel="No License"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ScadaElementDataAspect_ScadaTargetElementType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="None" value="0" displayLabel="&lt;None&gt;"/>
+        <ECEnumerator name="Manhole" value="1" displayLabel="Manhole"/>
+        <ECEnumerator name="Pressure_Junction" value="13" displayLabel="Pressure Junction"/>
+        <ECEnumerator name="Outfall" value="5" displayLabel="Outfall"/>
+        <ECEnumerator name="Transition" value="15" displayLabel="Transition"/>
+        <ECEnumerator name="Cross_Section" value="9" displayLabel="Cross Section"/>
+        <ECEnumerator name="Pond" value="7" displayLabel="Pond"/>
+        <ECEnumerator name="Wet_Well" value="12" displayLabel="Wet Well"/>
+        <ECEnumerator name="Catch_Basin" value="2" displayLabel="Catch Basin"/>
+        <ECEnumerator name="Catchment" value="6" displayLabel="Catchment"/>
+        <ECEnumerator name="Pressure_Pipe" value="14" displayLabel="Pressure Pipe"/>
+        <ECEnumerator name="Pump" value="68" displayLabel="Pump"/>
+        <ECEnumerator name="Variable_Speed_Pump_Battery" value="72" displayLabel="Variable Speed Pump Battery"/>
+        <ECEnumerator name="Conduit" value="3" displayLabel="Conduit"/>
+        <ECEnumerator name="Channel" value="4" displayLabel="Channel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StormEventResultsAspect_StormEventDepthTypeResult_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Incremental" value="0" displayLabel="Incremental"/>
+        <ECEnumerator name="Cumulative" value="1" displayLabel="Cumulative"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="AverageDepthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="AverageDepthResults_AverageDepth" typeName="double" displayLabel="Depth (Average)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicDepthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicDepthResults_Depth" typeName="double" displayLabel="Depth (Node)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicEnergyGradeLineResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicEnergyGradeLineResults_EnergyGradeLine" typeName="double" displayLabel="Energy Grade Line" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicFlowResults_Flow" typeName="double" displayLabel="Flow" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicH2SLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicH2SLinkResults_H2SConcentrationOut" typeName="double" displayLabel="H2S (Out)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="BasicH2SLinkResults_BODConcentrationOut" typeName="double" displayLabel="BOD (Out)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="BasicH2SLinkResults_H2SConcentrationIn" typeName="double" displayLabel="H2S (In)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="BasicH2SLinkResults_BODConcentrationIn" typeName="double" displayLabel="BOD (In) " category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="BasicH2SLinkResults_DetentionTime" typeName="double" displayLabel="Detention Time (average)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:TIME_FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicH2SNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicH2SNodeResults_H2SConcentrationOut" typeName="double" displayLabel="H2S (Out)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="BasicH2SNodeResults_BODConcentrationOut" typeName="double" displayLabel="BOD (Out)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:CONCENTRATION"/>
+        <ECProperty propertyName="BasicH2SNodeResults_DetentionTime" typeName="double" displayLabel="Detention Time (average)" category="Results_H2S_Drainage_Results_H2S_Drainage" priority="0" kindOfQuantity="cifu:TIME_FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicHeadlossResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicHeadlossResults_Headloss" typeName="double" displayLabel="Headloss" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicHydraulicGradeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicHydraulicGradeResults_HydraulicGrade" typeName="double" displayLabel="Hydraulic Grade" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicOverflowingResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicOverflowingResults_IsOverflowing" typeName="boolean" displayLabel="Is Overflowing?" category="Results_Drainage_Results_Drainage" priority="0"/>
+        <ECProperty propertyName="BasicOverflowingResults_EverOverflowing" typeName="boolean" displayLabel="Is Ever Overflowing?" category="Results_Drainage_Results_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicPipeFlowTimeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicPipeFlowTimeResults_PipeFlowTime" typeName="double" displayLabel="Time (Pipe Flow)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicSurchargedResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicSurchargedResults_IsSurcharged" typeName="boolean" displayLabel="Is Surcharged?" category="Results_Drainage_Results_Drainage" priority="0"/>
+        <ECProperty propertyName="BasicSurchargedResults_IsEverSurcharged" typeName="boolean" displayLabel="Is Ever Surcharged?" category="Results_Drainage_Results_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicVelocityResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicVelocityResults_Velocity" typeName="double" displayLabel="Velocity" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BasicVolumeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BasicVolumeResults_Volume" typeName="double" displayLabel="Volume" category="Results_Extended_Node_Drainage_Results_Extended_Node_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingDepthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingDepthResults_DepthIn" typeName="double" displayLabel="Depth (In)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="BoundingDepthResults_DepthOut" typeName="double" displayLabel="Depth (Out)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingEnergyGradeLineResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingEnergyGradeLineResults_EnergyGradeLineIn" typeName="double" displayLabel="Energy Grade Line (In)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="BoundingEnergyGradeLineResults_EnergyGradeLineOut" typeName="double" displayLabel="Energy Grade Line (Out)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingFroudeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingFroudeResults_StartFroude" typeName="double" displayLabel="Froude (Start)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="BoundingFroudeResults_StopFroude" typeName="double" displayLabel="Froude (Stop)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingHydraulicGradeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingHydraulicGradeResults_HydraulicGradeLineIn" typeName="double" displayLabel="Hydraulic Grade Line (In)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="BoundingHydraulicGradeResults_HydraulicGradeLineOut" typeName="double" displayLabel="Hydraulic Grade Line (Out)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingSpecificEnergyResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingSpecificEnergyResults_SpecificEnergyIn" typeName="double" displayLabel="Specific Energy (In)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="BoundingSpecificEnergyResults_SpecificEnergyOut" typeName="double" displayLabel="Specific Energy (Out)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingTopWidthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingTopWidthResults_StartTopWidth" typeName="double" displayLabel="Spread / Top Width (Start)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BoundingTopWidthResults_StopTopWidth" typeName="double" displayLabel="Spread / Top Width (Stop)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BoundingVelocityResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="BoundingVelocityResults_VelocityIn" typeName="double" displayLabel="Velocity (In)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="BoundingVelocityResults_VelocityOut" typeName="double" displayLabel="Velocity (Out)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasinGutterResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CatchBasinGutterResults_Depth" typeName="double" displayLabel="Depth (Gutter)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="CatchBasinGutterResults_Spread" typeName="double" displayLabel="Spread / Top Width" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchBasinGutterStatsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CatchBasinGutterStats_MaximumGutterDepth" typeName="string" displayLabel="Gutter Depth (Maximum)" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="CatchBasinGutterStats_MaximumGutterSpread" typeName="string" displayLabel="Gutter Spread (Maximum)" category="Category_Drainage_Category_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatchbasinNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CatchbasinNodeResults_CaptureEfficiency" typeName="double" displayLabel="Capture Efficiency (Calculated)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="CatchbasinNodeResults_CapturedFlow" typeName="double" displayLabel="Flow (Captured)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="CatchbasinNodeResults_BypassedFlow" typeName="double" displayLabel="Flow (Bypassed)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CatStatResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CatStatResults_TotalPrecipitation" typeName="double" displayLabel="Precipitation (Total)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="CatStatResults_TotalRunon" typeName="double" displayLabel="Runon (Total)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="CatStatResults_TotalEvaporation" typeName="double" displayLabel="Evaporation (Total)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="CatStatResults_TotalInfiltration" typeName="double" displayLabel="Infiltration (Total)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="CatStatResults_RunoffCoefficient" typeName="double" displayLabel="Runoff Coefficient (Calculated)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CompositeOutletStructureResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CompositeOutletStructureResults_ManningsOpenChannelMaxCapacity" typeName="double" displayLabel="Mannings open channel maximum capacity" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_UpstreamID" typeName="string" displayLabel="Upstream IDs" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_DownstreamID" typeName="string" displayLabel="Downstream IDs" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_StructureID" typeName="string" displayLabel="Structure ID" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_CumulativeHGLError" typeName="double" displayLabel="Cumulative HGL Convergence Error (+/-)" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_FlowPathElevation" typeName="double" displayLabel="Flow Path Elevation" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_FlowPathBranch" typeName="string" displayLabel="Flow path Branch" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="CompositeOutletStructureResults_TailwaterElevation" typeName="double" displayLabel="Tailwater" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ControlStructureResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ControlStructureResults_IsControlSubmerged" typeName="boolean" displayLabel="Is Control Submerged?" category="Results_Drainage_Results_Drainage" priority="0"/>
+        <ECProperty propertyName="ControlStructureResults_IsControlEverSubmerged" typeName="boolean" displayLabel="Is Control Ever Submerged?" category="Results_Drainage_Results_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CulvertFlowClassificationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CulvertFlowClassificationResults_TimeSpentInletControl" typeName="double" displayLabel="Time (Inlet Control) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CulvertResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CulvertControlType" typeName="CulvertResultsAspect_CulvertControlType_Enum" displayLabel="Culvert Control Type" category="Results_Profile_Summary_Drainage_Results_Profile_Summary_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DepthRatioResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DepthRatioResults_MaxDepthRiseRatio" typeName="double" displayLabel="Depth (Maximum) / Rise" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DepthStatisticResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DepthStatisticResults_MaximumDepth" typeName="double" displayLabel="Depth (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="DepthStatisticResults_TimeToMaximumDepth" typeName="double" displayLabel="Time to Maximum Depth" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="Derived2DNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Derived2DNodeResults_RimElevation" typeName="double" displayLabel="Elevation (Unified 2D Rim)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedCatchmentResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedCatchmentResults_CompositeCn" typeName="double" displayLabel="SCS CN (Composite)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="DerivedCatchmentResults_PerviousMaximumRetention" typeName="double" displayLabel="Maximum Retention (Pervious)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="DerivedCatchmentResults_PerviousMaximumRetentionTwentyPercent" typeName="double" displayLabel="Maximum Retention (Pervious, 20 percent)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="DerivedCatchmentResults_ImperviousMaximumRetention" typeName="double" displayLabel="Maximum Retention (Impervious)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="DerivedCatchmentResults_ImperviousMaximumRetentionTwentyPercent" typeName="double" displayLabel="Maximum Retention (Impervious, 20 percent)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="DerivedCatchmentResults_CompositeC" typeName="double" displayLabel="Runoff Coefficient (Rational Composite)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedConduitSizeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedConduitSizeResults_CatalogPipeSize" typeName="string" displayLabel="Size (Display)" category="Physical_Drainage_Physical_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedDropDepthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedDropDepthResults_HasDropStandpipe" typeName="boolean" displayLabel="Has Drop Standpipe?" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0"/>
+        <ECProperty propertyName="DerivedDropDepthResults_DropObservation" typeName="double" displayLabel="Backdrop Height" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedGridResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedGridResults_NumberCells" typeName="int" displayLabel="Total Cells" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="DerivedGridResults_TotalGridArea" typeName="double" displayLabel="Total Grid Area" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="DerivedGridResults_NumberColumns" typeName="int" displayLabel="Columns" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="DerivedGridResults_NumberRows" typeName="int" displayLabel="Rows" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0"/>
+        <ECProperty propertyName="DerivedGridResults_MinimumGroundElevation" typeName="double" displayLabel="Elevation (Minimum)" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="DerivedGridResults_MaximumGroundElevation" typeName="double" displayLabel="Elevation (Maximum)" category="TwoD_Solver_Drainage_2D_Solver_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedLinkResults_UnifiedLength" typeName="double" displayLabel="Length (Unified)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DerivedLinkResults_Pipe3DLength" typeName="double" displayLabel="Length (3D)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DerivedLinkResults_Slope" typeName="double" displayLabel="Slope (Calculated)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedNodeResults_StructureDepth" typeName="double" displayLabel="Depth (Structure)" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedPhysicalLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedPhysicalLinkResults_FullFlowArea" typeName="double" displayLabel="Area (Full Flow)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="DerivedPhysicalLinkResults_UnifiedRise" typeName="double" displayLabel="Rise (Unified)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedPumpResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PumpDefinitionType" typeName="DerivedPumpResultsAspect_PumpDefinitionType_Enum" displayLabel="Pump Definition Type" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedSurfacePolygonResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedSurfacePolygonResults_LandCoverCN" typeName="double" displayLabel="SCS CN (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="DerivedSurfacePolygonResults_LandCoverImpermeabilityFraction" typeName="double" displayLabel="Impermeability Fraction (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:FRACTION"/>
+        <ECProperty propertyName="DerivedSurfacePolygonResults_LandCoverMannings" typeName="double" displayLabel="Manning's n (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+        <ECProperty propertyName="DerivedSurfacePolygonResults_LandCoverC" typeName="double" displayLabel="Rational C (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DerivedSurfacePolylineResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DerivedSurfacePolylineResults_LandCoverCN" typeName="double" displayLabel="SCS CN (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="DerivedSurfacePolylineResults_LandCoverImpermeabilityFraction" typeName="double" displayLabel="Impermeability Fraction (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:FRACTION"/>
+        <ECProperty propertyName="DerivedSurfacePolylineResults_LandCoverMannings" typeName="double" displayLabel="Manning's n (Catalog)" category="Land_Cover_Drainage_Land_Cover_Drainage" priority="0" kindOfQuantity="cifu:ROUGHNESS_MANNINGS"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsAverageDepthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AverageDepthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicDepthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicDepthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicEnergyGradeLineResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicEnergyGradeLineResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicH2SLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicH2SLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicH2SNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicH2SNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicHeadlossResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicHeadlossResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicHydraulicGradeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicHydraulicGradeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicOverflowingResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicOverflowingResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicPipeFlowTimeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicPipeFlowTimeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicSurchargedResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicSurchargedResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicVelocityResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicVelocityResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBasicVolumeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BasicVolumeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingDepthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingDepthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingEnergyGradeLineResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingEnergyGradeLineResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingFroudeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingFroudeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingHydraulicGradeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingHydraulicGradeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingSpecificEnergyResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingSpecificEnergyResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingTopWidthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingTopWidthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBoundingVelocityResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BoundingVelocityResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasinGutterResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasinGutterResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchBasinGutterStatsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchBasinGutterStatsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatchbasinNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatchbasinNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCatStatResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CatStatResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCompositeOutletStructureResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CompositeOutletStructureResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsControlStructureResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ControlStructureResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCulvertFlowClassificationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CulvertFlowClassificationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCulvertResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CulvertResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDepthRatioResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DepthRatioResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDepthStatisticResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DepthStatisticResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerived2DNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Derived2DNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedCatchmentResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedCatchmentResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedConduitSizeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedConduitSizeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedDropDepthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedDropDepthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedGridResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedGridResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedPhysicalLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedPhysicalLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedPumpResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedPumpResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedSurfacePolygonResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedSurfacePolygonResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDerivedSurfacePolylineResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DerivedSurfacePolylineResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ElementResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElementResults_SubnetworkID" typeName="int" displayLabel="Subnetwork ID" category="Results_Engine_Parsing_Drainage_Results_Engine_Parsing_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsElementResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ElementResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FloodwaveElementResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FloodwaveElementResults_BranchID" typeName="int" displayLabel="Branch" category="Results_Engine_Parsing_Drainage_Results_Engine_Parsing_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFloodwaveElementResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FloodwaveElementResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowClassificationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FlowClassificationResults_TimeSpentDry" typeName="double" displayLabel="Time (Dry) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeStartSpendsDry" typeName="double" displayLabel="Time (Upstream Dry) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeStopEndsDry" typeName="double" displayLabel="Time (Downstream Dry) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeSpentSubcrit" typeName="double" displayLabel="Time (Subcritical) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeSpentSuperCrit" typeName="double" displayLabel="Time (Supercritical) /  Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeSpentStopCriticalDepth" typeName="double" displayLabel="Time (Downstream Critical) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeNormalFlowLimited" typeName="double" displayLabel="Time (Normal Depth) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="FlowClassificationResults_TimeSpentStartCriticalDepth" typeName="double" displayLabel="Time (Upstream Critical Depth) / Time (Simulation)" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowClassificationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowClassificationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowInResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FlowInResults_TotalFlowIn" typeName="double" displayLabel="Flow (Total In)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowInResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowInResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowOutResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FlowOutResults_TotalFlowOut" typeName="double" displayLabel="Flow (Total Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowOutResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowOutResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowStatisticsResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FlowStatisticsResults_TimeToMaxFlow" typeName="double" displayLabel="Time (Maximum Flow)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="FlowStatisticsResults_MaxFlow" typeName="double" displayLabel="Flow (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowStatisticsResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowStatisticsResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FlowSummaryResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FlowSummaryResults_TotalSanitaryFlow" typeName="double" displayLabel="Flow (System Sanitary)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+        <ECProperty propertyName="FlowSummaryResults_TotalWetWeatherFlow" typeName="double" displayLabel="Flow (System Total Wet Weather)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="FlowSummaryResults_TotalHydrographVolume" typeName="double" displayLabel="Volume (Total Outflow)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFlowSummaryResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FlowSummaryResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="FroudeNumberResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FroudeNumberResults_FroudeNumber" typeName="double" displayLabel="Froude Number" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsFroudeNumberResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="FroudeNumberResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityDerivedCapacityResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityDerivedCapacityResults_FullFlowCapacity" typeName="double" displayLabel="Capacity (Full Flow)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GravityDerivedCapacityResults_DesignCapacity" typeName="double" displayLabel="Capacity (Design)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GravityDerivedCapacityResults_ExcessFullCapacity" typeName="double" displayLabel="Capacity (Excess Full Flow)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GravityDerivedCapacityResults_ExcessDesignCapacity" typeName="double" displayLabel="Capacity (Excess Design)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GravityDerivedCapacityResults_FlowToDesignCapacityRatio" typeName="double" displayLabel="Flow / Capacity (Design)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityDerivedCapacityResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityDerivedCapacityResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityDerivedConduitResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityDerivedConduitResults_StartGroundElevation" typeName="double" displayLabel="Elevation Ground (Start)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_StopGroundElevation" typeName="double" displayLabel="Elevation Ground (Stop)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_StartCrownElevation" typeName="double" displayLabel="Elevation Crown (Start)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_StopCrownElevation" typeName="double" displayLabel="Elevation Crown (Stop)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_StartCover" typeName="double" displayLabel="Cover (Start)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_StopCover" typeName="double" displayLabel="Cover (Stop)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_MinimumCover" typeName="double" displayLabel="Cover (Minimum)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_MinimumCoverDistance" typeName="double" displayLabel="Minimum Cover Distance Along Pipe" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityDerivedConduitResults_AverageCover" typeName="double" displayLabel="Cover (Average)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityDerivedConduitResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityDerivedConduitResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityDerivedInletResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityDerivedInletResults_InletDrainageArea" typeName="double" displayLabel="Inlet Drainage Area" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GravityDerivedInletResults_InletC" typeName="double" displayLabel="Inlet C" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityDerivedInletResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityDerivedInletResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityDerivedPolygonResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityDerivedPolygonResults_UnifiedArea" typeName="double" displayLabel="Area (Unified)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityDerivedPolygonResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityDerivedPolygonResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityNodeStatisticResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityNodeStatisticResults_MaximumDepthOut" typeName="double" displayLabel="Depth (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="GravityNodeStatisticResults_MaximumHeadloss" typeName="double" displayLabel="Headloss (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GravityNodeStatisticResults_TimeToMaximumHeadloss" typeName="double" displayLabel="Time (Maximum Headloss)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityNodeStatisticResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityNodeStatisticResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GravityStructureResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GravityStructureResults_CalculatedStation" typeName="double" displayLabel="Station (Calculated)" category="Geometry_Drainage_Geometry_Drainage" priority="0" kindOfQuantity="cifu:STATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGravityStructureResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GravityStructureResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridBoundaryElevationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridBoundaryElevationResults_HGL" typeName="double" displayLabel="Elevation (Calculated)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridBoundaryElevationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridBoundaryElevationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridBoundaryFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridBoundaryFlowResults_TotalFlow" typeName="double" displayLabel="Flow (Contributing)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridBoundaryFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridBoundaryFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridElementStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridElementStatistics_MaximumDepthX" typeName="double" displayLabel="X (Maximum Depth)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="GridElementStatistics_MaximumDepthY" typeName="double" displayLabel="Y (Maximum Depth)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridElementStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridElementStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridInfiltrationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridInfiltrationResults_TotalInfiltration" typeName="double" displayLabel="Infiltration (Total)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GridInfiltrationResults_TotalInfiltrationVolume" typeName="double" displayLabel="Infiltration (Total Volume)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridInfiltrationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridInfiltrationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridPointResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridPointResults_Depth" typeName="double" displayLabel="Depth on Grid" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GridPointResults_HGL" typeName="double" displayLabel="Hydraulic Grade (Grid)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GridPointResults_Velocity" typeName="double" displayLabel="Velocity (Grid)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridPointResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridPointResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridRainfallResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridRainfallResults_IncrementalPrecip" typeName="double" displayLabel="Precipitation (Incremental)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GridRainfallResults_CumulativePrecip" typeName="double" displayLabel="Precipitation (Cumulative)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridRainfallResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridRainfallResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridStatistics_MaximumDepth" typeName="double" displayLabel="Depth (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="GridStatistics_TimeToMaximumDepth" typeName="double" displayLabel="Time (Maximum Depth)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GridStatistics_MaximumHGL" typeName="double" displayLabel="Hydraulic Grade (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GridStatistics_VelocityAtMaxDepth" typeName="double" displayLabel="Velocity (Maximum Depth)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="GridStatistics_FloodHazard" typeName="double" displayLabel="Flood Hazard" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:AREA_PER_TIME"/>
+        <ECProperty propertyName="GridStatistics_FloodArrivalTime" typeName="double" displayLabel="Time (Flood Arrival)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GridStatistics_MaximumFloodedArea" typeName="double" displayLabel="Flooded Area (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GridStatistics_FinalFloodedArea" typeName="double" displayLabel="Flooded Area (Final)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GridWideStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GridWideStatistics_MaximumFloodedArea" typeName="double" displayLabel="Flooded Area (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GridWideStatistics_FinalFloodedArea" typeName="double" displayLabel="Flooded Area (Final)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGridWideStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GridWideStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GutterFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GutterFlowResults_StartFlow" typeName="double" displayLabel="Flow (Start)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGutterFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GutterFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GutterSectionalLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GutterSectionalLinkResults_DesignConstraintsViolated" typeName="boolean" displayLabel="Gutter Design Constraints Ever Violated?" category="Results_Statistics_Drainage_Results_Statistics_Drainage" priority="0"/>
+        <ECProperty propertyName="GutterSectionalLinkResults_DesignConstraintViolatedAtTime" typeName="boolean" displayLabel="Gutter Design Constraints Violated at Time?" category="Results_Statistics_Drainage_Results_Statistics_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGutterSectionalLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GutterSectionalLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFAashtoHeadlossResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ContractionLossCoefficient" typeName="double" displayLabel="Contraction Loss Coefficient (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ContractionLoss" typeName="double" displayLabel="Contraction Loss (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLossControllingPipe" typeName="int" displayLabel="Bend Loss Controlling Pipe (AASHTO)" category="Results_AASHTO_Hydraulic_Analysis_Results_AASHTO_Hydraulic_Analysis" priority="0"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLossPipeAngle" typeName="double" displayLabel="Bend Loss Pipe Angle (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLossPipeVelocity" typeName="double" displayLabel="Bend Loss Pipe Velocity (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLossPipeVelocityHead" typeName="double" displayLabel="Bend Loss Pipe Velocity Head (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLossCoefficient" typeName="double" displayLabel="Bend Loss Coefficient (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLoss" typeName="double" displayLabel="Bend Loss (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ExpansionLossControllingPipe" typeName="int" displayLabel="Expansion Loss Controlling Pipe (AASHTO)" category="Results_AASHTO_Hydraulic_Analysis_Results_AASHTO_Hydraulic_Analysis" priority="0"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ExpansionLossPipeFlow" typeName="double" displayLabel="Expansion Loss Pipe Flow (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ExpansionLossPipeVelocity" typeName="double" displayLabel="Expansion Loss Pipe Velocity (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ExpansionLossPipeVelocityHead" typeName="double" displayLabel="Expansion Loss Pipe Velocity Head (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ExpansionLossCoefficient" typeName="double" displayLabel="Expansion Loss Coefficient (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_ExpansionLoss" typeName="double" displayLabel="Expansion Loss (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_IsNonPipedFlowSignifiant" typeName="boolean" displayLabel="Is Non-Piped Flow Significant? (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_NonPipedFlowCorrectionFactor" typeName="double" displayLabel="Non-Piped Flow Correction Factor (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_StructureShapingCorrectionFactor" typeName="double" displayLabel="Correction factor for shaping (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_UnadjustedHeadloss" typeName="double" displayLabel="Unadjusted Headloss (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_AdjustedHeadloss" typeName="double" displayLabel="Adjusted Headloss (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFAashtoHeadlossResults_BendLossConduitFlow" typeName="double" displayLabel="Bend Loss Conduit Flow (AASHTO)" category="Results_AASHTO_Drainage_Results_AASHTO_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFAashtoHeadlossResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFAashtoHeadlossResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFBypassedFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedCA" typeName="double" displayLabel="Bypassed CA" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedTimeOfConcentration" typeName="double" displayLabel="Bypassed Tc" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedIntensity" typeName="double" displayLabel="Bypassed Intensity" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedRationalFlow" typeName="double" displayLabel="Bypassed Rational Flow" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedAdditionalFlow" typeName="double" displayLabel="Bypassed Additional Carryover Flow" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedKnownFlow" typeName="double" displayLabel="Bypassed Known Flow" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedFixedFlow" typeName="double" displayLabel="Bypassed Fixed Flow" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedTotalFlow" typeName="double" displayLabel="Flow (Total Bypassed)" category="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFBypassedFlowResults_BypassedTargetID" typeName="int" displayLabel="Bypass Target" category="Results_Inlet_Bypassed_Flows_Hydraulic_Analysis_Results_Inlet_Bypassed_Flows_Hydraulic_Analysis" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFBypassedFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFBypassedFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFCarryoverFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFCarryoverFlowResults_CarryoverCA" typeName="double" displayLabel="Carryover CA" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFCarryoverFlowResults_CarryoverTimeOfConcentration" typeName="double" displayLabel="Carryover Tc" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GVFCarryoverFlowResults_Carryoverlntensity" typeName="double" displayLabel="Carryover Intensity" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFCarryoverFlowResults_CarryoverRationalFlow" typeName="double" displayLabel="Carryover Rational Flow" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFCarryoverFlowResults_CarryoverAdditionalFlow" typeName="double" displayLabel="Carryover Additional Flow" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFCarryoverFlowResults_CarryoverKnownFlow" typeName="double" displayLabel="Carryover Known Flow" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFCarryoverFlowResults_CarryoverFixedFlow" typeName="double" displayLabel="Carryover Fixed Flow" category="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFCarryoverFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFCarryoverFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFCatchmentResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFCatchmentResults_CatchmentCA" typeName="double" displayLabel="Catchment CA" category="Results_Catchment_Drainage_Results_Catchment_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFCatchmentResults_CatchmentFlowTime" typeName="double" displayLabel="Catchment Flow Time" category="Results_Catchment_Drainage_Results_Catchment_Drainage" priority="0" kindOfQuantity="cifu:TIME_FLOW"/>
+        <ECProperty propertyName="GVFCatchmentResults_CatchmentIntensity" typeName="double" displayLabel="Catchment Intensity" category="Results_Catchment_Drainage_Results_Catchment_Drainage" priority="0" kindOfQuantity="cifu:RAINFALL_INTENSITY"/>
+        <ECProperty propertyName="GVFCatchmentResults_CatchmentRationalFlow" typeName="double" displayLabel="Catchment Rational Flow" category="Results_Catchment_Drainage_Results_Catchment_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFCatchmentResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFCatchmentResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFConduitInfiltrationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFConduitInfiltrationResults_LocalAdditionalInfiltration" typeName="double" displayLabel="Infiltration (Local Additional)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+        <ECProperty propertyName="GVFConduitInfiltrationResults_LocalInfiltration" typeName="double" displayLabel="Infiltration (Local)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+        <ECProperty propertyName="GVFConduitInfiltrationResults_LocalTotalInfiltration" typeName="double" displayLabel="Infiltration (Local Total)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFConduitInfiltrationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFConduitInfiltrationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFConduitResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFConduitResults_BranchID" typeName="int" displayLabel="Branch ID" category="Results_Engine_Parsing_Drainage_Results_Engine_Parsing_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFConduitResults_CalculatedBendAngle" typeName="double" displayLabel="Bend Angle (Calculated)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="GVFConduitResults_ProfileDescription" typeName="string" displayLabel="Profile Description" category="Results_Profile_Summary_Drainage_Results_Profile_Summary_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFConduitResults_HasHydraulicJump" typeName="boolean" displayLabel="Has Hydraulic Jump?" category="Results_Profile_Summary_Drainage_Results_Profile_Summary_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFConduitResults_NormalDepth" typeName="double" displayLabel="Depth (Normal)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="GVFConduitResults_CriticalDepth" typeName="double" displayLabel="Depth (Critical)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="GVFConduitResults_FroudeNumber" typeName="double" displayLabel="Froude Number (Normal)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFConduitResults_FrictionSlope" typeName="double" displayLabel="Friction Slope" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="GVFConduitResults_NormalDepthOverRise" typeName="double" displayLabel="Depth (Normal) / Rise" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="GVFConduitResults_CriticalVelocity" typeName="double" displayLabel="Velocity (Critical)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFConduitResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFConduitResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFDivertedFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFDivertedFlowResults_TotalDivertedFlowIn" typeName="double" displayLabel="Flow (Total Diverted In)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFDivertedFlowResults_LocalDivertedFlowIn" typeName="double" displayLabel="Flow (Local Diverted In Same Subnetwork)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFDivertedFlowResults_GlobalDivertedFlowIn" typeName="double" displayLabel="Flow (Diverted In Outside Subnetworks)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFDivertedFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFDivertedFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFDivertedFlowResultsOutAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFDivertedFlowResultsOut_NonDivertedFlowOut" typeName="double" displayLabel="Flow (Non-Diverted Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFDivertedFlowResultsOut_PercentDivertedOut" typeName="double" displayLabel="Flow (Percent Diverted Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="GVFDivertedFlowResultsOut_DivertedFlowOut" typeName="double" displayLabel="Flow (Diverted Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFDivertedFlowResultsOut_TotalDivertedVolume" typeName="double" displayLabel="Volume (Local Diverted)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFDivertedFlowResultsOutAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFDivertedFlowResultsOutAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFGravityNodeInvertResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFGravityNodeInvertResults_InvertInElevation1" typeName="double" displayLabel="Elevation (Invert in 1)" category="Results_Connecting_Links_Drainage_Results_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFGravityNodeInvertResults_InvertInElevation2" typeName="double" displayLabel="Elevation (Invert in 2)" category="Results_Connecting_Links_Drainage_Results_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFGravityNodeInvertResults_InvertInElevation3" typeName="double" displayLabel="Elevation (Invert in 3)" category="Results_Connecting_Links_Drainage_Results_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFGravityNodeInvertResults_InvertInElevation4" typeName="double" displayLabel="Elevation (Invert in 4)" category="Results_Connecting_Links_Drainage_Results_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFGravityNodeInvertResults_InvertInElevation5" typeName="double" displayLabel="Elevation (Invert in 5)" category="Results_Connecting_Links_Drainage_Results_Connecting_Links_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFGravityNodeInvertResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFGravityNodeInvertResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFGravityNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFGravityNodeResults_TotalVolumeIn" typeName="double" displayLabel="Volume (Total In)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFGravityNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFGravityNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFGravityStructureDownstreamResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFGravityStructureDownstreamResults_DownstreamConduitDepth" typeName="double" displayLabel="Downstream Conduit Depth" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFGravityStructureDownstreamResults_DownstreamConduitFlow" typeName="double" displayLabel="Downstream Conduit Flow" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFGravityStructureDownstreamResults_DownstreamConduitVelocity" typeName="double" displayLabel="Downstream Conduit Velocity" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="GVFGravityStructureDownstreamResults_DownstreamConduitVelocityHead" typeName="double" displayLabel="Downstream Conduit Velocity Head" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="GVFGravityStructureDownstreamResults_DownstreamConduit" typeName="int" displayLabel="Downstream Conduit" category="Results_Misc_Hydraulic_Analysis_Results_Misc_Hydraulic_Analysis" priority="0"/>
+        <ECProperty propertyName="GVFGravityStructureDownstreamResults_InvertElevationOut" typeName="double" displayLabel="Elevation (Invert Out)" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="DownstreamPipeFlowType" typeName="GVFGravityStructureDownstreamResultsAspect_DownstreamPipeFlowType_Enum" displayLabel="Downstream Pipe Flow Type" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFGravityStructureDownstreamResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFGravityStructureDownstreamResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFGutterResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFGutterResults_GutterCA" typeName="double" displayLabel="CA (Gutter)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFGutterResults_GutterTc" typeName="double" displayLabel="Tc (Gutter)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GVFGutterResults_GutterIntensity" typeName="double" displayLabel="Intensity (Gutter)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFGutterResults_GutterRationalFlow" typeName="double" displayLabel="Rational Flow (Gutter)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFGutterResults_GutterFixedFlow" typeName="double" displayLabel="Additional Carryover (Gutter)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFGutterResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFGutterResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFHec22PipeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFHec22PipeResults_DownstreamStructure" typeName="int" displayLabel="Downstream Structure" category="Results_HEC_22_Hydraulic_Analysis_Results_HEC_22_Hydraulic_Analysis" priority="0"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownStructEquivDiameter" typeName="double" displayLabel="Downstream Structure Equivalent Diameter" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownStructHglIn" typeName="double" displayLabel="Downstream Structure Hydraulic Grade Line (In)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownStructHglOut" typeName="double" displayLabel="Downstream Structure Hydraulic Grade Line (Out)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownStructEglIn" typeName="double" displayLabel="Downstream Structure Energy Grade Line (In)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownStructEglOut" typeName="double" displayLabel="Downstream Structure Energy Grade Line (Out)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownstreamConduit" typeName="int" displayLabel="Downstream Conduit" category="Results_HEC_22_Hydraulic_Analysis_Results_HEC_22_Hydraulic_Analysis" priority="0"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownConduitRise" typeName="double" displayLabel="Rise (Downstream Conduit)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownConduitFlow" typeName="double" displayLabel="Flow (Downstream Conduit)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownConduitVelocity" typeName="double" displayLabel="Velocity (Downstream Conduit)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownConduitVelocityHead" typeName="double" displayLabel="Velocity Head (Downstream Conduit)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="GVFHec22PipeResults_EquivalentDiameter" typeName="double" displayLabel="Equivalent Diameter" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="GVFHec22PipeResults_StructurePlungingDepth" typeName="double" displayLabel="Downstream Structure Plunging Depth" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="GVFHec22PipeResults_InitialHeadlossCoefficient" typeName="double" displayLabel="Initial Headloss Coefficient (HEC-22, Second Edition)" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_UsesDiameterCorrection" typeName="boolean" displayLabel="Uses Diameter Correction?" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DiameterCorrectionFactor" typeName="double" displayLabel="Diameter Correction Factor" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_UsesFlowDepthCorrection" typeName="boolean" displayLabel="Uses Flow Depth Correction?" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFHec22PipeResults_FlowDepthCorrectionFactor" typeName="double" displayLabel="Flow Depth Correction Factor" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_UsesRelativeFlowCorrectionFactor" typeName="boolean" displayLabel="Uses Relative Flow Correction Factor?" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFHec22PipeResults_RelativeFlowCorrectionFactor" typeName="double" displayLabel="Relative Flow Correction Factor" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_UsesPlungingCorrectionFactor" typeName="boolean" displayLabel="Uses Plunging Correction Factor?" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFHec22PipeResults_PlungingFlowCorrectionFactor" typeName="double" displayLabel="Plunging Flow Correction Factor" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_BenchingCorrectionFactor" typeName="double" displayLabel="Benching Correction Factor" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_AdjustedHeadlossCoefficient" typeName="double" displayLabel="Adjusted Headloss Coefficient (HEC-22, Second Edition)" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownConduitDepth" typeName="double" displayLabel="Depth (Downstream Conduit)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DownConduitEquivalentDiameter" typeName="double" displayLabel="Equivalent Diameter (Downstream Conduit)" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="GVFHec22PipeResults_ConduitSpecificHec22Headloss" typeName="double" displayLabel="Headloss for Conduit (HEC-22, Second Edition)" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="GVFHec22PipeResults_DeflectionAngle" typeName="double" displayLabel="Deflection Angle" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="DownStructBenching" typeName="GVFHec22PipeResultsAspect_DownStructBenching_Enum" displayLabel="Downstream Structure Benching" category="Results_HEC_22_Drainage_Results_HEC_22_Drainage" priority="0"/>
+        <ECProperty propertyName="DownConduitFlowType" typeName="GVFHec22PipeResultsAspect_DownConduitFlowType_Enum" displayLabel="Downstream Conduit Flow Type" category="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFHec22PipeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFHec22PipeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFInterceptedFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedCA" typeName="double" displayLabel="Intercepted CA" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedTimeOfConcentration" typeName="double" displayLabel="Intercepted Tc" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedIntensity" typeName="double" displayLabel="Intercepted Intensity" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedRationalFlow" typeName="double" displayLabel="Intercepted Rational Flow" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedAdditionalFlow" typeName="double" displayLabel="Intercepted Additional Carryover Flow" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedKnownFlow" typeName="double" displayLabel="Intercepted Known Flow" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFInterceptedFlowResults_InterceptedFixedFlow" typeName="double" displayLabel="Intercepted Fixed Flow" category="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFInterceptedFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFInterceptedFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFLocalFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalCA" typeName="double" displayLabel="Local CA" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalFlowTime" typeName="double" displayLabel="Local Flow Time" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalIntensity" typeName="double" displayLabel="Local Intensity" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalRationalFlow" typeName="double" displayLabel="Local Rational Flow" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalAdditionalFlow" typeName="double" displayLabel="Local Additional Flow" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalKnownFlow" typeName="double" displayLabel="Local Known Flow" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLocalFlowResults_LocalFixedFlow" typeName="double" displayLabel="Local Fixed Flow" category="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFLocalFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFLocalFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFLostSurfaceFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceCA" typeName="double" displayLabel="Lost Surface CA" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceFlowTime" typeName="double" displayLabel="Lost Surface Flow Time" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:TIME_FLOW"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceIntensity" typeName="double" displayLabel="Lost Surface Intensity" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceRationalFlow" typeName="double" displayLabel="Lost Surface Rational Flow" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceAdditionalFlow" typeName="double" displayLabel="Lost Surface Additional Carryover Flow" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceKnownFlow" typeName="double" displayLabel="Bypassed Known Flow" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceFixedFlow" typeName="double" displayLabel="Lost Surface Fixed Flow" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFLostSurfaceFlowResults_LostSurfaceTotalFlow" typeName="double" displayLabel="Lost Surface Total Flow" category="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFLostSurfaceFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFLostSurfaceFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFPressureNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFPressureNodeResults_TotalPumpedFlow" typeName="double" displayLabel="Flow (Total Pumped)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFPressureNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFPressureNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFSystemFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemCA" typeName="double" displayLabel="System CA" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemFlowTime" typeName="double" displayLabel="System Flow Time" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:TIME_FLOW"/>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemIntensity" typeName="double" displayLabel="System Intensity" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemRationalFlow" typeName="double" displayLabel="System Rational Flow" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemAdditionalFlow" typeName="double" displayLabel="System Additional Flow" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemKnownFlow" typeName="double" displayLabel="System Known Flow" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="GVFSystemFlowResults_SystemFixedFlow" typeName="double" displayLabel="System Fixed Flow" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFSystemFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFSystemFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFTotalInletFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFTotalInletFlowResults_TotalInletCA" typeName="double" displayLabel="Total Inlet CA" category="Results_Inlet_Surface_Flows_Drainage_Results_Inlet_Surface_Flows_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="GVFTotalInletFlowResults_TotalInletTimeOfConcentration" typeName="double" displayLabel="Total Inlet Tc" category="Results_Inlet_Surface_Flows_Drainage_Results_Inlet_Surface_Flows_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="GVFTotalInletFlowResults_TotalInletIntensity" typeName="double" displayLabel="Total Inlet Intensity" category="Results_Inlet_Surface_Flows_Drainage_Results_Inlet_Surface_Flows_Drainage" priority="0" kindOfQuantity="cifu:INTENSITY"/>
+        <ECProperty propertyName="GVFTotalInletFlowResults_TotalInletRationalFlow" typeName="double" displayLabel="Total Rational Flow to Inlet" category="Results_Inlet_Surface_Flows_Drainage_Results_Inlet_Surface_Flows_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFTotalInletFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFTotalInletFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFTractiveStressResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFTractiveStressResults_CalculatedTractiveStress" typeName="double" displayLabel="Tractive Stress (Calculated)" category="Results_Tractive_Stress_Drainage_Results_Tractive_Stress_Drainage" priority="0" kindOfQuantity="cifu:STRESS"/>
+        <ECProperty propertyName="GVFTractiveStressResults_TractiveStressTargetExceeded" typeName="boolean" displayLabel="Is Tractive Stress Target Exceeded?" category="Results_Tractive_Stress_Drainage_Results_Tractive_Stress_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFTractiveStressResults_TractiveStressEverExceeded" typeName="boolean" displayLabel="Is Tractive Stress Target Ever Exceeded?" category="Results_Tractive_Stress_Drainage_Results_Tractive_Stress_Drainage" priority="0"/>
+        <ECProperty propertyName="GVFTractiveStressResults_TractiveHydraulicRadius" typeName="double" displayLabel="Hydraulic Radius (Normal)" category="Results_Tractive_Stress_Drainage_Results_Tractive_Stress_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFTractiveStressResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFTractiveStressResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GVFUKSystemFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GVFUKSystemFlowResults_ArealReductionFactor" typeName="double" displayLabel="Areal Reduction Factor" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGVFUKSystemFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GVFUKSystemFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="HeadwallNodeDerivedResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HeadwallNodeDerivedResults_HeadwallIsInlet" typeName="boolean" displayLabel="Is Inlet?" category="Physical_Headwall_Drainage_Physical_Headwall_Drainage" priority="0"/>
+        <ECProperty propertyName="HeadwallNodeDerivedResults_HeadwallBarrelShape" typeName="string" displayLabel="Culvert Barrel Shape" category="Physical_Headwall_Drainage_Physical_Headwall_Drainage" priority="0"/>
+        <ECProperty propertyName="HeadwallBoundaryType" typeName="HeadwallNodeDerivedResultsAspect_HeadwallBoundaryType_Enum" displayLabel="Network Boundary Type" category="Boundary_Condition_Drainage_Boundary_Condition_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHeadwallNodeDerivedResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="HeadwallNodeDerivedResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Hec22ThirdEditionLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Hec22ThirdEditionLinkResults_ExitLoss" typeName="double" displayLabel="Exit Loss" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionLinkResults_PlungingInflowEnergyLoss" typeName="double" displayLabel="Plunging Inflow Energy Loss" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionLinkResults_AngledInflowEnergyLoss" typeName="double" displayLabel="Angled Inflow Energy Loss" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionLinkResults_HasPlungingInflow" typeName="boolean" displayLabel="Has Plunging Inflow?" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="Hec22ThirdEditionLinkResults_HasAngledInflow" typeName="boolean" displayLabel="Has Angled Inflow?" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHec22ThirdEditionLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Hec22ThirdEditionLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Hec22ThirdEditionNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_EntranceLoss" typeName="double" displayLabel="Entrance Loss" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_TotalPlungingInflowEnergyLosses" typeName="double" displayLabel="Total Plunging Inflow Energy Losses" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_TotalAngledInflowEnergyLosses" typeName="double" displayLabel="Total Angled Inflow Energy Losses" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_BenchingEnergyLoss" typeName="double" displayLabel="Benching Energy Loss" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_TotalAdditionalStructureEnergyLosses" typeName="double" displayLabel="Total Additional Structure Energy Losses" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_TotalStructureEnergyLosses" typeName="double" displayLabel="Total Structure Energy Losses" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="EntranceLossControlType" typeName="Hec22ThirdEditionNodeResultsAspect_EntranceLossControlType_Enum" displayLabel="Entrance Loss Control Type" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_HasPlungingInflow" typeName="boolean" displayLabel="Has Plunging Inflow?" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0"/>
+        <ECProperty propertyName="Hec22ThirdEditionNodeResults_HasAngledInflow" typeName="boolean" displayLabel="Has Angled Inflow?" category="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHec22ThirdEditionNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Hec22ThirdEditionNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="HMIStandardResultRecordAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Time" typeName="double" displayLabel="Time" category="Drainage_Drainage" priority="0"/>
+        <ECProperty propertyName="FlowDirection" typeName="HMIStandardResultRecordAspect_FlowDirection_Enum" displayLabel="Flow Direction" category="Drainage_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHMIStandardResultRecordAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="HMIStandardResultRecordAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="HydrographResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HydrographResults_RunoffPeakDischarge" typeName="double" displayLabel="Flow (Peak Interpolated Output)" category="Results_Interpolated_Drainage_Results_Interpolated_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="HydrographResults_RunoffVolume" typeName="double" displayLabel="Volume" category="Results_Interpolated_Drainage_Results_Interpolated_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="HydrographResults_TimeToPeak" typeName="double" displayLabel="Time to Flow (Peak Interpolated Output)" category="Results_Interpolated_Drainage_Results_Interpolated_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="HydrographResults_Flow" typeName="double" displayLabel="Flow (Total)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsHydrographResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="HydrographResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoBatteryResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoBatteryResults_LeadPumpFlow" typeName="double" displayLabel="Flow (Lead Pump)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="IdahoBatteryResults_NumberOfRunningLagPumps" typeName="double" displayLabel="Number of Running Lag Pumps" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoBatteryResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoBatteryResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoClosableElementResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoClosableElementResults_IsClosed" typeName="boolean" displayLabel="Is Closed?" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+        <ECProperty propertyName="IdahoClosableElementResults_IsOpen" typeName="boolean" displayLabel="Is Open?" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+        <ECProperty propertyName="IdahoClosableElementResults_IsInitiallyClosed" typeName="boolean" displayLabel="Is Initially Closed?" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoClosableElementResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoClosableElementResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoControlsResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoControlsResults_IsControlled" typeName="boolean" displayLabel="Controlled?" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoControlsResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoControlsResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoDirectedNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoDirectedNodeResults_ElementCannotDeliverFlowOrHead" typeName="boolean" displayLabel="Cannot Deliver Flow or Head?" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoDirectedNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoDirectedNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoMinorLossDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoMinorLossData_UnifiedMinorLossCoefficient" typeName="double" displayLabel="Minor Loss Coefficient (Unified)" category="Physical_Drainage_Physical_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoMinorLossDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoMinorLossDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPeakEnergyCostResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPeakEnergyCostResults_PeakPower" typeName="double" displayLabel="Peak Power" category="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPeakEnergyCostResults_TimeOfPeak" typeName="double" displayLabel="Time of Peak Energy Cost" category="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="IdahoPeakEnergyCostResults_DemandCharge" typeName="double" displayLabel="Demand Charge" category="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" priority="0"/>
+        <ECProperty propertyName="IdahoPeakEnergyCostResults_DemandChargePeriod" typeName="double" displayLabel="Demand Charge Period" category="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="IdahoPeakEnergyCostResults_PeakPowerCost" typeName="double" displayLabel="Peak Power Cost" category="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPeakEnergyCostResults_DailyPeakPowerCost" typeName="double" displayLabel="Peak Power Cost (Daily)" category="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPeakEnergyCostResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPeakEnergyCostResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPipeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPipeResults_PipeHeadlossGradient" typeName="double" displayLabel="Headloss Gradient" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="IdahoPipeResults_PipeAbsoluteFlow" typeName="double" displayLabel="Flow (Absolute)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="IdahoPipeResults_PipeTravelTime" typeName="double" displayLabel="Travel Time" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:TIME_SHORT"/>
+        <ECProperty propertyName="IdahoPipeResults_PipeMinorHeadloss" typeName="double" displayLabel="Headloss (Minor)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="IdahoPipeResults_PipeFrictionHeadloss" typeName="double" displayLabel="Headloss (Friction)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="PipeResultControlStatus" typeName="IdahoPipeResultsAspect_PipeResultControlStatus_Enum" displayLabel="Status (Calculated)" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPipeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPipeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpDefinitionDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPumpDefinitionData_ShutoffHead" typeName="double" displayLabel="Head (Shutoff)" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="IdahoPumpDefinitionData_DesignHead" typeName="double" displayLabel="Head (Design)" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="IdahoPumpDefinitionData_DesignFlow" typeName="double" displayLabel="Flow (Design)" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="IdahoPumpDefinitionData_MaxOperatingHead" typeName="double" displayLabel="Head (Maximum Operating)" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="IdahoPumpDefinitionData_MaxOperatingFlow" typeName="double" displayLabel="Flow (Maximum Operating)" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="IdahoPumpDefinitionData_MaxExtendedFlow" typeName="double" displayLabel="Flow (Maximum Extended)" category="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpDefinitionDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpDefinitionDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpEnergyCostResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_IncrementalVolumePumped" typeName="double" displayLabel="Volume Pumped (Incremental)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_CumulativeVolumePumped" typeName="double" displayLabel="Volume Pumped (Cumulative)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_WaterPower" typeName="double" displayLabel="Water Power" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_PumpEfficiency" typeName="double" displayLabel="Pump Efficiency" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_WireToWaterEfficiency" typeName="double" displayLabel="Wire to Water Efficiency" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_WirePower" typeName="double" displayLabel="Wire Power" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_IncrementalEnergyUsed" typeName="double" displayLabel="Energy Used (Incremental)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_CumulativeEnergyUsed" typeName="double" displayLabel="Energy Used (Cumulative)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_EnergyPrice" typeName="double" displayLabel="Energy Price" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY_PER_ENERGY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_IncrementalEnergyCost" typeName="double" displayLabel="Energy Cost (Incremental)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_CumulativeEnergyCost" typeName="double" displayLabel="Energy Cost (Cumulative)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_CostPerUnitVolume" typeName="double" displayLabel="Cost per Unit Volume" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:COST_PER_UNITVOLUME"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_PumpSpeed" typeName="double" displayLabel="Relative Speed Factor (Energy Cost Engine)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostResults_MotorEfficiency" typeName="double" displayLabel="Motor Efficiency" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpEnergyCostResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpEnergyCostResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpEnergyCostSummaryResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_TimeOfUse" typeName="double" displayLabel="Time of Use" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_Utilization" typeName="double" displayLabel="Utilization" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_TotalVolumePumped" typeName="double" displayLabel="Volume Pumped (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_AverageWaterPower" typeName="double" displayLabel="Water Power (Average)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_AveragePumpEfficiency" typeName="double" displayLabel="Pump Efficiency (Average)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_AverageWireWaterEfficiency" typeName="double" displayLabel="Wire to Water Efficiency (Average)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_AverageWirePower" typeName="double" displayLabel="Wire Power (Average)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_TotalEnergyUsage" typeName="double" displayLabel="Energy Usage (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_TotalEnergyUseCost" typeName="double" displayLabel="Energy Use Cost (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_DailyEnergyUsage" typeName="double" displayLabel="Energy Usage (Daily)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_DailyEnergyUseCost" typeName="double" displayLabel="Energy Use Cost (Daily)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpEnergyCostSummaryResults_CostPerUnitVolume" typeName="double" displayLabel="Cost per Unit Volume (Summary)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:COST_PER_UNITVOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpEnergyCostSummaryResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpEnergyCostSummaryResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPumpResults_ResultRelativeSpeed" typeName="double" displayLabel="Relative Speed Factor (Calculated)" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="IdahoPumpResults_IntakePressure" typeName="double" displayLabel="Pressure (Suction)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:PRESSURE"/>
+        <ECProperty propertyName="IdahoPumpResults_DischargePressure" typeName="double" displayLabel="Pressure (Discharge)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:PRESSURE"/>
+        <ECProperty propertyName="IdahoPumpResults_PumpAbsoluteFlow" typeName="double" displayLabel="Flow (Absolute)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="IdahoPumpResults_PumpExceedsOperatingRange" typeName="boolean" displayLabel="Pump Exceeds Operating Range?" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+        <ECProperty propertyName="PumpResultControlStatus" typeName="IdahoPumpResultsAspect_PumpResultControlStatus_Enum" displayLabel="Status (Calculated)" category="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpStationEnergyCostResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_TotalFlow" typeName="double" displayLabel="Flow (Total)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_IncrementalVolumePumped" typeName="double" displayLabel="Volume Pumped (Incremental)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_CumulativeVolumePumped" typeName="double" displayLabel="Volume Pumped (Cumulative)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_WaterPower" typeName="double" displayLabel="Water Power" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_EfficiencyPumpStation" typeName="double" displayLabel="Efficiency Pump Station" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_WireToWaterEfficiency" typeName="double" displayLabel="Wire to Water Efficiency" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_WirePower" typeName="double" displayLabel="Wire Power" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:POWER"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_IncrementalEnergyUsed" typeName="double" displayLabel="Energy Used (Incremental)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_CumulativeEnergyUsed" typeName="double" displayLabel="Energy Used (Cumulative)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_EnergyPrice" typeName="double" displayLabel="Energy Price" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY_PER_ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_IncrementalEnergyCost" typeName="double" displayLabel="Energy Cost (Incremental)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_CumulativeEnergyCost" typeName="double" displayLabel="Energy Cost (Cumulative)" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostResults_CostPerUnitVolume" typeName="double" displayLabel="Cost per Unit Volume" category="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" priority="0" kindOfQuantity="cifu:COST_PER_UNITVOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpStationEnergyCostResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpStationEnergyCostResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoPumpStationEnergyCostSummaryResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_TimeOfUse" typeName="double" displayLabel="Time of Use" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_TotalVolumePumped" typeName="double" displayLabel="Volume Pumped (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:VOLUME_LARGE"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_TotalWaterPower" typeName="double" displayLabel="Water Power (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_EfficiencyAveragePumpStation" typeName="double" displayLabel="Efficiency (Average) Pump Station" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_WireToWaterEfficiencyAverage" typeName="double" displayLabel="Wire to Water Efficiency (Average)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_TotalWirePower" typeName="double" displayLabel="Wire Power (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_EnergyUsedTotal" typeName="double" displayLabel="Energy Usage (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_CostOfEnergyUseTotal" typeName="double" displayLabel="Energy Use Cost (Total)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_DailyEnergyUsage" typeName="double" displayLabel="Energy Usage (Daily)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_DailyEnergyUseCost" typeName="double" displayLabel="Energy Use Cost (Daily)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:CURRENCY"/>
+        <ECProperty propertyName="IdahoPumpStationEnergyCostSummaryResults_CostperUnitVolumeSummary" typeName="double" displayLabel="Cost per Unit Volume (Summary)" category="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" priority="0" kindOfQuantity="cifu:COST_PER_UNITVOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoPumpStationEnergyCostSummaryResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoPumpStationEnergyCostSummaryResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="IdahoStorageResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="IdahoStorageResults_NetInflow" typeName="double" displayLabel="Flow (In net)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsIdahoStorageResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="IdahoStorageResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ILSAXCatchmentResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ILSAXCatchmentResults_fi" typeName="double" displayLabel="fi (ILSAX) (Calculated)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="ILSAXCatchmentResults_fo" typeName="double" displayLabel="fo (ILSAX) (Calculated)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="ILSAXCatchmentResults_fc" typeName="double" displayLabel="fc (ILSAX) (Calculated)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="ILSAXCatchmentResults_k" typeName="double" displayLabel="k (ILSAX) (Calculated)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:REACTION_RATE"/>
+        <ECProperty propertyName="ILSAXCatchmentResults_fID" typeName="double" displayLabel="Accumulated Diminishing Infiltration (ILSAX) (Calculated)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="ILSAXCatchmentResults_InitialRate" typeName="double" displayLabel="Initial Rate (Calculated)" category="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsILSAXCatchmentResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ILSAXCatchmentResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="InfiltrationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InfiltrationResults_InfiltrationFlow" typeName="double" displayLabel="Infiltration" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="InfiltrationMethodResult" typeName="InfiltrationResultsAspect_InfiltrationMethodResult_Enum" displayLabel="Infiltration Method (Computed)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0"/>
+        <ECProperty propertyName="ConstantType_FlowRateResult" typeName="double" displayLabel="Infiltration Rate (Constant)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="AverageInfiltrationType_AverageRateResult" typeName="double" displayLabel="Infiltration Rate (Average)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="InfiltrationHeadDepthType_InfiltrationRateResult" typeName="double" displayLabel="Infiltration per unit of Head" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0"/>
+        <ECProperty propertyName="InfiltrationHeadDepthType_ExponentResult" typeName="double" displayLabel="K Exponent (Infiltration)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsInfiltrationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="InfiltrationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="InflowNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="InflowNodeResults_TotalLocalInflowResult" typeName="double" displayLabel="Flow (Local from Inflow Collection)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="InflowNodeResults_HasLocalInflow" typeName="boolean" displayLabel="Local Inflow?" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsInflowNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="InflowNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LateralInflowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LateralInflowResults_TotalLateralInflow" typeName="double" displayLabel="Flow (Total Lateral Inflow)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLateralInflowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LateralInflowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LIDDerivedResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LIDDerivedResults_CatchmentPortionArea" typeName="double" displayLabel="Portion of Parent Catchment Area" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="LIDDerivedResults_UnifiedAreaPerLID" typeName="double" displayLabel="Area Per Low Impact Development (Unified)" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="LIDDerivedResults_TotalLIDArea" typeName="double" displayLabel="Area (Total)" category="Results_Misc_Drainage_Results_Misc_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLIDDerivedResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LIDDerivedResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LIDResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LIDResults_Inflow" typeName="double" displayLabel="Inflow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_Evaporation" typeName="double" displayLabel="Evaporation" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_SurfaceInfiltration" typeName="double" displayLabel="Surface Infiltration" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_SoilPerc" typeName="double" displayLabel="Soil Percolation" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_BottomInfiltration" typeName="double" displayLabel="Bottom Infiltration" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_SurfaceRunoff" typeName="double" displayLabel="Surface Runoff" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_DrainOutflow" typeName="double" displayLabel="Drain Outflow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_SurfaceDepth" typeName="double" displayLabel="Surface Depth" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="LIDResults_SoilPavementMoisture" typeName="double" displayLabel="Soil/Pavement Moisture" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="LIDResults_StorageDepth" typeName="double" displayLabel="Storage Depth" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="LIDResults_PavementPerc" typeName="double" displayLabel="Pavement Percolation" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="LIDResults_PavementLevel" typeName="double" displayLabel="Pavement Level" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLIDResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LIDResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinkStorageResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LinkStorageResults_FlowVolume" typeName="double" displayLabel="Volume (Storage)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinkStorageResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinkStorageResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinkSurchargeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LinkSurchargeResults_SurchargeDepth" typeName="double" displayLabel="Depth (Surcharged)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinkSurchargeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinkSurchargeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LocalInflowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LocalInflowResults_MaximumLocalInflow" typeName="double" displayLabel="Local Inflow (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="LocalInflowResults_TimeToMaximumLocalInflow" typeName="double" displayLabel="Time to Local Inflow (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="LocalInflowResults_TotalLocalInflowVolume" typeName="double" displayLabel="Local Inflow (Total Volume)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLocalInflowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LocalInflowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LostFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="LostFlowResults_ResultLostFlow" typeName="double" displayLabel="Flow (Overflow)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLostFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LostFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="MiddleDepthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MiddleDepthResults_DepthMiddle" typeName="double" displayLabel="Depth (Middle)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsMiddleDepthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="MiddleDepthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="MiddleEnergyGradeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MiddleEnergyGradeResults_EnergyGradeLineMiddle" typeName="double" displayLabel="Energy Grade Line (Middle)" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsMiddleEnergyGradeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="MiddleEnergyGradeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="MiddleFroudeNumberResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MiddleFroudeNumberResults_FroudeNumberMiddle" typeName="double" displayLabel="Froude Number (Middle)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsMiddleFroudeNumberResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="MiddleFroudeNumberResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="MiddleHydraulicGradeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MiddleHydraulicGradeResults_HydraulicGradeMiddle" typeName="double" displayLabel="Hydraulic Grade" category="Results_Profile_Drainage_Results_Profile_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsMiddleHydraulicGradeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="MiddleHydraulicGradeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="MiddleVelocityResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MiddleVelocityResults_VelocityMiddle" typeName="double" displayLabel="Velocity (Middle)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsMiddleVelocityResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="MiddleVelocityResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NodeInflowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="NodeInflowResults_TotalInflowVolume" typeName="double" displayLabel="Volume (Locally Injected)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="NodeInflowResults_LocallyInjectedFlow" typeName="double" displayLabel="Flow (Local In)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNodeInflowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NodeInflowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="OutfallResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OutfallResults_Flow" typeName="double" displayLabel="Flow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOutfallResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="OutfallResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="OverflowStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OverflowStatistics_MaximumOverflow" typeName="double" displayLabel="Flow (Overflow Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="OverflowStatistics_TimeToMaximumOverflow" typeName="double" displayLabel="Time to Maximum Overflow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsOverflowStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="OverflowStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PeakFlowEstimatedStorageResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_MaximumComputedStorage" typeName="double" displayLabel="Maximum Computed Storage" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_EstimatedLength" typeName="double" displayLabel="Estimated Length" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_EstimatedDiameter" typeName="double" displayLabel="Estimated Diameter" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_VolumeBelowFreeboard" typeName="double" displayLabel="Volume up to Freeboard Elevation" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_VolumeAboveFreeboard" typeName="double" displayLabel="Volume from Freeboard to Top of Pond" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_TotalPondVolume" typeName="double" displayLabel="Total Pond Volume" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_PondDepth" typeName="double" displayLabel="Pond Depth (Calculated)" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_FreeboardDepth" typeName="double" displayLabel="Freeboard Depth" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_TopPondElevation" typeName="double" displayLabel="Top Pond Elevation" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_TopSurfaceArea" typeName="double" displayLabel="Top Surface Area" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_FreeboardElevation" typeName="double" displayLabel="Freeboard Elevation" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_FreeboardSurfaceArea" typeName="double" displayLabel="Freeboard Surface Area" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_BottomElevation" typeName="double" displayLabel="Bottom Elevation" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PeakFlowEstimatedStorageResults_BottomSurfaceArea" typeName="double" displayLabel="Bottom Surface Area" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPeakFlowEstimatedStorageResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PeakFlowEstimatedStorageResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PondedVolumeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PondedVolumeResults_MaxPondedVolume" typeName="double" displayLabel="Ponded Volume (Maximum)" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PondedVolumeResults_TimeToMaximumPondedVolume" typeName="double" displayLabel="Time to Maximum Ponded Volume" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPondedVolumeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PondedVolumeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PondInfiltrationResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PondInfiltrationResults_InfiltrationOutflow" typeName="double" displayLabel="Flow (Seepage loss)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PondInfiltrationResults_EvaporationOutflow" typeName="double" displayLabel="Flow (Evaporation loss)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPondInfiltrationResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PondInfiltrationResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureJunctionResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PressureJunctionResults_PressureHead" typeName="double" displayLabel="Pressure Head" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PressureJunctionResults_Pressure" typeName="double" displayLabel="Pressure" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PRESSURE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureJunctionResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureJunctionResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureNodeStatisticResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PressureNodeStatisticResults_MaximumPressure" typeName="double" displayLabel="Pressure (Maximum)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:PRESSURE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureNodeStatisticResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureNodeStatisticResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressurePipeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PressurePipeResults_HeadlossGradient" typeName="double" displayLabel="Headloss Gradient" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="PressurePipeResults_FrictionHeadloss" typeName="double" displayLabel="Headloss (Friction)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="PressurePipeResults_MinorHeadloss" typeName="double" displayLabel="Headloss (Minor)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+        <ECProperty propertyName="PressurePipeResults_Headloss" typeName="double" displayLabel="Headloss" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:HEADLOSS"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressurePipeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressurePipeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureSystemLoadableNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PressureSystemLoadableNodeResults_CalculatedLoad" typeName="double" displayLabel="Load (Calculated)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureSystemLoadableNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureSystemLoadableNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PressureSystemNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PressureSystemNodeResults_CalculatedHydraulicGrade" typeName="double" displayLabel="Hydraulic Grade Line (Calculated)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPressureSystemNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PressureSystemNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PumpResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PumpResults_PumpHead" typeName="double" displayLabel="Head (Pump)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PumpResults_PumpDischarge" typeName="double" displayLabel="Flow (Pump)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PumpResults_UpstreamHead" typeName="double" displayLabel="Hydraulic Grade (Upstream)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="PumpResults_DownstreamHead" typeName="double" displayLabel="Hydraulic Grade (Downstream)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPumpResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PumpResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PumpStatResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PumpStatResults_Utilized" typeName="double" displayLabel="Utilized" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="PumpStatResults_NumberOfStartups" typeName="int" displayLabel="Number of Start-Ups" category="Results_Drainage_Results_Drainage" priority="0"/>
+        <ECProperty propertyName="PumpStatResults_PumpedVolume" typeName="double" displayLabel="Volume (Pumped)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="PumpStatResults_PowerUsage" typeName="double" displayLabel="Power Usage" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ENERGY"/>
+        <ECProperty propertyName="PumpStatResults_TimeBelowPumpCurve" typeName="double" displayLabel="Time Below Pump Curve" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="PumpStatResults_TimeAbovePumpCurve" typeName="double" displayLabel="Time Above Pump Curve" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="PumpStatResults_MinimumFlow" typeName="double" displayLabel="Flow (Minimum Pumped)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PumpStatResults_AverageFlow" typeName="double" displayLabel="Flow (Average)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPumpStatResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PumpStatResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RatConduitResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RatConduitResults_UpstreamInletDrainageArea" typeName="double" displayLabel="Upstream Inlet Area" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="RatConduitResults_UpstreamInletC" typeName="double" displayLabel="Upstream Inlet C" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="RatConduitResults_InletTime" typeName="double" displayLabel="Upstream Inlet Tc" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="RatConduitResults_TotalRationalFlowToInlet" typeName="double" displayLabel="Upstream Structure Flow (Total Surface)" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="RatConduitResults_FlowNotCapturedByInlet" typeName="double" displayLabel="Upstream Structure Flow (Total Bypassed)" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="RatConduitResults_DesignPointHGL" typeName="double" displayLabel="Upstream Structure Hydraulic Grade Line (In)" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="RatConduitResults_UpstreamVelocity" typeName="double" displayLabel="Upstream Structure Velocity (In-Governing)" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="RatConduitResults_UpstreamVelocityHead" typeName="double" displayLabel="Upstream Structure Velocity Head (In-Governing)" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="RatConduitResults_DownstreamVelocityHead" typeName="double" displayLabel="Velocity Head (Out)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="RatConduitResults_MinorLossK" typeName="double" displayLabel="Upstream Structure Headloss Coefficient" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="RatConduitResults_TotalMinorLoss" typeName="double" displayLabel="Upstream Structure Headloss" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="RatConduitResults_UpstreamStructureEnergyGradeLineIn" typeName="double" displayLabel="Upstream Structure Energy Grade Line (In)" category="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="RatConduitResults_UpstreamStructureLabel" typeName="int" displayLabel="Upstream Structure" category="Results_Upstream_Structure_Hydraulic_Analysis_Results_Upstream_Structure_Hydraulic_Analysis" priority="0"/>
+        <ECProperty propertyName="RatConduitResults_BranchElementID" typeName="int" displayLabel="Branch Element ID" category="Results_Engine_Parsing_Drainage_Results_Engine_Parsing_Drainage" priority="0"/>
+        <ECProperty propertyName="RatConduitResults_FlowArea" typeName="double" displayLabel="Area (Flow)" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="RatConduitResults_WettedPerimeter" typeName="double" displayLabel="Wetted Perimeter" category="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRatConduitResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RatConduitResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RationalMethodQPeakResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RationalMethodQPeakResults_Tc" typeName="double" displayLabel="Time of Concentration" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRationalMethodQPeakResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RationalMethodQPeakResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RatioResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RatioResults_MaxFlowPipeFullRatio" typeName="double" displayLabel="Flow (Maximum) / Full Flow" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="RatioResults_AdjustedLengthActualLengthRatio" typeName="double" displayLabel="Adjusted Length / Actual Length" category="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRatioResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RatioResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReversibleLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ReversibleLinkResults_IsReversed" typeName="boolean" displayLabel="Is Reversed?" category="Results_Engine_Parsing_Drainage_Results_Engine_Parsing_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReversibleLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReversibleLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SanitaryFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SanitaryFlowResults_SanitaryPopulation" typeName="double" displayLabel="Population (Local Sanitary)" category="Results_Sanitary_Loading_Drainage_Results_Sanitary_Loading_Drainage" priority="0" kindOfQuantity="cifu:POPULATION"/>
+        <ECProperty propertyName="SanitaryFlowResults_SanitaryServiceArea" typeName="double" displayLabel="Area (Local Sanitary Service)" category="Results_Sanitary_Loading_Drainage_Results_Sanitary_Loading_Drainage" priority="0" kindOfQuantity="cifu:AREA_LARGE"/>
+        <ECProperty propertyName="SanitaryFlowResults_SanitaryBaseLoad" typeName="double" displayLabel="Base Load (Local Sanitary)" category="Results_Sanitary_Loading_Drainage_Results_Sanitary_Loading_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+        <ECProperty propertyName="SanitaryFlowResults_SanitaryAdjustedPopulation" typeName="double" displayLabel="Population (Local Sanitary Adjusted)" category="Results_Sanitary_Loading_Drainage_Results_Sanitary_Loading_Drainage" priority="0" kindOfQuantity="cifu:POPULATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSanitaryFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SanitaryFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ScadaElementDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ScadaElementData_TargetElementValue" typeName="double" displayLabel="Model Element Value (Numeric)" category="SCADA_Drainage_SCADA_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="ScadaElementData_Difference" typeName="double" displayLabel="Difference" category="SCADA_Drainage_SCADA_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="ScadaElementData_SignalValueRealtime" typeName="double" displayLabel="Real-time Signal Value (Numeric)" category="SCADA_Drainage_SCADA_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="ScadaElementData_SignalValueHistorical" typeName="double" displayLabel="Historical Signal Value (Numeric)" category="SCADA_Drainage_SCADA_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="ScadaElementData_TargetElementDisplayUnit" typeName="string" displayLabel="Display Unit (Model Element)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="ScadaElementData_TargetElementDisplayValue" typeName="string" displayLabel="Model Element Value (Display)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="ScadaElementData_SignalValueRealtimeDisplay" typeName="string" displayLabel="Real-time Signal Value (Display)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="ScadaElementData_SignalValueHistoricalDisplay" typeName="string" displayLabel="Historical Signal Value (Display)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="ScadaTargetElementType" typeName="ScadaElementDataAspect_ScadaTargetElementType_Enum" displayLabel="Model Element Type" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="ScadaSignalQualityRealtimeType" typeName="ScadaElementDataAspect_ScadaSignalQualityRealtimeType_Enum" displayLabel="Signal Quality (Real-time)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+        <ECProperty propertyName="ScadaSignalQualityHistoricalType" typeName="ScadaElementDataAspect_ScadaSignalQualityHistoricalType_Enum" displayLabel="Signal Quality (Historical)" category="SCADA_Drainage_SCADA_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsScadaElementDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ScadaElementDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SectionalLinkResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SectionalLinkResults_StartSection_Discharge" typeName="double" displayLabel="Flow (Start)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SectionalLinkResults_StopSection_Discharge" typeName="double" displayLabel="Flow (Stop)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SectionalLinkResults_MiddleSection_Discharge" typeName="double" displayLabel="Flow (Middle)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SectionalLinkResults_StartSection_FlowArea" typeName="double" displayLabel="Flow-Area (Start)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SectionalLinkResults_StartSection_FlowWidth" typeName="double" displayLabel="Flow-Width (Start)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SectionalLinkResults_MiddleSection_FlowArea" typeName="double" displayLabel="Flow-Area (Middle)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SectionalLinkResults_MiddleSection_FlowWidth" typeName="double" displayLabel="Flow-Width (Middle)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SectionalLinkResults_StopSection_FlowArea" typeName="double" displayLabel="Flow-Area (Stop)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SectionalLinkResults_StopSection_FlowWidth" typeName="double" displayLabel="Flow-Width (Stop)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSectionalLinkResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SectionalLinkResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardCatchbasinStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardCatchbasinStatistics_MaximumInletFlow" typeName="double" displayLabel="Flow (Surface Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_TimeToMaximumInletFlow" typeName="double" displayLabel="Time To Maximum Inlet Flow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_MaximumCapturedFlow" typeName="double" displayLabel="Flow (Captured Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_TimeToMaximumCapturedFlow" typeName="double" displayLabel="Time To Maximum Captured Flow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_MaximumGutterDepth" typeName="double" displayLabel="Gutter Depth (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_MaximumGutterSpread" typeName="double" displayLabel="Gutter Spread / Top Width (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_TimeToMaxGutterDepth" typeName="double" displayLabel="Time to Maximum Gutter Depth" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_TimeToMaxGutterSpread" typeName="double" displayLabel="Time to Maximum Gutter Spread / Top Width" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_MinimumCaptureEfficiency" typeName="double" displayLabel="Capture Efficiency (Calculated Minimum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="StandardCatchbasinStatistics_TimeToMinimumCaptureEfficiency" typeName="double" displayLabel="Time to Minimum Capture Efficiency" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardCatchbasinStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardCatchbasinStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardCatchmentResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardCatchmentResults_IncrementalPrecip" typeName="double" displayLabel="Precipitation (Incremental)" category="Results_Extended_Catchment_Drainage_Results_Extended_Catchment_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="StandardCatchmentResults_CumulativePrecip" typeName="double" displayLabel="Precipitation (Cumulative)" category="Results_Extended_Catchment_Drainage_Results_Extended_Catchment_Drainage" priority="0" kindOfQuantity="cifu:DEPTH"/>
+        <ECProperty propertyName="StandardCatchmentResults_CompositeTc" typeName="double" displayLabel="Time of Concentration (Composite)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardCatchmentResults_CompositeCn" typeName="double" displayLabel="SCS CN (Composite)" category="Runoff_Drainage_Runoff_Drainage" priority="0" kindOfQuantity="cifu:CURVE_NUMBER"/>
+        <ECProperty propertyName="StandardCatchmentResults_RunoffVolume" typeName="double" displayLabel="Volume (Total Runoff)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="StandardCatchmentResults_TotalSurfaceRunoff" typeName="double" displayLabel="Flow (Total Surface Runoff)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardCatchmentResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardCatchmentResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardConduitResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardConduitResults_RoadwayOvertoppingFlow" typeName="double" displayLabel="Flow (Roadway Overtopping)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardConduitResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardConduitResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardCxNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardCxNodeResults_FlowArea" typeName="double" displayLabel="Flow-Area" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="StandardCxNodeResults_FlowWidth" typeName="double" displayLabel="Flow-Width" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardCxNodeResults_FroudeNumber" typeName="double" displayLabel="Froude Number" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardCxNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardCxNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardInflowNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardInflowNodeResults_TotalOutflowResult" typeName="double" displayLabel="Flow (Outlet)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardInflowNodeResults_TotalInflowResult" typeName="double" displayLabel="Flow (Total In)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardInflowNodeResults_TotalOutflow" typeName="double" displayLabel="Flow (Total Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardInflowNodeResults_TotalPeakOutflow" typeName="double" displayLabel="Flow (Peak Total)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardInflowNodeResults_TotalTimetoPeak" typeName="double" displayLabel="Time to Peak (Total Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardInflowNodeResults_TotalVolume" typeName="double" displayLabel="Volume (Total Out)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardInflowNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardInflowNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardLinkDepthResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardLinkDepthResults_StandardLinkDepthRiseRatio" typeName="double" displayLabel="Depth/Rise" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardLinkDepthResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardLinkDepthResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardNodeResults_HydraulicGrade" typeName="double" displayLabel="#HydraulicGradeLineField" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardNodeStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardNodeStatistics_MaxCalcedInflow" typeName="double" displayLabel="Flow (Total In Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardNodeStatistics_MaximumOutflow" typeName="double" displayLabel="Flow (Out to Links Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="StandardNodeStatistics_TimeToMaxInflow" typeName="double" displayLabel="Time to Maximum Inflow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StandardNodeStatistics_TimeToMaxOutflow" typeName="double" displayLabel="Time to Maximum Outflow" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardNodeStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardNodeStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardStatistics_MaximumHGL" typeName="double" displayLabel="Hydraulic Grade (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="StandardStatistics_TimeToMaximumHGL" typeName="double" displayLabel="Time to Maximum Hydraulic Grade" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StandardStorageNodeStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StandardStorageNodeStatistics_MaximumStorage" typeName="double" displayLabel="Storage (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="StandardStorageNodeStatistics_TimeToMaximumStorage" typeName="double" displayLabel="Time to Maximum Storage" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStandardStorageNodeStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StandardStorageNodeStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StorageNodeResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StorageNodeResults_StorageNodeFreeboardHeight" typeName="double" displayLabel="Freeboard Height" category="Results_Extended_Node_Drainage_Results_Extended_Node_Drainage" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StorageNodeResults_StorageNodeFloodingDepth" typeName="double" displayLabel="Depth (Flooding)" category="Results_Extended_Node_Drainage_Results_Extended_Node_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStorageNodeResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StorageNodeResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StorageUnitStatsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StorageUnitStats_AverageVolume" typeName="double" displayLabel="Volume (Average)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:VOLUME"/>
+        <ECProperty propertyName="StorageUnitStats_AveragePercentFull" typeName="double" displayLabel="Percent Full (Average)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="StorageUnitStats_EvaporationLossFraction" typeName="double" displayLabel="Evaporation Loss" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="StorageUnitStats_MaximumPercentFull" typeName="double" displayLabel="Percent Full (Maximum)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="StorageUnitStats_ExfiltrationLossFraction" typeName="double" displayLabel="Exfiltration Loss" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStorageUnitStatsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StorageUnitStatsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StormEventResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StormEventResults_StartTime" typeName="double" displayLabel="Start Time" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StormEventResults_Increment" typeName="double" displayLabel="Increment" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StormEventResults_EndTime" typeName="double" displayLabel="End Time" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="StormEventResults_StormEventLabel" typeName="string" displayLabel="Label" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="StormEventResults_ReturnEvent" typeName="double" displayLabel="Return Event" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_LONG"/>
+        <ECProperty propertyName="StormEventDepthTypeResult" typeName="StormEventResultsAspect_StormEventDepthTypeResult_Enum" displayLabel="Storm Event Depth Type" category="Generic_Drainage_Generic_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStormEventResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StormEventResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SUDAInletResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SUDAInletResults_GutterCapacity" typeName="double" displayLabel="Capacity (Gutter)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SUDAInletResults_InletCapacity" typeName="double" displayLabel="Capacity (Inlet)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SUDAInletResults_DesignSpreadCapacity" typeName="double" displayLabel="Efficiency (At Design Spread)" category="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSUDAInletResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SUDAInletResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SurfaceInflowNodeResultAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SurfaceInflowNodeResult_TotalSurfaceInflow" typeName="double" displayLabel="Flow (Local Surface)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSurfaceInflowNodeResultAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SurfaceInflowNodeResultAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SwmmCatchmentResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SwmmCatchmentResults_SnowDepth" typeName="double" displayLabel="Depth (Snow)" category="SWMM_Results_Drainage_SWMM_Results_Drainage" priority="0" kindOfQuantity="cifu:DEPTH_LARGE"/>
+        <ECProperty propertyName="SwmmCatchmentResults_GroundwaterFlow" typeName="double" displayLabel="Flow (Groundwater)" category="SWMM_Results_Drainage_SWMM_Results_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SwmmCatchmentResults_GroundwaterElevation" typeName="double" displayLabel="Elevation (Groundwater)" category="SWMM_Results_Drainage_SWMM_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="SwmmCatchmentResults_RainfallIntensity" typeName="double" displayLabel="Intensity (Rainfall)" category="SWMM_Results_Drainage_SWMM_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="SwmmCatchmentResults_LossRate" typeName="double" displayLabel="Loss Rate" category="SWMM_Results_Drainage_SWMM_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+        <ECProperty propertyName="SwmmCatchmentResults_EvaporationRate" typeName="double" displayLabel="Evaporation Rate" category="SWMM_Results_Drainage_SWMM_Results_Drainage" priority="0" kindOfQuantity="cifu:INFILTRATION_RATE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSwmmCatchmentResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SwmmCatchmentResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SystemFlowResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SystemFlowResults_SystemAdditionalInfiltration" typeName="double" displayLabel="Infiltration (System Additional)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+        <ECProperty propertyName="SystemFlowResults_SystemAdjustedPopulation" typeName="double" displayLabel="Population (System Sanitary Adjusted)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:POPULATION"/>
+        <ECProperty propertyName="SystemFlowResults_SystemInfiltration" typeName="double" displayLabel="Infiltration (System Non-Additional)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+        <ECProperty propertyName="SystemFlowResults_SystemInflow" typeName="double" displayLabel="Flow (System Wet Weather Collection)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SystemFlowResults_SystemKnownFlow" typeName="double" displayLabel="Flow (System Known)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="SystemFlowResults_SystemPopulation" typeName="double" displayLabel="Population (System Sanitary)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:POPULATION"/>
+        <ECProperty propertyName="SystemFlowResults_SystemServiceArea" typeName="double" displayLabel="Area (System Sanitary Service)" category="Results_Flow_Drainage_Results_Flow_Drainage" priority="0" kindOfQuantity="cifu:AREA_LARGE"/>
+        <ECProperty propertyName="SystemFlowResults_SystemTotalInfiltration" typeName="double" displayLabel="Infiltration (System Total)" category="Results_Infiltration_Drainage_Results_Infiltration_Drainage" priority="0" kindOfQuantity="cifu:FLOW_SMALL"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSystemFlowResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SystemFlowResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TapNodeDerivedResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TapNodeDerivedResults_ConnectionElevation" typeName="double" displayLabel="Elevation (Connection)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTapNodeDerivedResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TapNodeDerivedResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="Tr55GraphicalPeakAndStorageResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_DrainageArea" typeName="double" displayLabel="Drainage Area" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_RunoffCurveNumber" typeName="double" displayLabel="Runoff Curve Number" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_TimeOfConcentration" typeName="double" displayLabel="Time of Concentration" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_PondAndSwampPercent" typeName="double" displayLabel="Pond and Swamp percent" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_PondAndSwampArea" typeName="double" displayLabel="Pond and Swamp Area" category="Category_Drainage_Category_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_PondAndSwampMessage" typeName="string" displayLabel="Tr55GraphicalPeakAndStorageResults_PondAndSwampMessage" category="Category_Drainage_Category_Drainage" priority="0"/>
+        <ECProperty propertyName="Tr55GraphicalPeakAndStorageResults_RainfallDistribution" typeName="string" displayLabel="Rainfall Distribution" category="Category_Drainage_Category_Drainage" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTr55GraphicalPeakAndStorageResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="Tr55GraphicalPeakAndStorageResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="UKCatchmentResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="UKCatchmentResults_ModifiedRationalUKC" typeName="double" displayLabel="Modified Rational (United Kingdom) C" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+        <ECProperty propertyName="UKCatchmentResults_ArealReductionFactor" typeName="double" displayLabel="Areal Reduction Factor" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:COEFFICIENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsUKCatchmentResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="UKCatchmentResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="UpstreamElementResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="UpstreamElementResults_UpstreamDrainageArea" typeName="double" displayLabel="System Drainage Area" category="Results_System_Flow_Drainage_Results_System_Flow_Drainage" priority="0" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsUpstreamElementResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="UpstreamElementResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="UpstreamVelocityHeadResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="UpstreamVelocityHeadResults_UpstreamVelocityHead" typeName="double" displayLabel="Velocity Head (In-Governing)" category="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsUpstreamVelocityHeadResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="UpstreamVelocityHeadResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VelocityStatisticsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="VelocityStatistics_MaxVelocity" typeName="double" displayLabel="Velocity (Maximum Calculated)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="VelocityStatistics_TimeToMaxVelocity" typeName="double" displayLabel="Time (Maximum Calculated Velocity)" category="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" priority="0" kindOfQuantity="cifu:TIME_EXTENDED"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVelocityStatisticsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VelocityStatisticsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WetWellResultsAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WetWellResults_IsAlarmTriggered" typeName="boolean" displayLabel="Is Alarm Triggered?" category="Results_Drainage_Results_Drainage" priority="0"/>
+        <ECProperty propertyName="WetWellResults_CalculatedPercentFull" typeName="double" displayLabel="Percent Full (Calculated)" category="Results_Drainage_Results_Drainage" priority="0" kindOfQuantity="cifu:PERCENT"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWetWellResultsAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WetWellResultsAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="Boundary_Condition_Drainage_Boundary_Condition_Drainage" description="Boundary Condition [Drainage]" displayLabel="Boundary Condition [Drainage]" priority="4294889026"/>
+    <PropertyCategory typeName="Boundary_Condition_Hydraulic_Analysis_Boundary_Condition_Hydraulic_Analysis" description="Boundary Condition [Hydraulic Analysis]" displayLabel="Boundary Condition [Hydraulic Analysis]" priority="4294889026"/>
+    <PropertyCategory typeName="Category_Drainage_Category_Drainage" description="Category [Drainage]" displayLabel="Category [Drainage]" priority="4294889436"/>
+    <PropertyCategory typeName="Category_Hydraulic_Analysis_Category_Hydraulic_Analysis" description="Category [Hydraulic Analysis]" displayLabel="Category [Hydraulic Analysis]" priority="4294889436"/>
+    <PropertyCategory typeName="Drainage_Drainage" description="# [Drainage]" displayLabel="# [Drainage]" priority="4294928186"/>
+    <PropertyCategory typeName="Generic_Drainage_Generic_Drainage" description="Generic [Drainage]" displayLabel="Generic [Drainage]" priority="4294885096"/>
+    <PropertyCategory typeName="Generic_Hydraulic_Analysis_Generic_Hydraulic_Analysis" description="Generic [Hydraulic Analysis]" displayLabel="Generic [Hydraulic Analysis]" priority="4294885096"/>
+    <PropertyCategory typeName="Geometry_Drainage_Geometry_Drainage" description="&lt;Geometry&gt; [Drainage]" displayLabel="&lt;Geometry&gt; [Drainage]" priority="4294899186"/>
+    <PropertyCategory typeName="Geometry_Hydraulic_Analysis_Geometry_Hydraulic_Analysis" description="&lt;Geometry&gt; [Hydraulic Analysis]" displayLabel="&lt;Geometry&gt; [Hydraulic Analysis]" priority="4294899186"/>
+    <PropertyCategory typeName="Hydraulic_Analysis_Hydraulic_Analysis" description="# [Hydraulic Analysis]" displayLabel="# [Hydraulic Analysis]" priority="4294928186"/>
+    <PropertyCategory typeName="ILSAX_Hydrologic_Model_Drainage_ILSAX_Hydrologic_Model_Drainage" description="ILSAX Hydrologic Model [Drainage]" displayLabel="ILSAX Hydrologic Model [Drainage]" priority="4294885866"/>
+    <PropertyCategory typeName="Land_Cover_Drainage_Land_Cover_Drainage" description="Land Cover [Drainage]" displayLabel="Land Cover [Drainage]" priority="4294880496"/>
+    <PropertyCategory typeName="Physical_Drainage_Physical_Drainage" description="Physical [Drainage]" displayLabel="Physical [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Headwall_Drainage_Physical_Headwall_Drainage" description="Physical (Headwall) [Drainage]" displayLabel="Physical (Headwall) [Drainage]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Headwall_Hydraulic_Analysis_Physical_Headwall_Hydraulic_Analysis" description="Physical (Headwall) [Hydraulic Analysis]" displayLabel="Physical (Headwall) [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Hydraulic_Analysis_Physical_Hydraulic_Analysis" description="Physical [Hydraulic Analysis]" displayLabel="Physical [Hydraulic Analysis]" priority="4294875686"/>
+    <PropertyCategory typeName="Results_AASHTO_Drainage_Results_AASHTO_Drainage" description="Results (AASHTO) [Drainage]" displayLabel="Results (AASHTO) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_AASHTO_Hydraulic_Analysis_Results_AASHTO_Hydraulic_Analysis" description="Results (AASHTO) [Hydraulic Analysis]" displayLabel="Results (AASHTO) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Carryover_Flow_Drainage_Results_Carryover_Flow_Drainage" description="Results (Carryover Flow) [Drainage]" displayLabel="Results (Carryover Flow) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Carryover_Flow_Hydraulic_Analysis_Results_Carryover_Flow_Hydraulic_Analysis" description="Results (Carryover Flow) [Hydraulic Analysis]" displayLabel="Results (Carryover Flow) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Catchment_Drainage_Results_Catchment_Drainage" description="Results (Catchment) [Drainage]" displayLabel="Results (Catchment) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Catchment_Hydraulic_Analysis_Results_Catchment_Hydraulic_Analysis" description="Results (Catchment) [Hydraulic Analysis]" displayLabel="Results (Catchment) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Connecting_Links_Drainage_Results_Connecting_Links_Drainage" description="Results (Connecting Links) [Drainage]" displayLabel="Results (Connecting Links) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Connecting_Links_Hydraulic_Analysis_Results_Connecting_Links_Hydraulic_Analysis" description="Results (Connecting Links) [Hydraulic Analysis]" displayLabel="Results (Connecting Links) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Drainage_Results_Drainage" description="Results [Drainage]" displayLabel="Results [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Cost_Peak_Drainage_Results_Energy_Cost_Peak_Drainage" description="Results (Energy Cost Peak) [Drainage]" displayLabel="Results (Energy Cost Peak) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Cost_Summary_Drainage_Results_Energy_Cost_Summary_Drainage" description="Results (Energy Cost Summary) [Drainage]" displayLabel="Results (Energy Cost Summary) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Drainage_Results_Energy_Costs_Drainage" description="Results (Energy Costs) [Drainage]" displayLabel="Results (Energy Costs) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Hydraulic_Analysis_Results_Energy_Costs_Hydraulic_Analysis" description="Results (Energy Costs) [Hydraulic Analysis]" displayLabel="Results (Energy Costs) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Peak_Drainage_Results_Energy_Costs_Peak_Drainage" description="Results (Energy Costs Peak) [Drainage]" displayLabel="Results (Energy Costs Peak) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Peak_Hydraulic_Analysis_Results_Energy_Costs_Peak_Hydraulic_Analysis" description="Results (Energy Costs Peak) [Hydraulic Analysis]" displayLabel="Results (Energy Costs Peak) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Summary_Drainage_Results_Energy_Costs_Summary_Drainage" description="Results (Energy Costs Summary) [Drainage]" displayLabel="Results (Energy Costs Summary) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Energy_Costs_Summary_Hydraulic_Analysis_Results_Energy_Costs_Summary_Hydraulic_Analysis" description="Results (Energy Costs Summary) [Hydraulic Analysis]" displayLabel="Results (Energy Costs Summary) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Engine_Parsing_Drainage_Results_Engine_Parsing_Drainage" description="Results (Engine Parsing) [Drainage]" displayLabel="Results (Engine Parsing) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Engine_Parsing_Hydraulic_Analysis_Results_Engine_Parsing_Hydraulic_Analysis" description="Results (Engine Parsing) [Hydraulic Analysis]" displayLabel="Results (Engine Parsing) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Extended_Catchment_Drainage_Results_Extended_Catchment_Drainage" description="Results (Extended Catchment) [Drainage]" displayLabel="Results (Extended Catchment) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Extended_Catchment_Hydraulic_Analysis_Results_Extended_Catchment_Hydraulic_Analysis" description="Results (Extended Catchment) [Hydraulic Analysis]" displayLabel="Results (Extended Catchment) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Extended_Node_Drainage_Results_Extended_Node_Drainage" description="Results (Extended Node) [Drainage]" displayLabel="Results (Extended Node) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Extended_Node_Hydraulic_Analysis_Results_Extended_Node_Hydraulic_Analysis" description="Results (Extended Node) [Hydraulic Analysis]" displayLabel="Results (Extended Node) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Flow_Classification_Drainage_Results_Flow_Classification_Drainage" description="Results (Flow Classification) [Drainage]" displayLabel="Results (Flow Classification) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Flow_Classification_Hydraulic_Analysis_Results_Flow_Classification_Hydraulic_Analysis" description="Results (Flow Classification) [Hydraulic Analysis]" displayLabel="Results (Flow Classification) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Flow_Drainage_Results_Flow_Drainage" description="Results (Flow) [Drainage]" displayLabel="Results (Flow) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Flow_Hydraulic_Analysis_Results_Flow_Hydraulic_Analysis" description="Results (Flow) [Hydraulic Analysis]" displayLabel="Results (Flow) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_H2S_Drainage_Results_H2S_Drainage" description="Results (H2S) [Drainage]" displayLabel="Results (H2S) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_H2S_Hydraulic_Analysis_Results_H2S_Hydraulic_Analysis" description="Results (H2S) [Hydraulic Analysis]" displayLabel="Results (H2S) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_HEC_22__Second_Edition_Drainage_Results_HEC_22__Second_Edition_Drainage" description="Results (HEC-22, Second Edition) [Drainage]" displayLabel="Results (HEC-22, Second Edition) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_HEC_22__Second_Edition_Hydraulic_Analysis_Results_HEC_22__Second_Edition_Hydraulic_Analysis" description="Results (HEC-22, Second Edition) [Hydraulic Analysis]" displayLabel="Results (HEC-22, Second Edition) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_HEC_22__Third_Edition_Drainage_Results_HEC_22__Third_Edition_Drainage" description="Results (HEC-22, Third Edition) [Drainage]" displayLabel="Results (HEC-22, Third Edition) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_HEC_22__Third_Edition_Hydraulic_Analysis_Results_HEC_22__Third_Edition_Hydraulic_Analysis" description="Results (HEC-22, Third Edition) [Hydraulic Analysis]" displayLabel="Results (HEC-22, Third Edition) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_HEC_22_Drainage_Results_HEC_22_Drainage" description="Results (HEC-22) [Drainage]" displayLabel="Results (HEC-22) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_HEC_22_Hydraulic_Analysis_Results_HEC_22_Hydraulic_Analysis" description="Results (HEC-22) [Hydraulic Analysis]" displayLabel="Results (HEC-22) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Hydraulic_Analysis_Results_Hydraulic_Analysis" description="Results [Hydraulic Analysis]" displayLabel="Results [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Hydraulic_Drainage_Results_Hydraulic_Drainage" description="Results (Hydraulic) [Drainage]" displayLabel="Results (Hydraulic) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Hydraulic_Hydraulic_Analysis_Results_Hydraulic_Hydraulic_Analysis" description="Results (Hydraulic) [Hydraulic Analysis]" displayLabel="Results (Hydraulic) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Hydraulic_Summary_Drainage_Results_Hydraulic_Summary_Drainage" description="Results (Hydraulic Summary) [Drainage]" displayLabel="Results (Hydraulic Summary) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Hydraulic_Summary_Hydraulic_Analysis_Results_Hydraulic_Summary_Hydraulic_Analysis" description="Results (Hydraulic Summary) [Hydraulic Analysis]" displayLabel="Results (Hydraulic Summary) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Infiltration_Drainage_Results_Infiltration_Drainage" description="Results (Infiltration) [Drainage]" displayLabel="Results (Infiltration) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Infiltration_Hydraulic_Analysis_Results_Infiltration_Hydraulic_Analysis" description="Results (Infiltration) [Hydraulic Analysis]" displayLabel="Results (Infiltration) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Inlet_Bypassed_Flows_Drainage_Results_Inlet_Bypassed_Flows_Drainage" description="Results (Inlet Bypassed Flows) [Drainage]" displayLabel="Results (Inlet Bypassed Flows) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Inlet_Bypassed_Flows_Hydraulic_Analysis_Results_Inlet_Bypassed_Flows_Hydraulic_Analysis" description="Results (Inlet Bypassed Flows) [Hydraulic Analysis]" displayLabel="Results (Inlet Bypassed Flows) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Inlet_Capture_Drainage_Results_Inlet_Capture_Drainage" description="Results (Inlet Capture) [Drainage]" displayLabel="Results (Inlet Capture) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Inlet_Capture_Hydraulic_Analysis_Results_Inlet_Capture_Hydraulic_Analysis" description="Results (Inlet Capture) [Hydraulic Analysis]" displayLabel="Results (Inlet Capture) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Inlet_Surface_Flows_Drainage_Results_Inlet_Surface_Flows_Drainage" description="Results (Inlet Surface Flows) [Drainage]" displayLabel="Results (Inlet Surface Flows) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Inlet_Surface_Flows_Hydraulic_Analysis_Results_Inlet_Surface_Flows_Hydraulic_Analysis" description="Results (Inlet Surface Flows) [Hydraulic Analysis]" displayLabel="Results (Inlet Surface Flows) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Intercepted_Flow_Drainage_Results_Intercepted_Flow_Drainage" description="Results (Intercepted Flow) [Drainage]" displayLabel="Results (Intercepted Flow) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Intercepted_Flow_Hydraulic_Analysis_Results_Intercepted_Flow_Hydraulic_Analysis" description="Results (Intercepted Flow) [Hydraulic Analysis]" displayLabel="Results (Intercepted Flow) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Interpolated_Drainage_Results_Interpolated_Drainage" description="Results (Interpolated) [Drainage]" displayLabel="Results (Interpolated) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Interpolated_Hydraulic_Analysis_Results_Interpolated_Hydraulic_Analysis" description="Results (Interpolated) [Hydraulic Analysis]" displayLabel="Results (Interpolated) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Local_Flows_Drainage_Results_Local_Flows_Drainage" description="Results (Local Flows) [Drainage]" displayLabel="Results (Local Flows) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Local_Flows_Hydraulic_Analysis_Results_Local_Flows_Hydraulic_Analysis" description="Results (Local Flows) [Hydraulic Analysis]" displayLabel="Results (Local Flows) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Lost_Flow_Drainage_Results_Lost_Flow_Drainage" description="Results (Lost Flow) [Drainage]" displayLabel="Results (Lost Flow) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Lost_Flow_Hydraulic_Analysis_Results_Lost_Flow_Hydraulic_Analysis" description="Results (Lost Flow) [Hydraulic Analysis]" displayLabel="Results (Lost Flow) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Maximum_Values_Drainage_Results_Maximum_Values_Drainage" description="Results (Maximum Values) [Drainage]" displayLabel="Results (Maximum Values) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Maximum_Values_Hydraulic_Analysis_Results_Maximum_Values_Hydraulic_Analysis" description="Results (Maximum Values) [Hydraulic Analysis]" displayLabel="Results (Maximum Values) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Misc_Drainage_Results_Misc_Drainage" description="Results (Misc) [Drainage]" displayLabel="Results (Misc) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Misc_Hydraulic_Analysis_Results_Misc_Hydraulic_Analysis" description="Results (Misc) [Hydraulic Analysis]" displayLabel="Results (Misc) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Operating_Status_Drainage_Results_Operating_Status_Drainage" description="Results (Operating Status) [Drainage]" displayLabel="Results (Operating Status) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Operating_Status_Hydraulic_Analysis_Results_Operating_Status_Hydraulic_Analysis" description="Results (Operating Status) [Hydraulic Analysis]" displayLabel="Results (Operating Status) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Profile_Drainage_Results_Profile_Drainage" description="Results (Profile) [Drainage]" displayLabel="Results (Profile) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Profile_Hydraulic_Analysis_Results_Profile_Hydraulic_Analysis" description="Results (Profile) [Hydraulic Analysis]" displayLabel="Results (Profile) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Profile_Summary_Drainage_Results_Profile_Summary_Drainage" description="Results (Profile Summary) [Drainage]" displayLabel="Results (Profile Summary) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Profile_Summary_Hydraulic_Analysis_Results_Profile_Summary_Hydraulic_Analysis" description="Results (Profile Summary) [Hydraulic Analysis]" displayLabel="Results (Profile Summary) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Pump_Definition_Summary_Drainage_Results_Pump_Definition_Summary_Drainage" description="Results (Pump Definition Summary) [Drainage]" displayLabel="Results (Pump Definition Summary) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Pump_Definition_Summary_Hydraulic_Analysis_Results_Pump_Definition_Summary_Hydraulic_Analysis" description="Results (Pump Definition Summary) [Hydraulic Analysis]" displayLabel="Results (Pump Definition Summary) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Sanitary_Loading_Drainage_Results_Sanitary_Loading_Drainage" description="Results (Sanitary Loading) [Drainage]" displayLabel="Results (Sanitary Loading) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Sanitary_Loading_Hydraulic_Analysis_Results_Sanitary_Loading_Hydraulic_Analysis" description="Results (Sanitary Loading) [Hydraulic Analysis]" displayLabel="Results (Sanitary Loading) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Statistics_Drainage_Results_Statistics_Drainage" description="Results (Statistics) [Drainage]" displayLabel="Results (Statistics) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Statistics_Hydraulic_Analysis_Results_Statistics_Hydraulic_Analysis" description="Results (Statistics) [Hydraulic Analysis]" displayLabel="Results (Statistics) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_System_Flow_Drainage_Results_System_Flow_Drainage" description="Results (System Flow) [Drainage]" displayLabel="Results (System Flow) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_System_Flow_Hydraulic_Analysis_Results_System_Flow_Hydraulic_Analysis" description="Results (System Flow) [Hydraulic Analysis]" displayLabel="Results (System Flow) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Tractive_Stress_Drainage_Results_Tractive_Stress_Drainage" description="Results (Tractive Stress) [Drainage]" displayLabel="Results (Tractive Stress) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Tractive_Stress_Hydraulic_Analysis_Results_Tractive_Stress_Hydraulic_Analysis" description="Results (Tractive Stress) [Hydraulic Analysis]" displayLabel="Results (Tractive Stress) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Upstream_Structure_Drainage_Results_Upstream_Structure_Drainage" description="Results (Upstream Structure) [Drainage]" displayLabel="Results (Upstream Structure) [Drainage]" priority="4294874046"/>
+    <PropertyCategory typeName="Results_Upstream_Structure_Hydraulic_Analysis_Results_Upstream_Structure_Hydraulic_Analysis" description="Results (Upstream Structure) [Hydraulic Analysis]" displayLabel="Results (Upstream Structure) [Hydraulic Analysis]" priority="4294874046"/>
+    <PropertyCategory typeName="Runoff_Drainage_Runoff_Drainage" description="Runoff [Drainage]" displayLabel="Runoff [Drainage]" priority="4294872496"/>
+    <PropertyCategory typeName="Runoff_Hydraulic_Analysis_Runoff_Hydraulic_Analysis" description="Runoff [Hydraulic Analysis]" displayLabel="Runoff [Hydraulic Analysis]" priority="4294872496"/>
+    <PropertyCategory typeName="SCADA_Drainage_SCADA_Drainage" description="SCADA [Drainage]" displayLabel="SCADA [Drainage]" priority="4294876946"/>
+    <PropertyCategory typeName="SCADA_Hydraulic_Analysis_SCADA_Hydraulic_Analysis" description="SCADA [Hydraulic Analysis]" displayLabel="SCADA [Hydraulic Analysis]" priority="4294876946"/>
+    <PropertyCategory typeName="SWMM_Results_Drainage_SWMM_Results_Drainage" description="SWMM Results [Drainage]" displayLabel="SWMM Results [Drainage]" priority="4294874826"/>
+    <PropertyCategory typeName="SWMM_Results_Hydraulic_Analysis_SWMM_Results_Hydraulic_Analysis" description="SWMM Results [Hydraulic Analysis]" displayLabel="SWMM Results [Hydraulic Analysis]" priority="4294874826"/>
+    <PropertyCategory typeName="TwoD_Solver_Drainage_2D_Solver_Drainage" description="2D Solver [Drainage]" displayLabel="2D Solver [Drainage]" priority="4294910176"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifRail.01.00.04.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifRail.01.00.04.ecschema.xml
@@ -1,0 +1,1082 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifRail" alias="cifrl" version="01.00.04" description="iModel Connector schema containing aspect classes with properties from OpenRail Designer." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.01" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="CantEntityAspect_CantEntity_RotateAbout_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inside_Rail" value="0" displayLabel="Inside Rail"/>
+        <ECEnumerator name="Center" value="1" displayLabel="Center"/>
+        <ECEnumerator name="Outside_Rail" value="2" displayLabel="Outside Rail"/>
+        <ECEnumerator name="Left_Rail" value="3" displayLabel="Left Rail"/>
+        <ECEnumerator name="Right_Rail" value="4" displayLabel="Right Rail"/>
+        <ECEnumerator name="Force_Positive" value="5" displayLabel="Force Positive"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossingRuleAspect_CrossingRule_Hand_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="ToThe_Left" value="-1" displayLabel="ToThe Left"/>
+        <ECEnumerator name="To_the_Right" value="1" displayLabel="To the Right"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossingRuleAspect_CrossingRule_Orientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Leading" value="1" displayLabel="Leading"/>
+        <ECEnumerator name="Trailing" value="-1" displayLabel="Trailing"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossingRuleAspect_CrossingRule_PlacementPoint_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="By_Point0" value="0" displayLabel="By Point0"/>
+        <ECEnumerator name="By_Point1" value="1" displayLabel="By Point1"/>
+        <ECEnumerator name="By_Point2" value="2" displayLabel="By Point2"/>
+        <ECEnumerator name="By_Point3" value="3" displayLabel="By Point3"/>
+        <ECEnumerator name="By_Point4" value="4" displayLabel="By Point4"/>
+        <ECEnumerator name="By_Point5" value="5" displayLabel="By Point5"/>
+        <ECEnumerator name="By_Second_Point0" value="6" displayLabel="By Second Point0"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossoverRuleAspect_CrossoverRule_Orientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Leading" value="1" displayLabel="Leading"/>
+        <ECEnumerator name="Trailing" value="-1" displayLabel="Trailing"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossoverRuleAspect_CrossoverRule_PlacementPoint_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="By_Point0" value="0" displayLabel="By Point0"/>
+        <ECEnumerator name="By_Point1" value="1" displayLabel="By Point1"/>
+        <ECEnumerator name="By_Point2" value="2" displayLabel="By Point2"/>
+        <ECEnumerator name="By_Point3" value="3" displayLabel="By Point3"/>
+        <ECEnumerator name="By_Point4" value="4" displayLabel="By Point4"/>
+        <ECEnumerator name="By_Point5" value="5" displayLabel="By Point5"/>
+        <ECEnumerator name="By_Second_Point0" value="6" displayLabel="By Second Point0"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CrossoverRuleAspect_CrossoverRule_SinglePlacementPoint_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="By_Point0" value="0" displayLabel="By Point0"/>
+        <ECEnumerator name="By_Point1" value="1" displayLabel="By Point1"/>
+        <ECEnumerator name="By_Point2" value="2" displayLabel="By Point2"/>
+        <ECEnumerator name="By_Point3" value="3" displayLabel="By Point3"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="DistanceKeeperComponentAspect_RemainderLengthOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="At_Start" value="0" displayLabel="At Start"/>
+        <ECEnumerator name="At_End" value="1" displayLabel="At End"/>
+        <ECEnumerator name="At_Both_Start_And_End" value="2" displayLabel="At Both Start And End"/>
+        <ECEnumerator name="EqualDistance" value="3" displayLabel="EqualDistance"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ProfileFromRailsRuleAspect_ProfileFromRailsRule_ElevationMethod_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inside_Rail" value="0" displayLabel="Inside Rail"/>
+        <ECEnumerator name="Outside_Rail" value="1" displayLabel="Outside Rail"/>
+        <ECEnumerator name="Center" value="2" displayLabel="Center"/>
+        <ECEnumerator name="Left_Rail" value="3" displayLabel="Left Rail"/>
+        <ECEnumerator name="Right_Rail" value="4" displayLabel="Right Rail"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RailKeyPointsComponentForJointAspect_ControllingRail_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inside_Rail" value="2" displayLabel="Inside Rail"/>
+        <ECEnumerator name="Outside_Rail" value="1" displayLabel="Outside Rail"/>
+        <ECEnumerator name="SingleRail" value="0" displayLabel="SingleRail"/>
+        <ECEnumerator name="Propagate_From_Opposite_Rail" value="3" displayLabel="Propagate From Opposite Rail"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RailKeyPointsComponentForJointAspect_Remainder_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="At_Start" value="0" displayLabel="At Start"/>
+        <ECEnumerator name="At_End" value="1" displayLabel="At End"/>
+        <ECEnumerator name="At_Both_Start_And_End" value="2" displayLabel="At Both Start And End"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RailOffsetRuleAspect_RailOffsetRule_CreateMesh_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RailTrackComponentAspect_RailTrackComponent_CreateMesh_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RegressionCurvatureRuleAspect_Multiplier_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="x_1_5" value="0" displayLabel="x 1.5"/>
+        <ECEnumerator name="x_3_0" value="1" displayLabel="x 3.0"/>
+        <ECEnumerator name="x_4_5" value="2" displayLabel="x 4.5"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RegressionCurvatureRuleAspect_RemoveOutliers_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="RegressionDetailsEntityAspect_RegressionDetailsEntity_Status_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Use_Point" value="0" displayLabel="Use Point"/>
+        <ECEnumerator name="Ignore_Point" value="1" displayLabel="Ignore Point"/>
+        <ECEnumerator name="Fixed_Point" value="2" displayLabel="Fixed Point"/>
+        <ECEnumerator name="Information_Point" value="3" displayLabel="Information Point"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TurnoutRuleAspect_TurnoutRule_Hand_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="ToThe_Left" value="-1" displayLabel="ToThe Left"/>
+        <ECEnumerator name="To_the_Right" value="1" displayLabel="To the Right"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TurnoutRuleAspect_TurnoutRule_Orientation_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Leading" value="1" displayLabel="Leading"/>
+        <ECEnumerator name="Trailing" value="-1" displayLabel="Trailing"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TurnoutRuleAspect_TurnoutRule_PlacementPoint_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="By_Point0" value="0" displayLabel="By Point0"/>
+        <ECEnumerator name="By_Point1" value="1" displayLabel="By Point1"/>
+        <ECEnumerator name="By_Point2" value="2" displayLabel="By Point2"/>
+        <ECEnumerator name="By_Point3" value="3" displayLabel="By Point3"/>
+        <ECEnumerator name="By_Point4" value="4" displayLabel="By Point4"/>
+        <ECEnumerator name="By_Point5" value="5" displayLabel="By Point5"/>
+        <ECEnumerator name="By_Second_Point0" value="6" displayLabel="By Second Point0"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TurnoutRuleAspect_TurnoutRule_SinglePlacementPoint_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="By_Point0" value="0" displayLabel="By Point0"/>
+        <ECEnumerator name="By_Point1" value="1" displayLabel="By Point1"/>
+        <ECEnumerator name="By_Point2" value="2" displayLabel="By Point2"/>
+        <ECEnumerator name="By_Point3" value="3" displayLabel="By Point3"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="VerticalRegressionCurvatureRuleAspect_Multiplier_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="x_1_5" value="0" displayLabel="x 1.5"/>
+        <ECEnumerator name="x_3_0" value="1" displayLabel="x 3.0"/>
+        <ECEnumerator name="x_4_5" value="2" displayLabel="x 4.5"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="VerticalRegressionCurvatureRuleAspect_RemoveOutliers_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="BaseRegressionPointsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="SlewExaggeration" typeName="double" displayLabel="Slew Exaggeration" category="HorizontalRegression_Horizontal_Regression" priority="299990"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseTurnoutBranchesObjectSettings">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchTheoreticalToActual" typeName="double" displayLabel="Theoretical To Actual" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchLengthAlongMainline" typeName="double" displayLabel="Length Along Mainline" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchLength0To2" typeName="double" displayLabel="Length 0 To 2" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchLength0To3" typeName="double" displayLabel="Length 0 To 3" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchRatioAt0" typeName="double" displayLabel="Ratio At 0" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299950"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchRatioAt1" typeName="double" displayLabel="Ratio At 1" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299940"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchDistanceLLSlpr" typeName="double" displayLabel="Distance Last Long Sleeper" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchLeadingLinear" typeName="boolean" displayLabel="Leading Linear" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299900"/>
+        <ECProperty propertyName="BaseTurnoutBranchesObjectSettings_BranchNumberOfElements" typeName="int" displayLabel="Number Of Elements" category="Miscellaneous_Base_Turnout_Branches_Feature" priority="299890"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseTurnoutElementsObjectSettings">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="BaseTurnoutElementsObjectSettings_ElementLength" typeName="double" displayLabel="Length" category="Miscellaneous_Base_Turnout_Elements_Feature" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutElementsObjectSettings_ElementEntranceRadius" typeName="double" displayLabel="Entrance Radius" category="Miscellaneous_Base_Turnout_Elements_Feature" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaseTurnoutElementsObjectSettings_ElementExitRadius" typeName="double" displayLabel="Exit Radius" category="Miscellaneous_Base_Turnout_Elements_Feature" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseVerticalRegressionPointsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="SlewExaggeration" typeName="double" displayLabel="Slew Exaggeration" category="VerticalRegression_Vertical_Regression" priority="299990"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BendingAxisTableEntryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="TableEntry_Bending_Axis_Table_Entry" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Correction" typeName="double" displayLabel="Correction" category="TableEntry_Bending_Axis_Table_Entry" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CantEntityAspect" displayLabel="Cant">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CantEntity_CenterToCenter" typeName="double" displayLabel="Rail Gauge (Center to Center)" category="Cant_Cant" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantEntity_AppliedConstant" typeName="double" displayLabel="Applied Constant" category="Cant_Cant" priority="299997"/>
+        <ECProperty propertyName="CantEntity_EquilibriumConstant" typeName="double" displayLabel="Equilibrium Constant" category="Cant_Cant" priority="299996"/>
+        <ECProperty propertyName="CantEntity_RotateAbout" typeName="CantEntityAspect_CantEntity_RotateAbout_Enum" displayLabel="Rotate About" category="Cant_Cant" priority="299994"/>
+        <ECProperty propertyName="CantEntity_SpeedScheme" typeName="string" displayLabel="Speed Scheme" category="Cant_Cant" priority="299998"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CantStationPointAspect" displayLabel="Cant Station Point">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CantStationPoint_TransitionType" typeName="string" displayLabel="Object Type" category="CantStationPoint_Cant_Station_Point" priority="299999"/>
+        <ECProperty propertyName="CantStationPoint_Station" typeName="double" displayLabel="Station" category="CantStationPoint_Cant_Station_Point" priority="299998" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CantStationPoint_DesignSpeed" typeName="double" displayLabel="Design Speed" category="CantStationPoint_Cant_Station_Point" priority="299997" kindOfQuantity="cifu:VELOCITY"/>
+        <ECProperty propertyName="CantStationPoint_Radius" typeName="double" displayLabel="Radius" category="CantStationPoint_Cant_Station_Point" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_Length" typeName="double" displayLabel="Length" category="CantStationPoint_Cant_Station_Point" priority="299995" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_EqilibriumCant" typeName="double" displayLabel="Equilibrium Cant" category="CantStationPoint_Cant_Station_Point" priority="299994" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_AppliedCant" typeName="double" displayLabel="Applied Cant" category="CantStationPoint_Cant_Station_Point" priority="299993" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_CantDeficiency" typeName="double" displayLabel="Cant Deficiency" category="CantStationPoint_Cant_Station_Point" priority="299992" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_LateralAcceleration" typeName="string" displayLabel="Non-compensating Lateral Acceleration" category="CantStationPoint_Cant_Station_Point" priority="299991"/>
+        <ECProperty propertyName="CantStationPoint_AppliedRateOfChange" typeName="string" displayLabel="Applied Rate of Change" category="CantStationPoint_Cant_Station_Point" priority="299990"/>
+        <ECProperty propertyName="CantStationPoint_DeficiencyRateOfChange" typeName="string" displayLabel="Deficiency Rate of Change" category="CantStationPoint_Cant_Station_Point" priority="299989"/>
+        <ECProperty propertyName="CantStationPoint_AppGrad" typeName="string" displayLabel="Applied Gradient" category="CantStationPoint_Cant_Station_Point" priority="299988"/>
+        <ECProperty propertyName="CantStationPoint_LeftRail" typeName="double" displayLabel="Left Rail" category="CantStationPoint_Cant_Station_Point" priority="299987" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_RightRail" typeName="double" displayLabel="Right Rail" category="CantStationPoint_Cant_Station_Point" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_Center" typeName="double" displayLabel="Center" category="CantStationPoint_Cant_Station_Point" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CantTableEntryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="TableEntry_Cant_Table_Entry" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Cant" typeName="double" displayLabel="Cant" category="TableEntry_Cant_Table_Entry" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CoachAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CoachAtStationRule_Station" typeName="double" displayLabel="Station" category="LocationProperties_Location" priority="299990" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CoachAtStationRule_TemplateName" typeName="string" displayLabel="Template Name" category="CoachProperties_Coach" priority="299980"/>
+        <ECProperty propertyName="CoachAtStationRule_BogieBase" typeName="double" displayLabel="Bogie Base" category="CoachProperties_Coach" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CoachAtStationRule_RearExtension" typeName="double" displayLabel="Rear Extension" category="CoachProperties_Coach" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CoachAtStationRule_FrontExtension" typeName="double" displayLabel="Front Extension" category="CoachProperties_Coach" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CoachAtStationRule_Height" typeName="double" displayLabel="Height" category="CoachProperties_Coach" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CoachAtStationRule_Width" typeName="double" displayLabel="Width" category="CoachProperties_Coach" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CoachAtStationRule_Elevation" typeName="double" displayLabel="Elevation" category="CoachProperties_Coach" priority="299920" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossingRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossingRule_Hand" typeName="CrossingRuleAspect_CrossingRule_Hand_Enum" displayLabel="Hand" category="CrossingProperties_Crossing" priority="299960"/>
+        <ECProperty propertyName="CrossingRule_Orientation" typeName="CrossingRuleAspect_CrossingRule_Orientation_Enum" displayLabel="Orientation" category="CrossingProperties_Crossing" priority="299950"/>
+        <ECProperty propertyName="CrossingRule_PlacementPoint" typeName="CrossingRuleAspect_CrossingRule_PlacementPoint_Enum" displayLabel="Placement Point" category="CrossingProperties_Crossing" priority="299940"/>
+        <ECProperty propertyName="CrossingRule_ToePointStation" typeName="double" displayLabel="Toe Point" category="CrossingProperties_Crossing" priority="299970" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_UseSleeperStub" typeName="boolean" displayLabel="Use LLS Extension" category="CrossingProperties_Crossing" priority="299930"/>
+        <ECProperty propertyName="CrossingRule_Branch1P0" typeName="point3d" displayLabel="Branch1 P0" category="CrossingPointsProperties_Crossing_Points" priority="299800"/>
+        <ECProperty propertyName="CrossingRule_Branch1P1" typeName="point3d" displayLabel="Branch1 P1" category="CrossingPointsProperties_Crossing_Points" priority="299790"/>
+        <ECProperty propertyName="CrossingRule_Branch1P2" typeName="point3d" displayLabel="Branch1 P2" category="CrossingPointsProperties_Crossing_Points" priority="299780"/>
+        <ECProperty propertyName="CrossingRule_Branch1P3" typeName="point3d" displayLabel="Branch1 P3" category="CrossingPointsProperties_Crossing_Points" priority="299770"/>
+        <ECProperty propertyName="CrossingRule_Branch1Nose" typeName="point3d" displayLabel="Branch1 Nose" category="CrossingPointsProperties_Crossing_Points" priority="299760"/>
+        <ECProperty propertyName="CrossingRule_Branch1Common" typeName="point3d" displayLabel="Branch1 Common" category="CrossingPointsProperties_Crossing_Points" priority="299750"/>
+        <ECProperty propertyName="CrossingRule_Branch1Obtuse" typeName="point3d" displayLabel="Branch1 Obtuse" category="CrossingPointsProperties_Crossing_Points" priority="299740"/>
+        <ECProperty propertyName="CrossingRule_Branch2P0" typeName="point3d" displayLabel="Branch2 P0" category="CrossingPointsProperties_Crossing_Points" priority="299730"/>
+        <ECProperty propertyName="CrossingRule_Branch2P1" typeName="point3d" displayLabel="Branch2 P1" category="CrossingPointsProperties_Crossing_Points" priority="299720"/>
+        <ECProperty propertyName="CrossingRule_Branch2P2" typeName="point3d" displayLabel="Branch2 P2" category="CrossingPointsProperties_Crossing_Points" priority="299710"/>
+        <ECProperty propertyName="CrossingRule_Branch2P3" typeName="point3d" displayLabel="Branch2 P3" category="CrossingPointsProperties_Crossing_Points" priority="299700"/>
+        <ECProperty propertyName="CrossingRule_Branch2Nose" typeName="point3d" displayLabel="Branch2 Nose" category="CrossingPointsProperties_Crossing_Points" priority="299690"/>
+        <ECProperty propertyName="CrossingRule_Branch2Common" typeName="point3d" displayLabel="Branch2 Common" category="CrossingPointsProperties_Crossing_Points" priority="299680"/>
+        <ECProperty propertyName="CrossingRule_Branch2Obtuse" typeName="point3d" displayLabel="Branch2 Obtuse" category="CrossingPointsProperties_Crossing_Points" priority="299670"/>
+        <ECProperty propertyName="CrossingRule_Branch1P0Station" typeName="double" displayLabel="Branch1 P0 Station" category="CrossingPointsProperties_Crossing_Points" priority="299400" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1P1Station" typeName="double" displayLabel="Branch1 P1 Station" category="CrossingPointsProperties_Crossing_Points" priority="299390" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1P2Station" typeName="double" displayLabel="Branch1 P2 Station" category="CrossingPointsProperties_Crossing_Points" priority="299380" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1P3Station" typeName="double" displayLabel="Branch1 P3 Station" category="CrossingPointsProperties_Crossing_Points" priority="299370" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1NoseStation" typeName="double" displayLabel="Branch1 Nose Station" category="CrossingPointsProperties_Crossing_Points" priority="299360" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1CommonStation" typeName="double" displayLabel="Branch1 Common Station" category="CrossingPointsProperties_Crossing_Points" priority="299350" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1ObtuseStation" typeName="double" displayLabel="Branch1 Obtuse Station" category="CrossingPointsProperties_Crossing_Points" priority="299340" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2P0Station" typeName="double" displayLabel="Branch2 P0 Station" category="CrossingPointsProperties_Crossing_Points" priority="299330" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2P1Station" typeName="double" displayLabel="Branch2 P1 Station" category="CrossingPointsProperties_Crossing_Points" priority="299320" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2P2Station" typeName="double" displayLabel="Branch2 P2 Station" category="CrossingPointsProperties_Crossing_Points" priority="299310" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2P3Station" typeName="double" displayLabel="Branch2 P3 Station" category="CrossingPointsProperties_Crossing_Points" priority="299300" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2NoseStation" typeName="double" displayLabel="Branch2 Nose Station" category="CrossingPointsProperties_Crossing_Points" priority="299290" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2CommonStation" typeName="double" displayLabel="Branch2 Common Station" category="CrossingPointsProperties_Crossing_Points" priority="299280" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2ObtuseStation" typeName="double" displayLabel="Branch2 Obtuse Station" category="CrossingPointsProperties_Crossing_Points" priority="299270" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch1LLS" typeName="point3d" displayLabel="Branch 1 LLS" category="CrossingPointsProperties_Crossing_Points" priority="299735"/>
+        <ECProperty propertyName="CrossingRule_Branch2LLS" typeName="point3d" displayLabel="Branch 2 LLS" category="CrossingPointsProperties_Crossing_Points" priority="299665"/>
+        <ECProperty propertyName="CrossingRule_Branch1LLSStation" typeName="double" displayLabel="Branch1 LLS Extension Station" category="CrossingPointsProperties_Crossing_Points" priority="299335" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossingRule_Branch2LLSStation" typeName="double" displayLabel="Branch2 LLS Extension Station" category="CrossingPointsProperties_Crossing_Points" priority="299265" kindOfQuantity="cifu:STATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CrossoverRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CrossoverRule_Orientation" typeName="CrossoverRuleAspect_CrossoverRule_Orientation_Enum" displayLabel="Orientation" category="CrossoverProperties_Crossover" priority="299950"/>
+        <ECProperty propertyName="CrossoverRule_PlacementPoint" typeName="CrossoverRuleAspect_CrossoverRule_PlacementPoint_Enum" displayLabel="Placement Point" category="CrossoverProperties_Crossover" priority="299940"/>
+        <ECProperty propertyName="CrossoverRule_SinglePlacementPoint" typeName="CrossoverRuleAspect_CrossoverRule_SinglePlacementPoint_Enum" displayLabel="Single Placement Point" category="CrossoverProperties_Crossover" priority="299930"/>
+        <ECProperty propertyName="CrossoverRule_ToePointStation" typeName="double" displayLabel="Toe Point" category="CrossoverProperties_Crossover" priority="299970" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_UseSleeperStub" typeName="boolean" displayLabel="Use LLS Extension" category="CrossoverProperties_Crossover" priority="299920"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P0" typeName="point3d" displayLabel="First Turnout Branch1 P0" category="CrossoverPointsProperties_Crossover_Points" priority="299800"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P1" typeName="point3d" displayLabel="First Turnout Branch1 P1" category="CrossoverPointsProperties_Crossover_Points" priority="299790"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P2" typeName="point3d" displayLabel="First Turnout Branch1 P2" category="CrossoverPointsProperties_Crossover_Points" priority="299780"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P3" typeName="point3d" displayLabel="First Turnout Branch1 P3" category="CrossoverPointsProperties_Crossover_Points" priority="299770"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1TheoreticalP1" typeName="point3d" displayLabel="First Turnout Branch1 Theoretical P1" category="CrossoverPointsProperties_Crossover_Points" priority="299760"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P0" typeName="point3d" displayLabel="Second Turnout Branch1 P0" category="CrossoverPointsProperties_Crossover_Points" priority="299750"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P1" typeName="point3d" displayLabel="Second Turnout Branch1 P1" category="CrossoverPointsProperties_Crossover_Points" priority="299740"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P2" typeName="point3d" displayLabel="Second Turnout Branch1 P2" category="CrossoverPointsProperties_Crossover_Points" priority="299730"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P3" typeName="point3d" displayLabel="Second Turnout Branch1 P3" category="CrossoverPointsProperties_Crossover_Points" priority="299720"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1TheoreticalP1" typeName="point3d" displayLabel="Second Turnout Branch1 Theoretical P1" category="CrossoverPointsProperties_Crossover_Points" priority="299710"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P0" typeName="point3d" displayLabel="First Turnout Branch2 P0" category="CrossoverPointsProperties_Crossover_Points" priority="299700"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P1" typeName="point3d" displayLabel="First Turnout Branch2 P1" category="CrossoverPointsProperties_Crossover_Points" priority="299690"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P2" typeName="point3d" displayLabel="First Turnout Branch2 P2" category="CrossoverPointsProperties_Crossover_Points" priority="299680"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P3" typeName="point3d" displayLabel="First Turnout Branch2 P3" category="CrossoverPointsProperties_Crossover_Points" priority="299670"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2TheoreticalP1" typeName="point3d" displayLabel="First Turnout Branch2 Theoretical P1" category="CrossoverPointsProperties_Crossover_Points" priority="299660"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P0" typeName="point3d" displayLabel="Second Turnout Branch2 P0" category="CrossoverPointsProperties_Crossover_Points" priority="299650"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P1" typeName="point3d" displayLabel="Second Turnout Branch2 P1" category="CrossoverPointsProperties_Crossover_Points" priority="299640"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P2" typeName="point3d" displayLabel="Second Turnout Branch2 P2" category="CrossoverPointsProperties_Crossover_Points" priority="299630"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P3" typeName="point3d" displayLabel="Second Turnout Branch2 P3" category="CrossoverPointsProperties_Crossover_Points" priority="299620"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2TheoreticalP1" typeName="point3d" displayLabel="Second Turnout Branch2 Theoretical P1" category="CrossoverPointsProperties_Crossover_Points" priority="299610"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P0Station" typeName="double" displayLabel="First Turnout Branch1 P0 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299400" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P1Station" typeName="double" displayLabel="First Turnout Branch1 P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299390" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P2Station" typeName="double" displayLabel="First Turnout Branch1 P2 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299380" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1P3Station" typeName="double" displayLabel="First Turnout Branch1 P3 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299370" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch1TheoreticalP1Station" typeName="double" displayLabel="First Turnout Branch1 Theoretical P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299360" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P0Station" typeName="double" displayLabel="Second Turnout Branch1 P0 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299350" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P1Station" typeName="double" displayLabel="Second Turnout Branch1 P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299340" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P2Station" typeName="double" displayLabel="Second Turnout Branch1 P2 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299330" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1P3Station" typeName="double" displayLabel="Second Turnout Branch1 P3 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299320" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch1TheoreticalP1Station" typeName="double" displayLabel="Second Turnout Branch1 Theoretical P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299310" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P0Station" typeName="double" displayLabel="First Turnout Branch2 P0 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299300" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P1Station" typeName="double" displayLabel="First Turnout Branch2 P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299290" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P2Station" typeName="double" displayLabel="First Turnout Branch2 P2 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299280" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2P3Station" typeName="double" displayLabel="First Turnout Branch2 P3 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299270" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout1Branch2TheoreticalP1Station" typeName="double" displayLabel="First Turnout Branch2 Theoretical P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299260" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P0Station" typeName="double" displayLabel="Second Turnout Branch2 P0 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299250" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P1Station" typeName="double" displayLabel="Second Turnout Branch2 P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299240" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P2Station" typeName="double" displayLabel="Second Turnout Branch2 P2 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299230" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2P3Station" typeName="double" displayLabel="Second Turnout Branch2 P3 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299220" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="CrossoverRule_Turnout2Branch2TheoreticalP1Station" typeName="double" displayLabel="Second Turnout Branch2 Theoretical P1 Station" category="CrossoverPointsProperties_Crossover_Points" priority="299210" kindOfQuantity="cifu:STATION"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DistanceKeeperComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="DistanceKeepersProperties_Distance_Keepers" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="DistanceKeepersProperties_Distance_Keepers" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="IntervalDistance" typeName="double" displayLabel="Interval Distance" category="DistanceKeepersProperties_Distance_Keepers" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MinDistanceBetweenKeeper" typeName="double" displayLabel="Minimum Distance Between Keepers" category="DistanceKeepersProperties_Distance_Keepers" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxDistanceBetweenKeeper" typeName="double" displayLabel="Maximum Distance Between Keepers" category="DistanceKeepersProperties_Distance_Keepers" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DistFromStartPoint" typeName="double" displayLabel="Distance From Start Point" category="DistanceKeepersProperties_Distance_Keepers" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DistFromEndPoint" typeName="double" displayLabel="Distance From End Point" category="DistanceKeepersProperties_Distance_Keepers" priority="299920" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RemainderLengthOption" typeName="double" displayLabel="Remainder Length Option [Deprecated]" category="DistanceKeepersProperties_Distance_Keepers" priority="299960" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Use 'RemainderLengthOptionValue' instead</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="RemainderLengthOptionValue" typeName="DistanceKeeperComponentAspect_RemainderLengthOption_Enum" displayLabel="Remainder Length Option" category="DistanceKeepersProperties_Distance_Keepers" priority="299960"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseRegressionPointsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseRegressionPointsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseTurnoutBranchesObjectSettings" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseTurnoutBranchesObjectSettings"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseTurnoutElementsObjectSettings" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseTurnoutElementsObjectSettings"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseVerticalRegressionPointsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseVerticalRegressionPointsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBendingAxisTableEntryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BendingAxisTableEntryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCantEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CantEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCantStationPointAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CantStationPointAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCantTableEntryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CantTableEntryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCoachAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CoachAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossingRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossingRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCrossoverRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CrossoverRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDistanceKeeperComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DistanceKeeperComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PathwayAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Name_General_Category" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPathwayAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PathwayAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PathwayEdgeAssetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DistanceAlongEdge" typeName="double" displayLabel="Distance Along Edge" category="Position_Position_On_Edge" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="OffsetToEdge" typeName="double" displayLabel="Offset To Edge" category="Position_Position_On_Edge" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="OrientationAngle" typeName="double" displayLabel="Orientation Angle" category="Position_Position_On_Edge" priority="299997" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPathwayEdgeAssetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PathwayEdgeAssetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PathwayRouteAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Direction" typeName="int" displayLabel="Direction" category="Name_Pathway_Route" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPathwayRouteAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PathwayRouteAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PointControlExtensionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Cant" typeName="string" displayLabel="Cant" category="CantPoints_Cant_Points" priority="299977"/>
+        <ECProperty propertyName="CenterCantPoint" typeName="string" displayLabel="Center Cant Point" category="CantPoints_Cant_Points" priority="299976"/>
+        <ECProperty propertyName="LeftCantPoint" typeName="string" displayLabel="Left Cant Point" category="CantPoints_Cant_Points" priority="299975"/>
+        <ECProperty propertyName="RightCantPoint" typeName="string" displayLabel="Right Cant Point" category="CantPoints_Cant_Points" priority="299974"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPointControlExtensionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PointControlExtensionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileFromRailsRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="ProfileFromRailsRule_ElevationMethod" typeName="ProfileFromRailsRuleAspect_ProfileFromRailsRule_ElevationMethod_Enum" displayLabel="Elevation Method" category="CenterlineProfile_Track_Centerline_Profile" priority="299990"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileFromRailsRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileFromRailsRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProjectedSweptCoachRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ProjectedSweptCoachRule_StartStation" typeName="double" displayLabel="Start Distance" category="SweepPathProperties_Swept_Path" priority="299990" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_EndStation" typeName="double" displayLabel="End Distance" category="SweepPathProperties_Swept_Path" priority="299980" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_CoachSampling" typeName="double" displayLabel="Coach Sampling" category="SweepPathProperties_Swept_Path" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_SectionSampling" typeName="double" displayLabel="Section Sampling" category="SweepPathProperties_Swept_Path" priority="299890" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_TemplateName" typeName="string" displayLabel="Template Name" category="CoachProperties_Coach" priority="299970"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_BogieBase" typeName="double" displayLabel="Bogie Base" category="CoachProperties_Coach" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_RearExtension" typeName="double" displayLabel="Rear Extension" category="CoachProperties_Coach" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ProjectedSweptCoachRule_FrontExtension" typeName="double" displayLabel="Front Extension" category="CoachProperties_Coach" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProjectedSweptCoachRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProjectedSweptCoachRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailJointAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="Joint_Joint" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="Joint_Joint" priority="299920" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="Offset" category="Joint_Joint" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Rail" typeName="double" displayLabel="Rail" category="Joint_Joint" priority="299910" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ConstrainedPoint" typeName="boolean" displayLabel="Constrained Position" category="Joint_Joint" priority="299900"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailJointAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailJointAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailKeyPointsComponentForJointAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MinRailLength" typeName="double" displayLabel="Min Rail Length" category="JointGroup_Joint_Group" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="MaxRailLength" typeName="double" displayLabel="Max Rail Length" category="JointGroup_Joint_Group" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ControllingRail" typeName="RailKeyPointsComponentForJointAspect_ControllingRail_Enum" displayLabel="Controlling Rail" category="JointGroup_Joint_Group" priority="299970"/>
+        <ECProperty propertyName="Remainder" typeName="RailKeyPointsComponentForJointAspect_Remainder_Enum" displayLabel="Remainder Placement" category="JointGroup_Joint_Group" priority="299960"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailKeyPointsComponentForJointAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailKeyPointsComponentForJointAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RailOffsetRule_StartDistance" typeName="double" displayLabel="Start Distance" category="RailProperties_Rail" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailOffsetRule_EndDistance" typeName="double" displayLabel="End Distance" category="RailProperties_Rail" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailOffsetRule_MaximumRailLength" typeName="double" displayLabel="Maximum Rail Length" category="RailProperties_Rail" priority="299985" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailOffsetRule_Offset" typeName="double" displayLabel="Offset" category="RailProperties_Rail" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailOffsetRule_AxisToEdge" typeName="double" displayLabel="Axis to Edge" category="RailProperties_Rail" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailOffsetRule_CreateMesh" typeName="RailOffsetRuleAspect_RailOffsetRule_CreateMesh_BoolEnum" displayLabel="Create Rail Mesh" category="RailProperties_Rail" priority="299950"/>
+        <ECProperty propertyName="RailOffsetRule_TemplateName" typeName="string" displayLabel="Template Name" category="RailProperties_Rail" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailTrackComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RailTrackComponent_StartDistance" typeName="double" displayLabel="Start Distance" category="RailProperties_Rail" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailTrackComponent_EndDistance" typeName="double" displayLabel="End Distance" category="RailProperties_Rail" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RailTrackComponent_CreateMesh" typeName="RailTrackComponentAspect_RailTrackComponent_CreateMesh_BoolEnum" displayLabel="Create Rail Mesh" category="RailProperties_Rail" priority="299970"/>
+        <ECProperty propertyName="RailTrackComponent_TemplateName" typeName="string" displayLabel="Template Name" category="RailProperties_Rail" priority="0"/>
+        <ECProperty propertyName="RailTrackComponent_StrokingTolerance" typeName="double" displayLabel="Stroking Tolerance" category="RailProperties_Rail" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailTrackComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailTrackComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailwayEdgeAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Name_Railway_Edge" priority="299999"/>
+        <ECProperty propertyName="StartDistanceAlong" typeName="double" displayLabel="Distance Along Railway" category="Name_Railway_Edge" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="Name_Railway_Edge" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailwayEdgeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailwayEdgeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailwayEdgeSegmentClass">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="SegmentName" typeName="string" displayLabel="Name" category="Miscellaneous_RailwayEdgeSegmentClass" priority="0"/>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Distance Along Edge" category="Miscellaneous_RailwayEdgeSegmentClass" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="Miscellaneous_RailwayEdgeSegmentClass" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailwayEdgeSegmentClass" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailwayEdgeSegmentClass"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RailwayNodeAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Railway Node" category="Name_Railway_Node" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRailwayNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RailwayNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RegressionCurvatureRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="RemoveOutliers" typeName="RegressionCurvatureRuleAspect_RemoveOutliers_BoolEnum" displayLabel="Remove Outliers" category="HorizontalRegression_Horizontal_Regression" priority="299990"/>
+        <ECProperty propertyName="Multiplier" typeName="RegressionCurvatureRuleAspect_Multiplier_Enum" displayLabel="Standard Deviation Multiplier" category="HorizontalRegression_Horizontal_Regression" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRegressionCurvatureRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RegressionCurvatureRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="RegressionDetailsEntityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="RegressionDetailsEntity_Slew" typeName="double" displayLabel="Slew" category="RegressionPoint_Regression_Point" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RegressionDetailsEntity_Weight" typeName="double" displayLabel="Weight" category="RegressionPoint_Regression_Point" priority="299980"/>
+        <ECProperty propertyName="RegressionDetailsEntity_Status" typeName="RegressionDetailsEntityAspect_RegressionDetailsEntity_Status_Enum" displayLabel="Status" category="RegressionPoint_Regression_Point" priority="299970"/>
+        <ECProperty propertyName="RegressionDetailsEntity_Offset" typeName="double" displayLabel="Offset" category="RegressionPoint_Regression_Point" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsRegressionDetailsEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="RegressionDetailsEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SchemaElemOnPathwayEdgeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="RefDistanceAlongEdge" typeName="double" displayLabel="Distance Along Referenced Edge" category="SchemaElementAttributes_General_Category" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="VisDistanceAlongEdge" typeName="double" displayLabel="Distance Along Edge" category="SchemaElementAttributes_General_Category" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSchemaElemOnPathwayEdgeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SchemaElemOnPathwayEdgeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SchemaPathwayEdgeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartPoint" typeName="point3d" displayLabel="Start Point" category="SchemaLineAttributes_General_Category" priority="299999"/>
+        <ECProperty propertyName="EndPoint" typeName="point3d" displayLabel="End Point" category="SchemaLineAttributes_General_Category" priority="299998"/>
+        <ECProperty propertyName="RefLength" typeName="double" displayLabel="Referenced Entity Length" category="SchemaLineAttributes_General_Category" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ScaleRatio" typeName="double" displayLabel="Scale Ratio" category="SchemaLineAttributes_General_Category" priority="299996" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSchemaPathwayEdgeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SchemaPathwayEdgeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SchemaPathwayNodeRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CenterPoint" typeName="point3d" displayLabel="Center" category="CenterPoint_General_Category" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSchemaPathwayNodeRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SchemaPathwayNodeRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SingleElementFromCurvatureRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="MaximumOffset" typeName="double" displayLabel="Maximum Slew" category="HorizontalRegression_Horizontal_Regression" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardError" typeName="double" displayLabel="Standard Error" category="HorizontalRegression_Horizontal_Regression" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSingleElementFromCurvatureRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SingleElementFromCurvatureRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SingleElementHorizontalRegressionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="MaximumOffset" typeName="double" displayLabel="Maximum Slew" category="HorizontalRegression_Horizontal_Regression" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardError" typeName="double" displayLabel="Standard Error" category="HorizontalRegression_Horizontal_Regression" priority="299980"/>
+        <ECProperty propertyName="FirstPoint" typeName="point3d" displayLabel="First Point" category="HorizontalRegression_Horizontal_Regression" priority="299970"/>
+        <ECProperty propertyName="SecondPoint" typeName="point3d" displayLabel="Second Point" category="HorizontalRegression_Horizontal_Regression" priority="299960"/>
+        <ECProperty propertyName="LastPoint" typeName="point3d" displayLabel="Last Point" category="HorizontalRegression_Horizontal_Regression" priority="299950"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSingleElementHorizontalRegressionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SingleElementHorizontalRegressionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SingleElementSectionFromCurvatureRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="MaximumOffset" typeName="double" displayLabel="Maximum Slew" category="HorizontalRegression_Horizontal_Regression" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardError" typeName="double" displayLabel="Standard Error" category="HorizontalRegression_Horizontal_Regression" priority="299980"/>
+        <ECProperty propertyName="FirstPoint" typeName="point3d" displayLabel="First Point" category="HorizontalRegression_Horizontal_Regression" priority="299970"/>
+        <ECProperty propertyName="SecondPoint" typeName="point3d" displayLabel="Second Point" category="HorizontalRegression_Horizontal_Regression" priority="299960"/>
+        <ECProperty propertyName="LastPoint" typeName="point3d" displayLabel="Last Point" category="HorizontalRegression_Horizontal_Regression" priority="299950"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSingleElementSectionFromCurvatureRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SingleElementSectionFromCurvatureRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SingleElementVerticalRegressionRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="MaximumOffset" typeName="double" displayLabel="Maximum Slew" category="VerticalRegression_Vertical_Regression" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardError" typeName="double" displayLabel="Standard Error" category="VerticalRegression_Vertical_Regression" priority="299980"/>
+        <ECProperty propertyName="FirstPoint" typeName="point3d" displayLabel="First Point" category="VerticalRegression_Vertical_Regression" priority="299970"/>
+        <ECProperty propertyName="SecondPoint" typeName="point3d" displayLabel="Second Point" category="VerticalRegression_Vertical_Regression" priority="299960"/>
+        <ECProperty propertyName="LastPoint" typeName="point3d" displayLabel="Last Point" category="VerticalRegression_Vertical_Regression" priority="299950"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSingleElementVerticalRegressionRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SingleElementVerticalRegressionRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SingleProfileFromCurvatureRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="MaximumOffset" typeName="double" displayLabel="Maximum Slew" category="VerticalRegression_Vertical_Regression" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="StandardError" typeName="double" displayLabel="Standard Error" category="VerticalRegression_Vertical_Regression" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSingleProfileFromCurvatureRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SingleProfileFromCurvatureRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SleeperComponentAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="RailProperties_Rail" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="RailProperties_Rail" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperLength" typeName="double" displayLabel="Sleeper Length" category="RailProperties_Rail" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperWidth" typeName="double" displayLabel="Sleeper Width" category="RailProperties_Rail" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperThickness" typeName="double" displayLabel="Sleeper Thickness" category="RailProperties_Rail" priority="299955" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSpacing" typeName="double" displayLabel="Sleeper Spacing" category="RailProperties_Rail" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="RailProperties_Rail" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperCount" typeName="int" displayLabel="Sleeper Count" category="RailProperties_Rail" priority="299930"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSleeperComponentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SleeperComponentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SleepersStub">
+        <BaseClass>BaseTurnoutElementsObjectSettings</BaseClass>
+        <ECProperty propertyName="BaseTurnoutElementsObjectSettings_SleepersStub_Fixed" typeName="boolean" displayLabel="Fixed" category="Miscellaneous_LLS_Extension" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSleepersStub" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SleepersStub"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SweptCoachAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SweptCoachRule_StartStation" typeName="double" displayLabel="Start Distance" category="SweepPathProperties_Swept_Path" priority="299990" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="SweptCoachRule_EndStation" typeName="double" displayLabel="End Distance" category="SweepPathProperties_Swept_Path" priority="299980" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="SweptCoachRule_CoachSampling" typeName="double" displayLabel="Coach Sampling" category="SweepPathProperties_Swept_Path" priority="299900" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_SectionSampling" typeName="double" displayLabel="Section Sampling" category="SweepPathProperties_Swept_Path" priority="299890" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_TemplateName" typeName="string" displayLabel="Template Name" category="CoachProperties_Coach" priority="299970"/>
+        <ECProperty propertyName="SweptCoachRule_BogieBase" typeName="double" displayLabel="Bogie Base" category="CoachProperties_Coach" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_RearExtension" typeName="double" displayLabel="Rear Extension" category="CoachProperties_Coach" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_FrontExtension" typeName="double" displayLabel="Front Extension" category="CoachProperties_Coach" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_Height" typeName="double" displayLabel="Height" category="CoachProperties_Coach" priority="299930" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_Width" typeName="double" displayLabel="Width" category="CoachProperties_Coach" priority="299920" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SweptCoachRule_Elevation" typeName="double" displayLabel="Elevation" category="CoachProperties_Coach" priority="299910" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSweptCoachAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SweptCoachAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TrackSleeperRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>TrackSleeperRuleAspect is no longer in use. Use SleeperComponentAspect instead.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Distance" category="RailProperties_Rail" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="EndDistance" typeName="double" displayLabel="End Distance" category="RailProperties_Rail" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperLength" typeName="double" displayLabel="Sleeper Length" category="RailProperties_Rail" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperWidth" typeName="double" displayLabel="Sleeper Width" category="RailProperties_Rail" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperThickness" typeName="double" displayLabel="Sleeper Thickness" category="RailProperties_Rail" priority="299955" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSpacing" typeName="double" displayLabel="Sleeper Spacing" category="RailProperties_Rail" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="RailProperties_Rail" priority="299940" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTrackSleeperRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TrackSleeperRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TrackWideningTableEntryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="TableEntry_Track_Widening_Table_Entry" priority="299999" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="InnerWidening" typeName="double" displayLabel="Inner Widening" category="TableEntry_Track_Widening_Table_Entry" priority="299998" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="OuterWidening" typeName="double" displayLabel="Outer Widening" category="TableEntry_Track_Widening_Table_Entry" priority="299997" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTrackWideningTableEntryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TrackWideningTableEntryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TurnoutGeometryItemPropertyProviderAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TurnoutGeometryItemPropertyProvider_StartPoint" typeName="point3d" displayLabel="Start Point" category="TurnoutGeometryProperties_Geometry" priority="299990"/>
+        <ECProperty propertyName="TurnoutGeometryItemPropertyProvider_EndPoint" typeName="point3d" displayLabel="End Point" category="TurnoutGeometryProperties_Geometry" priority="299980"/>
+        <ECProperty propertyName="TurnoutGeometryItemPropertyProvider_Length" typeName="double" displayLabel="Length" category="TurnoutGeometryProperties_Geometry" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="TurnoutGeometryItemPropertyProvider_Direction" typeName="double" displayLabel="Direction" category="TurnoutGeometryProperties_Geometry" priority="299960"/>
+        <ECProperty propertyName="TurnoutGeometryItemPropertyProvider_Radius" typeName="double" displayLabel="Radius" category="TurnoutGeometryProperties_Geometry" priority="299950" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTurnoutGeometryItemPropertyProviderAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TurnoutGeometryItemPropertyProviderAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TurnoutRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="TurnoutRule_Hand" typeName="TurnoutRuleAspect_TurnoutRule_Hand_Enum" displayLabel="Hand" category="TurnoutProperties_Turnout" priority="299960"/>
+        <ECProperty propertyName="TurnoutRule_Orientation" typeName="TurnoutRuleAspect_TurnoutRule_Orientation_Enum" displayLabel="Orientation" category="TurnoutProperties_Turnout" priority="299950"/>
+        <ECProperty propertyName="TurnoutRule_PlacementPoint" typeName="TurnoutRuleAspect_TurnoutRule_PlacementPoint_Enum" displayLabel="Placement Point" category="TurnoutProperties_Turnout" priority="299940"/>
+        <ECProperty propertyName="TurnoutRule_SinglePlacementPoint" typeName="TurnoutRuleAspect_TurnoutRule_SinglePlacementPoint_Enum" displayLabel="Single Placement Point" category="TurnoutProperties_Turnout" priority="299930"/>
+        <ECProperty propertyName="TurnoutRule_ToePointStation" typeName="double" displayLabel="Toe Point" category="TurnoutProperties_Turnout" priority="299970" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_UseSleeperStub" typeName="boolean" displayLabel="Use LLS Extension" category="TurnoutProperties_Turnout" priority="299920"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P0" typeName="point3d" displayLabel="Branch1 P0" category="TurnoutPointsProperties_Turnout_Points" priority="299800"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P1" typeName="point3d" displayLabel="Branch1 P1" category="TurnoutPointsProperties_Turnout_Points" priority="299790"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P2" typeName="point3d" displayLabel="Branch1 P2" category="TurnoutPointsProperties_Turnout_Points" priority="299780"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P3" typeName="point3d" displayLabel="Branch1 P3" category="TurnoutPointsProperties_Turnout_Points" priority="299770"/>
+        <ECProperty propertyName="TurnoutRule_Branch1TheoreticalP1" typeName="point3d" displayLabel="Branch1 Theoretical P1" category="TurnoutPointsProperties_Turnout_Points" priority="299760"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P0" typeName="point3d" displayLabel="Branch2 P0" category="TurnoutPointsProperties_Turnout_Points" priority="299750"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P1" typeName="point3d" displayLabel="Branch2 P1" category="TurnoutPointsProperties_Turnout_Points" priority="299740"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P2" typeName="point3d" displayLabel="Branch2 P2" category="TurnoutPointsProperties_Turnout_Points" priority="299730"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P3" typeName="point3d" displayLabel="Branch2 P3" category="TurnoutPointsProperties_Turnout_Points" priority="299720"/>
+        <ECProperty propertyName="TurnoutRule_Branch2TheoreticalP1" typeName="point3d" displayLabel="Branch2 Theoretical P1" category="TurnoutPointsProperties_Turnout_Points" priority="299710"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P0Station" typeName="double" displayLabel="Branch1 P0 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299400" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P1Station" typeName="double" displayLabel="Branch1 P1 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299390" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P2Station" typeName="double" displayLabel="Branch1 P2 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299380" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch1P3Station" typeName="double" displayLabel="Branch1 P3 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299370" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch1TheoreticalP1Station" typeName="double" displayLabel="Branch1 Theoretical P1 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299360" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P0Station" typeName="double" displayLabel="Branch2 P0 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299350" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P1Station" typeName="double" displayLabel="Branch2 P1 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299340" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P2Station" typeName="double" displayLabel="Branch2 P2 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299330" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch2P3Station" typeName="double" displayLabel="Branch2 P3 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299320" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch2TheoreticalP1Station" typeName="double" displayLabel="Branch2 Theoretical P1 Station" category="TurnoutPointsProperties_Turnout_Points" priority="299310" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch1LLS" typeName="point3d" displayLabel="Branch 1 LLS" category="TurnoutPointsProperties_Turnout_Points" priority="299755"/>
+        <ECProperty propertyName="TurnoutRule_Branch2LLS" typeName="point3d" displayLabel="Branch 2 LLS" category="TurnoutPointsProperties_Turnout_Points" priority="299705"/>
+        <ECProperty propertyName="TurnoutRule_Branch1LLSStation" typeName="double" displayLabel="Branch1 LLS Extension Station" category="TurnoutPointsProperties_Turnout_Points" priority="299359" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="TurnoutRule_Branch2LLSStation" typeName="double" displayLabel="Branch2 LLS Extension Station" category="TurnoutPointsProperties_Turnout_Points" priority="299309" kindOfQuantity="cifu:STATION"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTurnoutRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TurnoutRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TurnoutSleeperRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>TurnoutSleeperRuleAspect is no longer in use. Use SleeperComponentAspect instead.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="SleeperLength" typeName="double" displayLabel="Sleeper Length" category="RailProperties_Rail" priority="299990" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperWidth" typeName="double" displayLabel="Sleeper Width" category="RailProperties_Rail" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperThickness" typeName="double" displayLabel="Sleeper Thickness" category="RailProperties_Rail" priority="299965" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SleeperSpacing" typeName="double" displayLabel="Sleeper Spacing" category="RailProperties_Rail" priority="299970" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="RailProperties_Rail" priority="299960" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTurnoutSleeperRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TurnoutSleeperRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="VerticalRegressionCurvatureRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>This aspect has been deprecated.</Description>
+            </Deprecated>
+            <HiddenClass xmlns="CoreCustomAttributes.01.00.03"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="RemoveOutliers" typeName="VerticalRegressionCurvatureRuleAspect_RemoveOutliers_BoolEnum" displayLabel="Remove Outliers" category="VerticalRegression_Vertical_Regression" priority="299990"/>
+        <ECProperty propertyName="Multiplier" typeName="VerticalRegressionCurvatureRuleAspect_Multiplier_Enum" displayLabel="Standard Deviation Multiplier" category="VerticalRegression_Vertical_Regression" priority="299980"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsVerticalRegressionCurvatureRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VerticalRegressionCurvatureRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="Cant_Cant" description="Cant" displayLabel="Cant" priority="199800"/>
+    <PropertyCategory typeName="CantPoints_Cant_Points" description="CantPoints" displayLabel="Cant Points" priority="199700"/>
+    <PropertyCategory typeName="CantStationPoint_Cant_Station_Point" description="CantStationPoint" displayLabel="Cant Station Point" priority="199800"/>
+    <PropertyCategory typeName="CenterlineProfile_Track_Centerline_Profile" description="CenterlineProfile" displayLabel="Track Centerline Profile" priority="4294967286"/>
+    <PropertyCategory typeName="CenterPoint_General_Category" description="CenterPoint" displayLabel="General Category" priority="200000"/>
+    <PropertyCategory typeName="CoachProperties_Coach" description="CoachProperties" displayLabel="Coach" priority="4294967286"/>
+    <PropertyCategory typeName="CrossingPointsProperties_Crossing_Points" description="CrossingPointsProperties" displayLabel="Crossing Points" priority="4294967276"/>
+    <PropertyCategory typeName="CrossingProperties_Crossing" description="CrossingProperties" displayLabel="Crossing" priority="4294967286"/>
+    <PropertyCategory typeName="CrossoverPointsProperties_Crossover_Points" description="CrossoverPointsProperties" displayLabel="Crossover Points" priority="4294967276"/>
+    <PropertyCategory typeName="CrossoverProperties_Crossover" description="CrossoverProperties" displayLabel="Crossover" priority="4294967286"/>
+    <PropertyCategory typeName="DistanceKeepersProperties_Distance_Keepers" description="DistanceKeepersProperties" displayLabel="Distance Keepers" priority="4294967286"/>
+    <PropertyCategory typeName="HorizontalRegression_Horizontal_Regression" description="HorizontalRegression" displayLabel="Horizontal Regression" priority="4294967286"/>
+    <PropertyCategory typeName="Joint_Joint" description="Joint" displayLabel="Joint" priority="4294967286"/>
+    <PropertyCategory typeName="JointGroup_Joint_Group" description="JointGroup" displayLabel="Joint Group" priority="4294967281"/>
+    <PropertyCategory typeName="LocationProperties_Location" description="LocationProperties" displayLabel="Location" priority="4294967284"/>
+    <PropertyCategory typeName="Miscellaneous_Base_Turnout_Branches_Feature" description="Miscellaneous" displayLabel="Base Turnout Branches Feature" priority="401000"/>
+    <PropertyCategory typeName="Miscellaneous_Base_Turnout_Elements_Feature" description="Miscellaneous" displayLabel="Base Turnout Elements Feature" priority="401000"/>
+    <PropertyCategory typeName="Miscellaneous_LLS_Extension" description="Miscellaneous" displayLabel="LLS Extension" priority="401000"/>
+    <PropertyCategory typeName="Miscellaneous_RailwayEdgeSegmentClass" description="Miscellaneous" displayLabel="RailwayEdgeSegmentClass" priority="401000"/>
+    <PropertyCategory typeName="Miscellaneous_Sleepers_Stub" description="Miscellaneous" displayLabel="Sleepers Stub" priority="401000"/>
+    <PropertyCategory typeName="Name_General_Category" description="Name" displayLabel="General Category" priority="300000"/>
+    <PropertyCategory typeName="Name_Pathway_Route" description="Name" displayLabel="Pathway Route" priority="300000"/>
+    <PropertyCategory typeName="Name_Railway_Edge" description="Name" displayLabel="Railway Edge" priority="300000"/>
+    <PropertyCategory typeName="Name_Railway_Node" description="Name" displayLabel="Railway Node" priority="300000"/>
+    <PropertyCategory typeName="PointControl_Point_Control" description="PointControl" displayLabel="Point Control" priority="199700"/>
+    <PropertyCategory typeName="Position_Position_On_Edge" description="Position" displayLabel="Position On Edge" priority="300000"/>
+    <PropertyCategory typeName="RailProperties_Rail" description="RailProperties" displayLabel="Rail" priority="4294967286"/>
+    <PropertyCategory typeName="RegressionPoint_Regression_Point" description="RegressionPoint" displayLabel="Regression Point" priority="4294967286"/>
+    <PropertyCategory typeName="SchemaElementAttributes_General_Category" description="SchemaElementAttributes" displayLabel="General Category" priority="200000"/>
+    <PropertyCategory typeName="SchemaLineAttributes_General_Category" description="SchemaLineAttributes" displayLabel="General Category" priority="200000"/>
+    <PropertyCategory typeName="SweepPathProperties_Sweep_Path" description="SweepPathProperties" displayLabel="Sweep Path" priority="4294967286"/>
+    <PropertyCategory typeName="SweepPathProperties_Swept_Path" description="SweepPathProperties" displayLabel="Swept Path" priority="4294967286"/>
+    <PropertyCategory typeName="TableEntry_Bending_Axis_Table_Entry" description="TableEntry" displayLabel="Bending Axis Table Entry" priority="0"/>
+    <PropertyCategory typeName="TableEntry_Cant_Table_Entry" description="TableEntry" displayLabel="Cant Table Entry" priority="0"/>
+    <PropertyCategory typeName="TableEntry_Track_Widening_Table_Entry" description="TableEntry" displayLabel="Track Widening Table Entry" priority="0"/>
+    <PropertyCategory typeName="TurnoutGeometryProperties_Geometry" description="TurnoutGeometryProperties" displayLabel="Geometry" priority="299990"/>
+    <PropertyCategory typeName="TurnoutPointsProperties_Turnout_Points" description="TurnoutPointsProperties" displayLabel="Turnout Points" priority="4294967276"/>
+    <PropertyCategory typeName="TurnoutProperties_Turnout" description="TurnoutProperties" displayLabel="Turnout" priority="4294967286"/>
+    <PropertyCategory typeName="VerticalRegression_Vertical_Regression" description="VerticalRegression" displayLabel="Vertical Regression" priority="4294967286"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifSubsurface.01.00.05.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifSubsurface.01.00.05.ecschema.xml
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifSubsurface" alias="cifssuf" version="01.00.05" description="iModel Connector schema containing aspect classes with properties from the Subsurface Utilities module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.01" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="CLASS_SU_LinkAspect_PROP_SU_CreateTrench_BoolEnum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="True" value="1" displayLabel="Yes"/>
+        <ECEnumerator name="False" value="0" displayLabel="No"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="NodeToPointAlongLinkRuleAspect_DistanceAlongFrom_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Referenced_link_start_node" value="1" displayLabel="Referenced link start node"/>
+        <ECEnumerator name="Referenced_link_stop_node" value="2" displayLabel="Referenced link stop node"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReachAspect_NodeDrawType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Box" value="0" displayLabel="Box"/>
+        <ECEnumerator name="Line" value="1" displayLabel="Line"/>
+        <ECEnumerator name="Triangle" value="2" displayLabel="Triangle"/>
+        <ECEnumerator name="Cell" value="3" displayLabel="Cell"/>
+        <ECEnumerator name="Slice" value="4" displayLabel="Slice"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="TapNodeToTrunkLineAspect_ConnectionType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Center" value="0" displayLabel="Center"/>
+        <ECEnumerator name="Soffit___Crown" value="1" displayLabel="Soffit / Crown"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="CLASS_ConduitDefaultsEntityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="NominalDiameter" typeName="double" displayLabel="Nominal Diameter" category="CategoryInstance_Category_Instance" priority="300000"/>
+        <ECProperty propertyName="InsideDiameter" typeName="double" displayLabel="Inside Diameter" category="CategoryInstance_Category_Instance" priority="299999"/>
+        <ECProperty propertyName="DepthWidthCurve" typeName="string" displayLabel="Depth Width Curve" category="CategoryInstance_Category_Instance" priority="299999"/>
+        <ECProperty propertyName="IrregularChannelSection" typeName="string" displayLabel="Irregular Channel Section" category="CategoryInstance_Category_Instance" priority="299999"/>
+        <ECProperty propertyName="Thickness" typeName="double" displayLabel="Thickness" category="CategoryInstance_Category_Instance" priority="299998"/>
+        <ECProperty propertyName="MinBendRadius" typeName="double" displayLabel="Min. Bend Radius" category="CategoryInstance_Category_Instance" priority="299997"/>
+        <ECProperty propertyName="JointDeflection" typeName="double" displayLabel="Joint Deflection" category="CategoryInstance_Category_Instance" priority="299996"/>
+        <ECProperty propertyName="UnitLength" typeName="double" displayLabel="Unit Length" category="CategoryInstance_Category_Instance" priority="299995"/>
+        <ECProperty propertyName="Rise" typeName="double" displayLabel="Rise" category="CategoryInstance_Category_Instance" priority="300000"/>
+        <ECProperty propertyName="Span" typeName="double" displayLabel="Span" category="CategoryInstance_Category_Instance" priority="299999"/>
+        <ECProperty propertyName="MinCover" typeName="double" displayLabel="Min. Cover" category="CategoryInstance_Category_Instance" priority="299990"/>
+        <ECProperty propertyName="FullArea" typeName="double" displayLabel="Full Area" category="CategoryInstance_Category_Instance" priority="299988"/>
+        <ECProperty propertyName="TopRadius" typeName="double" displayLabel="Top Radius" category="CategoryInstance_Category_Instance" priority="299988"/>
+        <ECProperty propertyName="BottomRadius" typeName="double" displayLabel="Bottom Radius" category="CategoryInstance_Category_Instance" priority="299987"/>
+        <ECProperty propertyName="BottomDistance" typeName="double" displayLabel="Bottom Distance" category="CategoryInstance_Category_Instance" priority="299986"/>
+        <ECProperty propertyName="CornerRadius" typeName="double" displayLabel="Corner Radius" category="CategoryInstance_Category_Instance" priority="299985"/>
+        <ECProperty propertyName="PowerExponent" typeName="double" displayLabel="Power Exponent" category="CategoryInstance_Category_Instance" priority="299997"/>
+        <ECProperty propertyName="TriangleHeight" typeName="double" displayLabel="Triangle Height" category="CategoryInstance_Category_Instance" priority="299997"/>
+        <ECProperty propertyName="BottomWidth" typeName="double" displayLabel="Bottom Width" category="CategoryInstance_Category_Instance" priority="299997"/>
+        <ECProperty propertyName="SideSlopeLeft" typeName="double" displayLabel="Side Slope (Left)" category="CategoryInstance_Category_Instance" priority="299996"/>
+        <ECProperty propertyName="SideSlopeRight" typeName="double" displayLabel="Side Slope (Right)" category="CategoryInstance_Category_Instance" priority="299995"/>
+        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" category="CategoryInstance_Category_Instance" priority="300000"/>
+        <ECProperty propertyName="ForDesign" typeName="boolean" displayLabel="For Design?" category="CategoryInstance_Category_Instance" priority="299987"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CLASS_IrregularChannelSectionAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PROP_Offset" typeName="double" displayLabel="Offset" category="StationElevationEntries_StationElevationEntries" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_Elevation" typeName="double" displayLabel="Elevation (Relative)" category="StationElevationEntries_StationElevationEntries" priority="299999"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CLASS_SU_LateralLinkRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PROP_SU_Skew" typeName="double" displayLabel="Skew to Trunk" category="Utility_Drainage_and_Utilities" priority="0" kindOfQuantity="cifu:ANGLE"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CLASS_SU_LinkAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PROP_SU_StartNode" typeName="string" displayLabel="Start Node" category="Utility_Drainage_and_Utilities" priority="299208"/>
+        <ECProperty propertyName="PROP_SU_StopNode" typeName="string" displayLabel="Stop Node" category="Utility_Drainage_and_Utilities" priority="299207"/>
+        <ECProperty propertyName="PROP_SU_SetInvertToStart" typeName="boolean" displayLabel="Set Invert to Start?" category="Utility_Drainage_and_Utilities" priority="299206"/>
+        <ECProperty propertyName="PROP_SU_StartInvert" typeName="double" displayLabel="Start Invert" category="Utility_Drainage_and_Utilities" priority="299205" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_SetInvertToStop" typeName="boolean" displayLabel="Set Invert to Stop?" category="Utility_Drainage_and_Utilities" priority="299204"/>
+        <ECProperty propertyName="PROP_SU_StopInvert" typeName="double" displayLabel="Stop Invert" category="Utility_Drainage_and_Utilities" priority="299203" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_Diameter" typeName="double" displayLabel="Diameter [Deprecated]" category="Utility_Drainage_and_Utilities" priority="299202" kindOfQuantity="cifu:LENGTH">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Use 'PROP_SU_DiameterValue' instead</Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="PROP_SU_InterpolateElevations" typeName="boolean" displayLabel="Single Gradient" category="Utility_Drainage_and_Utilities" priority="299196"/>
+        <ECProperty propertyName="PROP_SU_Description" typeName="string" displayLabel="Description" category="FeatureProperties_Feature" priority="0"/>
+        <ECProperty propertyName="PROP_SU_CreateTrench" typeName="CLASS_SU_LinkAspect_PROP_SU_CreateTrench_BoolEnum" displayLabel="Create Trench" category="FeatureProperties_Feature" priority="-10"/>
+        <ECProperty propertyName="CIF_ID" typeName="int" displayLabel="Utility ID" category="Utility_Utility" priority="299200"/>
+        <ECProperty propertyName="PROP_SU_NumberOfBarrels" typeName="int" displayLabel="Number of Barrels" category="Utility_Drainage_and_Utilities" priority="299202"/>
+        <ECProperty propertyName="CalculatedSlope" typeName="double" displayLabel="Slope (Calculated)" category="Utility_Drainage_and_Utilities" priority="299200" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="PROP_SU_ConstructionSlope" typeName="double" displayLabel="Slope (Construction)" category="Utility_Drainage_and_Utilities" priority="299199" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="PROP_SU_ConstructionLength" typeName="double" displayLabel="Length (Construction)" category="Utility_Drainage_and_Utilities" priority="299198" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length (Unified)" category="Utility_Drainage_and_Utilities" priority="299198" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_Material" typeName="string" displayLabel="Material" category="Utility_Drainage_and_Utilities" priority="299197"/>
+        <ECProperty propertyName="PROP_SU_Owner" typeName="string" displayLabel="Owner" category="Utility_Drainage_and_Utilities" priority="299195"/>
+        <ECProperty propertyName="PROP_SU_Capacity" typeName="double" displayLabel="Capacity (Full Flow)" category="Results_Drainage_Results" priority="299200" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PROP_SU_Flow" typeName="double" displayLabel="Flow" category="Results_Drainage_Results" priority="299199" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PROP_SU_Depth" typeName="double" displayLabel="Depth (Normal)" category="Results_Drainage_Results" priority="299198" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_Velocity" typeName="double" displayLabel="Velocity" category="Results_Drainage_Results" priority="299197" kindOfQuantity="cifu:FLOW_VELOCITY"/>
+        <ECProperty propertyName="PROP_SU_SpreadStart" typeName="double" displayLabel="Spread / Top Width (Start)" category="Results_Drainage_Results" priority="299196" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_SpreadStop" typeName="double" displayLabel="Spread / Top Width (Stop)" category="Results_Drainage_Results" priority="299195" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_DepthIn" typeName="double" displayLabel="Depth (In)" category="Results_Drainage_Results" priority="299194" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_DepthOut" typeName="double" displayLabel="Depth (Out)" category="Results_Drainage_Results" priority="299193" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_SU_RationalFlow" typeName="double" displayLabel="Rational Flow (Gutter)" category="Results_Drainage_Results" priority="299192" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="PROP_SU_DiameterValue" typeName="double" displayLabel="Diameter" category="Utility_Drainage_and_Utilities" priority="299202" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="DepthWidthEntityAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Depth" typeName="double" displayLabel="Elevation (Relative)" category="DepthWidthCurve_Depth_Width_Curve" priority="300000" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Width" typeName="double" displayLabel="Width" category="DepthWidthCurve_Depth_Width_Curve" priority="299999"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsCLASS_ConduitDefaultsEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CLASS_ConduitDefaultsEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCLASS_IrregularChannelSectionAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CLASS_IrregularChannelSectionAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCLASS_SU_LateralLinkRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CLASS_SU_LateralLinkRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCLASS_SU_LinkAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CLASS_SU_LinkAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsDepthWidthEntityAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DepthWidthEntityAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="LinkProfileByDTMRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElevationOffset" typeName="double" displayLabel="Vertical Offset" category="Utility_Drainage_and_Utilities" priority="299201" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ActiveReference" typeName="string" displayLabel="Elevation Reference" category="Utility_Drainage_and_Utilities" priority="299200"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsLinkProfileByDTMRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="LinkProfileByDTMRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NodeAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GroundElevation" typeName="double" displayLabel="Ground Elevation" category="Utility_Drainage_and_Utilities" priority="299211" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="InvertElevation" typeName="double" displayLabel="Invert Elevation" category="Utility_Drainage_and_Utilities" priority="299209" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="OrientTopToSurface" typeName="boolean" displayLabel="Use Slope of Surface" category="Utility_Drainage_and_Utilities" priority="299203"/>
+        <ECProperty propertyName="ActiveReference" typeName="string" displayLabel="Elevation Reference" category="Utility_Drainage_and_Utilities" priority="299208"/>
+        <ECProperty propertyName="ActiveStationOffsetReference" typeName="string" displayLabel="Baseline Reference" category="Utility_Drainage_and_Utilities" priority="299196"/>
+        <ECProperty propertyName="IndependentConduitElevations" typeName="boolean" displayLabel="Independent Conduit Elevations" category="Utility_Drainage_and_Utilities" priority="299199"/>
+        <ECProperty propertyName="MatchSlopeofConduit" typeName="boolean" displayLabel="Match Slope of Conduit" category="Utility_Drainage_and_Utilities" priority="299200"/>
+        <ECProperty propertyName="CIF_ID" typeName="int" displayLabel="Utility ID" category="Utility_Utility" priority="299199"/>
+        <ECProperty propertyName="ElevationIsInvert" typeName="boolean" displayLabel="Elevation is the Invert" category="Utility_Drainage_and_Utilities" priority="299990"/>
+        <ECProperty propertyName="UseRoadCrossSlope" typeName="boolean" displayLabel="Use Road Cross Slope" category="Utility_Drainage_and_Utilities" priority="299202"/>
+        <ECProperty propertyName="RoadCrossSlopeDistance" typeName="double" displayLabel="Road Cross Slope Offset" category="Utility_Drainage_and_Utilities" priority="299201" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="PROP_OnlyIncludeContributingSlopes" typeName="boolean" displayLabel="Only Include Contributing Slopes" category="Utility_Drainage_and_Utilities" priority="299184"/>
+        <ECProperty propertyName="PROP_PROP_CrosssectionOffset" typeName="double" displayLabel="Maximum Offset" category="Utility_Drainage_and_Utilities" priority="299183" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SetOutElevation" typeName="double" displayLabel="Set Out Elevation" category="Utility_Drainage_and_Utilities" priority="299206" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SetOutX" typeName="double" displayLabel="Set Out X" category="Utility_Drainage_and_Utilities" priority="299205" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SetOutY" typeName="double" displayLabel="Set Out Y" category="Utility_Drainage_and_Utilities" priority="299204" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaselineStation" typeName="double" displayLabel="Baseline Station" category="Utility_Drainage_and_Utilities" priority="299195" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="BaselineOffset" typeName="double" displayLabel="Baseline Offset" category="Utility_Drainage_and_Utilities" priority="299194" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Depth" typeName="double" displayLabel="Depth (Structure)" category="Utility_Drainage_and_Utilities" priority="299191" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Width" typeName="double" displayLabel="Width" category="Utility_Drainage_and_Utilities" priority="299190" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="Utility_Drainage_and_Utilities" priority="299189" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Diameter" typeName="double" displayLabel="Diameter" category="Utility_Drainage_and_Utilities" priority="299188" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+        <ECProperty propertyName="GrateLength" typeName="double" displayLabel="Grate Length" category="Utility_Drainage_and_Utilities" priority="299187" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="GrateWidth" typeName="double" displayLabel="Grate Width" category="Utility_Drainage_and_Utilities" priority="299186" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CurbOpeningLength" typeName="double" displayLabel="Curb Opening Length" category="Utility_Drainage_and_Utilities" priority="299185" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LongitudinalSlope" typeName="double" displayLabel="Longitudinal Slope" category="Utility_Drainage_and_Utilities" priority="299197" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="PROP_Owner" typeName="string" displayLabel="Owner" category="Utility_Drainage_and_Utilities" priority="299182"/>
+        <ECProperty propertyName="Spread" typeName="double" displayLabel="Spread / Top Width" category="Results_Drainage_Results" priority="299184" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CapturedFlow" typeName="double" displayLabel="Flow (Captured)" category="Results_Drainage_Results" priority="299181" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="BypassedFlow" typeName="double" displayLabel="Flow (Total Bypassed)" category="Results_Drainage_Results" priority="299180" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="DelineationReference" typeName="string" displayLabel="Delineation Reference" category="Utility_Drainage_and_Utilities" priority="299207"/>
+        <ECProperty propertyName="UseLongitudinalSlope" typeName="boolean" displayLabel="Use Longitudinal Slope" category="Utility_Drainage_and_Utilities" priority="299198"/>
+        <ECProperty propertyName="RimElevation" typeName="double" displayLabel="Rim Elevation" category="Utility_Drainage_and_Utilities" priority="299210" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NodeInvertTo3dElementRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="PROP_InvertReferenceName" typeName="string" displayLabel="Invert Reference" category="InvertTo3dReferenceRule_Invert_To_3D_Reference_Rule" priority="300000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNodeInvertTo3dElementRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NodeInvertTo3dElementRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NodeOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Offset" typeName="double" displayLabel="Vertical Offset" category="Utility_Drainage_and_Utilities" priority="299980" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNodeOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NodeOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="NodeToPointAlongLinkRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="DistanceAlong" typeName="double" displayLabel="Distance along link" category="NodeToPointAlongRuleProperties_Node_To_Point_Along_Link_Rule" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="DistanceAlongFrom" typeName="NodeToPointAlongLinkRuleAspect_DistanceAlongFrom_Enum" displayLabel="Distance along measured from:" category="NodeToPointAlongRuleProperties_Node_To_Point_Along_Link_Rule" priority="0"/>
+        <ECProperty propertyName="ReferencedLink" typeName="string" displayLabel="Referenced Link" category="NodeToPointAlongRuleProperties_Node_To_Point_Along_Link_Rule" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsNodeToPointAlongLinkRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="NodeToPointAlongLinkRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PolygonAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="OutflowElement" typeName="string" displayLabel="Outflow Element" category="Utility_Drainage_and_Utilities" priority="300000"/>
+        <ECProperty propertyName="ActiveReference" typeName="string" displayLabel="Elevation Reference" category="Utility_Drainage_and_Utilities" priority="299990"/>
+        <ECProperty propertyName="UseScaledArea" typeName="boolean" displayLabel="Use Scaled Area" category="Utility_Drainage_and_Utilities" priority="299989"/>
+        <ECProperty propertyName="Area" typeName="double" displayLabel="Area (User Defined)" category="Utility_Drainage_and_Utilities" priority="299987" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="ScaledArea" typeName="double" displayLabel="Scaled Area" category="Utility_Drainage_and_Utilities" priority="299988" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="CIF_ID" typeName="int" displayLabel="Utility ID" category="Utility_Utility" priority="299204"/>
+        <ECProperty propertyName="UnifiedArea" typeName="double" displayLabel="Area (Unified)" category="Utility_Drainage_and_Utilities" priority="299986" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="TimeOfConcentration" typeName="double" displayLabel="Time of Concentration (Composite)" category="Utility_Drainage_and_Utilities" priority="299984" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="RunoffCoefficient" typeName="double" displayLabel="Runoff Coefficient (Rational)" category="Utility_Drainage_and_Utilities" priority="299983" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Intensity" typeName="double" displayLabel="Catchment Intensity" category="Results_Drainage_Results" priority="299986" kindOfQuantity="cifu:RAINFALL_INTENSITY"/>
+        <ECProperty propertyName="RationalFlow" typeName="double" displayLabel="Catchment Rational Flow" category="Results_Drainage_Results" priority="299985" kindOfQuantity="cifu:FLOW"/>
+        <ECProperty propertyName="CatchmentCA" typeName="double" displayLabel="Catchment CA" category="Results_Drainage_Results" priority="299984" kindOfQuantity="cifu:AREA"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPolygonAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PolygonAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="PolygonBySurfaceEntityRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="MaxElevation" typeName="double" displayLabel="Top Elevation" category="PolygonBySurfaceEntityRuleAttributes_Polygon_By_Surface_Entity_Rule" priority="299202" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPolygonBySurfaceEntityRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PolygonBySurfaceEntityRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ProfileByLinearEntity3dOffsetRuleAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElevationOffset" typeName="double" displayLabel="Vertical Offset" category="Utility_Drainage_and_Utilities" priority="300000"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsProfileByLinearEntity3dOffsetRuleAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ProfileByLinearEntity3dOffsetRuleAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReachAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Name" typeName="string" displayLabel="Name" category="Reach_Profile_Run" priority="299999"/>
+        <ECProperty propertyName="HasHaestadProfile" typeName="boolean" displayLabel="Has Extended Profiles" category="Reach_Profile_Run" priority="299997"/>
+        <ECProperty propertyName="NodeDrawType" typeName="ReachAspect_NodeDrawType_Enum" displayLabel="Node Draw Type" category="Reach_Profile_Run" priority="299998"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReachAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReachAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="TapNodeToTrunkLineAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElevationOffset" typeName="double" displayLabel="Tap Elevation Offset" category="Utility_Drainage_and_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="ConnectionType" typeName="TapNodeToTrunkLineAspect_ConnectionType_Enum" displayLabel="Tap Connection Type" category="Utility_Drainage_and_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsTapNodeToTrunkLineAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="TapNodeToTrunkLineAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="Area_Area" description="Area" displayLabel="Area" priority="200000"/>
+    <PropertyCategory typeName="CategoryInstance_Category_Instance" description="CategoryInstance" displayLabel="Category Instance" priority="1"/>
+    <PropertyCategory typeName="DepthWidthCurve_Depth_Width_Curve" description="DepthWidthCurve" displayLabel="Depth Width Curve" priority="400000"/>
+    <PropertyCategory typeName="FeatureProperties_Feature" description="FeatureProperties" displayLabel="Feature" priority="299999"/>
+    <PropertyCategory typeName="InvertTo3dReferenceRule_Invert_To_3D_Reference_Rule" description="InvertTo3dReferenceRule" displayLabel="Invert To 3D Reference Rule" priority="100000"/>
+    <PropertyCategory typeName="NodeToPointAlongRuleProperties_Node_To_Point_Along_Link_Rule" description="NodeToPointAlongRuleProperties" displayLabel="Node To Point Along Link Rule" priority="300000"/>
+    <PropertyCategory typeName="PolygonBySurfaceEntityRuleAttributes_Polygon_By_Surface_Entity_Rule" description="PolygonBySurfaceEntityRuleAttributes" displayLabel="Polygon By Surface Entity Rule" priority="0"/>
+    <PropertyCategory typeName="Reach_Profile_Run" description="Reach" displayLabel="Profile Run" priority="299999"/>
+    <PropertyCategory typeName="Results_Drainage_Results" description="Results" displayLabel="Drainage Results" priority="299997"/>
+    <PropertyCategory typeName="StationElevationEntries_StationElevationEntries" description="StationElevationEntries" displayLabel="&lt;- StationElevationEntries -&gt;" priority="300000"/>
+    <PropertyCategory typeName="Utility_Drainage_and_Utilities" description="Utility" displayLabel="Drainage and Utilities" priority="299999"/>
+    <PropertyCategory typeName="Utility_Utility" description="Utility" displayLabel="Utility" priority="299999"/>
+</ECSchema>

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifSubsurfaceConflictAnalysis.01.00.05.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifSubsurfaceConflictAnalysis.01.00.05.ecschema.xml
@@ -1,0 +1,1231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="CifSubsurfaceConflictAnalysis" alias="cifsscfan" version="01.00.05" description="iModel Connector schema containing aspect classes with properties from the Subsurface Utilities Engineering module as part of Civil Designer applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.14" alias="bis"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="CifCommon" version="01.00.03" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.01" alias="cifu"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>Production</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+    <ECEnumeration typeName="BaseLink_HmiDataSetGeometryAspect_Authority_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Certified" value="0" displayLabel="Certified"/>
+        <ECEnumerator name="Non_Certified" value="1" displayLabel="Non-Certified"/>
+        <ECEnumerator name="Unknown" value="2" displayLabel="Unknown"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseLink_HmiDataSetGeometryAspect_InvestigationLevel_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Land_Survey" value="0" displayLabel="Land Survey"/>
+        <ECEnumerator name="Engineering_Survey" value="1" displayLabel="Engineering Survey"/>
+        <ECEnumerator name="Informational_Survey" value="2" displayLabel="Informational Survey"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseLink_HmiDataSetGeometryAspect_QualityLevel_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Quality_Level_A" value="0" displayLabel="Quality Level A"/>
+        <ECEnumerator name="Quality_Level_B" value="1" displayLabel="Quality Level B"/>
+        <ECEnumerator name="Quality_Level_C" value="2" displayLabel="Quality Level C"/>
+        <ECEnumerator name="Quality_Level_D" value="3" displayLabel="Quality Level D"/>
+        <ECEnumerator name="Undetermined" value="4" displayLabel="Undetermined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseLink_NetworkDataAspect_UtiltityOperationalStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Abandoned" value="0" displayLabel="Abandoned"/>
+        <ECEnumerator name="In_Service" value="1" displayLabel="In Service"/>
+        <ECEnumerator name="Proposed" value="2" displayLabel="Proposed"/>
+        <ECEnumerator name="Removed" value="3" displayLabel="Removed"/>
+        <ECEnumerator name="Temporary" value="4" displayLabel="Temporary"/>
+        <ECEnumerator name="Under_Construction" value="5" displayLabel="Under Construction"/>
+        <ECEnumerator name="Abandon_In_Place" value="6" displayLabel="Abandon In Place"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseLink_Physical_SegmentShapeTypeAspect_SegmentShapeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Circle" value="2" displayLabel="Circle"/>
+        <ECEnumerator name="Box" value="3" displayLabel="Box"/>
+        <ECEnumerator name="Basket_Handle" value="4" displayLabel="Basket-Handle"/>
+        <ECEnumerator name="Ellipse" value="5" displayLabel="Ellipse"/>
+        <ECEnumerator name="Horseshoe" value="6" displayLabel="Horseshoe"/>
+        <ECEnumerator name="Egg" value="7" displayLabel="Egg"/>
+        <ECEnumerator name="Semi_Ellipse" value="8" displayLabel="Semi-Ellipse"/>
+        <ECEnumerator name="Pipe_Arch" value="10" displayLabel="Pipe-Arch"/>
+        <ECEnumerator name="Semi_Circle" value="12" displayLabel="Semi-Circle"/>
+        <ECEnumerator name="Catenary" value="13" displayLabel="Catenary"/>
+        <ECEnumerator name="Gothic" value="14" displayLabel="Gothic"/>
+        <ECEnumerator name="Modified_Basket_Handle" value="15" displayLabel="Modified Basket-Handle"/>
+        <ECEnumerator name="Arch" value="30" displayLabel="Arch"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseNode_HmiDataSetGeometryAspect_Authority_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Certified" value="0" displayLabel="Certified"/>
+        <ECEnumerator name="Non_Certified" value="1" displayLabel="Non-Certified"/>
+        <ECEnumerator name="Unknown" value="2" displayLabel="Unknown"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseNode_HmiDataSetGeometryAspect_InvestigationLevel_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Land_Survey" value="0" displayLabel="Land Survey"/>
+        <ECEnumerator name="Engineering_Survey" value="1" displayLabel="Engineering Survey"/>
+        <ECEnumerator name="Informational_Survey" value="2" displayLabel="Informational Survey"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseNode_HmiDataSetGeometryAspect_QualityLevel_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Quality_Level_A" value="0" displayLabel="Quality Level A"/>
+        <ECEnumerator name="Quality_Level_B" value="1" displayLabel="Quality Level B"/>
+        <ECEnumerator name="Quality_Level_C" value="2" displayLabel="Quality Level C"/>
+        <ECEnumerator name="Quality_Level_D" value="3" displayLabel="Quality Level D"/>
+        <ECEnumerator name="Undetermined" value="4" displayLabel="Undetermined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="BaseNode_NetworkDataAspect_UtiltityOperationalStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Abandoned" value="0" displayLabel="Abandoned"/>
+        <ECEnumerator name="In_Service" value="1" displayLabel="In Service"/>
+        <ECEnumerator name="Proposed" value="2" displayLabel="Proposed"/>
+        <ECEnumerator name="Removed" value="3" displayLabel="Removed"/>
+        <ECEnumerator name="Temporary" value="4" displayLabel="Temporary"/>
+        <ECEnumerator name="Under_Construction" value="5" displayLabel="Under Construction"/>
+        <ECEnumerator name="Abandon_In_Place" value="6" displayLabel="Abandon In Place"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CommunicationNode_NetworkDataAspect_CommNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Access_Point" value="0" displayLabel="Access Point"/>
+        <ECEnumerator name="Amplifier" value="1" displayLabel="Amplifier"/>
+        <ECEnumerator name="Antenna" value="2" displayLabel="Antenna"/>
+        <ECEnumerator name="DB_Splice" value="3" displayLabel="DB Splice"/>
+        <ECEnumerator name="Device" value="4" displayLabel="Device"/>
+        <ECEnumerator name="Distribution_Panel" value="5" displayLabel="Distribution Panel"/>
+        <ECEnumerator name="Ground" value="6" displayLabel="Ground"/>
+        <ECEnumerator name="ImpedanceMatching" value="7" displayLabel="ImpedanceMatching"/>
+        <ECEnumerator name="Load_Capacitor" value="8" displayLabel="Load Capacitor"/>
+        <ECEnumerator name="Load_Coil" value="9" displayLabel="Load Coil"/>
+        <ECEnumerator name="Media_Converter" value="10" displayLabel="Media Converter"/>
+        <ECEnumerator name="Repeater" value="11" displayLabel="Repeater"/>
+        <ECEnumerator name="Sensor" value="12" displayLabel="Sensor"/>
+        <ECEnumerator name="Speaker" value="13" displayLabel="Speaker"/>
+        <ECEnumerator name="Splice" value="14" displayLabel="Splice"/>
+        <ECEnumerator name="Splitter" value="15" displayLabel="Splitter"/>
+        <ECEnumerator name="Terminal" value="16" displayLabel="Terminal"/>
+        <ECEnumerator name="Terminator" value="17" displayLabel="Terminator"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CommunicationNode_NetworkDataAspect_CommunicationNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Telephone" value="0" displayLabel="Telephone"/>
+        <ECEnumerator name="CATV" value="1" displayLabel="CATV"/>
+        <ECEnumerator name="Fiber_Optic" value="2" displayLabel="Fiber Optic"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CommunicationSegment_NetworkDataAspect_ComConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Cable" value="0" displayLabel="Cable"/>
+        <ECEnumerator name="Duct" value="1" displayLabel="Duct"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CommunicationSegment_NetworkDataAspect_CommSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Segmented_Cable" value="0" displayLabel="Segmented Cable"/>
+        <ECEnumerator name="Service_Loop" value="1" displayLabel="Service Loop"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="CommunicationSegment_NetworkDataAspect_CommunicationNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Telephone" value="0" displayLabel="Telephone"/>
+        <ECEnumerator name="CATV" value="1" displayLabel="CATV"/>
+        <ECEnumerator name="Fiber_Optic" value="2" displayLabel="Fiber Optic"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ConflictNode_ConflictAspect_ConflictType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Hard" value="0" displayLabel="Hard"/>
+        <ECEnumerator name="Soft" value="1" displayLabel="Soft"/>
+        <ECEnumerator name="Trench" value="2" displayLabel="Trench"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ConflictNode_ConflictAspect_CurrentStatus_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Created" value="0" displayLabel="Created"/>
+        <ECEnumerator name="Owner_Informed" value="1" displayLabel="Owner Informed"/>
+        <ECEnumerator name="Resolution_Strategy_Selected" value="2" displayLabel="Resolution Strategy Selected"/>
+        <ECEnumerator name="Resolved" value="3" displayLabel="Resolved"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ConflictNode_ConflictAspect_RecommendedResolution_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Relocation_Before_Construction" value="0" displayLabel="Relocation Before Construction"/>
+        <ECEnumerator name="Design_Change" value="1" displayLabel="Design Change"/>
+        <ECEnumerator name="Protect_in_place" value="2" displayLabel="Protect in-place"/>
+        <ECEnumerator name="Ignore" value="3" displayLabel="Ignore"/>
+        <ECEnumerator name="Other" value="4" displayLabel="Other"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ConflictNode_HmiDataSetGeometryAspect_FeatureA_QualityLevel_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Quality_Level_A" value="0" displayLabel="Quality Level A"/>
+        <ECEnumerator name="Quality_Level_B" value="1" displayLabel="Quality Level B"/>
+        <ECEnumerator name="Quality_Level_C" value="2" displayLabel="Quality Level C"/>
+        <ECEnumerator name="Quality_Level_D" value="3" displayLabel="Quality Level D"/>
+        <ECEnumerator name="Undetermined" value="4" displayLabel="Undetermined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ConflictNode_HmiDataSetGeometryAspect_FeatureB_QualityLevel_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Quality_Level_A" value="0" displayLabel="Quality Level A"/>
+        <ECEnumerator name="Quality_Level_B" value="1" displayLabel="Quality Level B"/>
+        <ECEnumerator name="Quality_Level_C" value="2" displayLabel="Quality Level C"/>
+        <ECEnumerator name="Quality_Level_D" value="3" displayLabel="Quality Level D"/>
+        <ECEnumerator name="Undetermined" value="4" displayLabel="Undetermined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ElectricalNode_NetworkDataAspect_ElectricNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Power" value="0" displayLabel="Power"/>
+        <ECEnumerator name="Lighting" value="-1" displayLabel="Lighting"/>
+        <ECEnumerator name="Service" value="2" displayLabel="Service"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ElectricalNode_NetworkDataAspect_ElectricNodeDataType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Capacitor_Bank" value="0" displayLabel="Capacitor Bank"/>
+        <ECEnumerator name="Device_Protective_Device" value="1" displayLabel="Device Protective Device"/>
+        <ECEnumerator name="Exterior_Light" value="2" displayLabel="Exterior Light"/>
+        <ECEnumerator name="Fuse" value="4" displayLabel="Fuse"/>
+        <ECEnumerator name="Generator" value="5" displayLabel="Generator"/>
+        <ECEnumerator name="Grounding_Point" value="6" displayLabel="Grounding Point"/>
+        <ECEnumerator name="Meter_Point" value="7" displayLabel="Meter Point"/>
+        <ECEnumerator name="Open_Point" value="8" displayLabel="Open Point"/>
+        <ECEnumerator name="Switch" value="9" displayLabel="Switch"/>
+        <ECEnumerator name="Transformer" value="10" displayLabel="Transformer"/>
+        <ECEnumerator name="Voltage_Regulator" value="11" displayLabel="Voltage Regulator"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+        <ECEnumerator name="Fitting" value="3" displayLabel="Fitting"/>
+        <ECEnumerator name="Access_Point" value="12" displayLabel="Access Point"/>
+        <ECEnumerator name="Control_Node" value="13" displayLabel="Control Node"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ElectricalSegment_NetworkDataAspect_ElectricConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Cable" value="0" displayLabel="Cable"/>
+        <ECEnumerator name="Duct" value="1" displayLabel="Duct"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ElectricalSegment_NetworkDataAspect_ElectricNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Power" value="0" displayLabel="Power"/>
+        <ECEnumerator name="Lighting" value="-1" displayLabel="Lighting"/>
+        <ECEnumerator name="Service" value="2" displayLabel="Service"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ElectricalSegment_NetworkDataAspect_ElectricSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Bus_Bar" value="0" displayLabel="Bus Bar"/>
+        <ECEnumerator name="Primary_Overhead_Line" value="1" displayLabel="Primary Overhead Line"/>
+        <ECEnumerator name="Primary_Underground_Line" value="2" displayLabel="Primary Underground Line"/>
+        <ECEnumerator name="Secondary_Overhead_Line" value="3" displayLabel="Secondary Overhead Line"/>
+        <ECEnumerator name="Secondary_Underground_Line" value="4" displayLabel="Secondary Underground Line"/>
+        <ECEnumerator name="Overhead_Transmission_Line" value="5" displayLabel="Overhead Transmission Line"/>
+        <ECEnumerator name="Transmission_Underground_Line" value="6" displayLabel="Transmission Underground Line"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GasNode_NetworkDataAspect_GasNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="High_Pressure" value="0" displayLabel="High Pressure"/>
+        <ECEnumerator name="Low_Pressure" value="1" displayLabel="Low Pressure"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GasNode_NetworkDataAspect_GasNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Controllable_Fitting" value="0" displayLabel="Controllable Fitting"/>
+        <ECEnumerator name="Drip" value="1" displayLabel="Drip"/>
+        <ECEnumerator name="Gas_Lamp" value="2" displayLabel="Gas Lamp"/>
+        <ECEnumerator name="Meter_Point" value="3" displayLabel="Meter Point"/>
+        <ECEnumerator name="Non_Controllable_Fitting" value="4" displayLabel="Non Controllable Fitting"/>
+        <ECEnumerator name="Odorizer" value="5" displayLabel="Odorizer"/>
+        <ECEnumerator name="Pressure_Monitoring_Device" value="6" displayLabel="Pressure Monitoring Device"/>
+        <ECEnumerator name="Regulator" value="7" displayLabel="Regulator"/>
+        <ECEnumerator name="Regulator_Station" value="8" displayLabel="Regulator Station"/>
+        <ECEnumerator name="ReliefValve" value="9" displayLabel="ReliefValve"/>
+        <ECEnumerator name="Rural_Tap" value="10" displayLabel="Rural Tap"/>
+        <ECEnumerator name="TownBorderStation" value="11" displayLabel="TownBorderStation"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+        <ECEnumerator name="Valve_Isolation" value="12" displayLabel="Valve Isolation"/>
+        <ECEnumerator name="Valve_Regulating" value="13" displayLabel="Valve Regulating"/>
+        <ECEnumerator name="Fitting" value="14" displayLabel="Fitting"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GasSegment_NetworkDataAspect_GasConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pressure_Pipe" value="0" displayLabel="Pressure Pipe"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GasSegment_NetworkDataAspect_GasNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="High_Pressure" value="0" displayLabel="High Pressure"/>
+        <ECEnumerator name="Low_Pressure" value="1" displayLabel="Low Pressure"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="GasSegment_NetworkDataAspect_GasSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Main_Line" value="0" displayLabel="Main Line"/>
+        <ECEnumerator name="Service_Line" value="1" displayLabel="Service Line"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="POLNode_NetworkDataAspect_POLNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Automotive_Diesel_DF_2" value="0" displayLabel="Automotive Diesel (DF-2)"/>
+        <ECEnumerator name="Bio_Diesel_B20" value="1" displayLabel="Bio-Diesel (B20)"/>
+        <ECEnumerator name="Burner_Fuel_No__1" value="2" displayLabel="Burner Fuel No. 1"/>
+        <ECEnumerator name="Burner_Fuel_No__2" value="3" displayLabel="Burner Fuel No. 2"/>
+        <ECEnumerator name="Burner_Fuel_No__3" value="4" displayLabel="Burner Fuel No. 3"/>
+        <ECEnumerator name="Burner_Fuel_No__4" value="5" displayLabel="Burner Fuel No. 4"/>
+        <ECEnumerator name="Burner_Fuel_No__5_Heavy" value="6" displayLabel="Burner Fuel No. 5 (Heavy)"/>
+        <ECEnumerator name="Burner_Fuel_No__5_Light" value="7" displayLabel="Burner Fuel No. 5 (Light)"/>
+        <ECEnumerator name="Burner_Fuel_No__6" value="8" displayLabel="Burner Fuel No. 6"/>
+        <ECEnumerator name="Compressed_Natural_Gas_CNG" value="9" displayLabel="Compressed Natural Gas (CNG)"/>
+        <ECEnumerator name="E85" value="10" displayLabel="E85"/>
+        <ECEnumerator name="Hydrazine_Water_H_70" value="11" displayLabel="Hydrazine-Water (H-70)"/>
+        <ECEnumerator name="Jet_A" value="12" displayLabel="Jet A"/>
+        <ECEnumerator name="Jet_A_1" value="13" displayLabel="Jet A-1"/>
+        <ECEnumerator name="JP_10" value="14" displayLabel="JP-10"/>
+        <ECEnumerator name="JP_4" value="15" displayLabel="JP-4"/>
+        <ECEnumerator name="JP_5" value="16" displayLabel="JP-5"/>
+        <ECEnumerator name="JP_7" value="17" displayLabel="JP-7"/>
+        <ECEnumerator name="JP_8" value="18" displayLabel="JP-8"/>
+        <ECEnumerator name="JP_Thermally_Stable" value="19" displayLabel="JP (Thermally Stable)"/>
+        <ECEnumerator name="Kerosene" value="20" displayLabel="Kerosene"/>
+        <ECEnumerator name="Liquified_Petroleum_Gas_LPG" value="21" displayLabel="Liquified Petroleum Gas (LPG)"/>
+        <ECEnumerator name="Marine_Diesel" value="22" displayLabel="Marine Diesel"/>
+        <ECEnumerator name="Motor_Gasoline_MOGAS" value="23" displayLabel="Motor Gasoline (MOGAS)"/>
+        <ECEnumerator name="O_250" value="24" displayLabel="O-250"/>
+        <ECEnumerator name="O_278" value="250" displayLabel="O-278"/>
+        <ECEnumerator name="OTTO" value="251" displayLabel="OTTO"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="POLNode_NetworkDataAspect_POLNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Dispenser" value="0" displayLabel="Dispenser"/>
+        <ECEnumerator name="FillStand" value="1" displayLabel="FillStand"/>
+        <ECEnumerator name="Filter_Separator" value="2" displayLabel="Filter Separator"/>
+        <ECEnumerator name="Hydrant_Outlet" value="3" displayLabel="Hydrant Outlet"/>
+        <ECEnumerator name="Injector" value="4" displayLabel="Injector"/>
+        <ECEnumerator name="Loading_Arm" value="5" displayLabel="Loading Arm"/>
+        <ECEnumerator name="Meter" value="6" displayLabel="Meter"/>
+        <ECEnumerator name="Pump" value="7" displayLabel="Pump"/>
+        <ECEnumerator name="Relaxation_Tank" value="8" displayLabel="Relaxation Tank"/>
+        <ECEnumerator name="Strainer" value="9" displayLabel="Strainer"/>
+        <ECEnumerator name="Tank" value="10" displayLabel="Tank"/>
+        <ECEnumerator name="Valve" value="11" displayLabel="Valve"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+        <ECEnumerator name="Access_Point" value="12" displayLabel="Access Point"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="POLSegment_NetworkDataAspect_POLConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Conduit" value="0" displayLabel="Conduit"/>
+        <ECEnumerator name="Pressure_Pipe" value="1" displayLabel="Pressure Pipe"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="POLSegment_NetworkDataAspect_POLNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Automotive_Diesel_DF_2" value="0" displayLabel="Automotive Diesel (DF-2)"/>
+        <ECEnumerator name="Bio_Diesel_B20" value="1" displayLabel="Bio-Diesel (B20)"/>
+        <ECEnumerator name="Burner_Fuel_No__1" value="2" displayLabel="Burner Fuel No. 1"/>
+        <ECEnumerator name="Burner_Fuel_No__2" value="3" displayLabel="Burner Fuel No. 2"/>
+        <ECEnumerator name="Burner_Fuel_No__3" value="4" displayLabel="Burner Fuel No. 3"/>
+        <ECEnumerator name="Burner_Fuel_No__4" value="5" displayLabel="Burner Fuel No. 4"/>
+        <ECEnumerator name="Burner_Fuel_No__5_Heavy" value="6" displayLabel="Burner Fuel No. 5 (Heavy)"/>
+        <ECEnumerator name="Burner_Fuel_No__5_Light" value="7" displayLabel="Burner Fuel No. 5 (Light)"/>
+        <ECEnumerator name="Burner_Fuel_No__6" value="8" displayLabel="Burner Fuel No. 6"/>
+        <ECEnumerator name="Compressed_Natural_Gas_CNG" value="9" displayLabel="Compressed Natural Gas (CNG)"/>
+        <ECEnumerator name="E85" value="10" displayLabel="E85"/>
+        <ECEnumerator name="Hydrazine_Water_H_70" value="11" displayLabel="Hydrazine-Water (H-70)"/>
+        <ECEnumerator name="Jet_A" value="12" displayLabel="Jet A"/>
+        <ECEnumerator name="Jet_A_1" value="13" displayLabel="Jet A-1"/>
+        <ECEnumerator name="JP_10" value="14" displayLabel="JP-10"/>
+        <ECEnumerator name="JP_4" value="15" displayLabel="JP-4"/>
+        <ECEnumerator name="JP_5" value="16" displayLabel="JP-5"/>
+        <ECEnumerator name="JP_7" value="17" displayLabel="JP-7"/>
+        <ECEnumerator name="JP_8" value="18" displayLabel="JP-8"/>
+        <ECEnumerator name="JP_Thermally_Stable" value="19" displayLabel="JP (Thermally Stable)"/>
+        <ECEnumerator name="Kerosene" value="20" displayLabel="Kerosene"/>
+        <ECEnumerator name="Liquified_Petroleum_Gas_LPG" value="21" displayLabel="Liquified Petroleum Gas (LPG)"/>
+        <ECEnumerator name="Marine_Diesel" value="22" displayLabel="Marine Diesel"/>
+        <ECEnumerator name="Motor_Gasoline_MOGAS" value="23" displayLabel="Motor Gasoline (MOGAS)"/>
+        <ECEnumerator name="O_250" value="24" displayLabel="O-250"/>
+        <ECEnumerator name="O_278" value="250" displayLabel="O-278"/>
+        <ECEnumerator name="OTTO" value="251" displayLabel="OTTO"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="POLSegment_NetworkDataAspect_POLSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Installation_Pipeline" value="0" displayLabel="Installation Pipeline"/>
+        <ECEnumerator name="Interterminal_Pipeline" value="1" displayLabel="Interterminal Pipeline"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ReferenceDomainElementAspect_DataSourceType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Utility_Project" value="0" displayLabel="Utility Project"/>
+        <ECEnumerator name="Microstation_External_Element" value="1" displayLabel="Microstation External Element"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StormWaterNode_NetworkDataAspect_StormNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Storm_Water_Only" value="0" displayLabel="Storm Water Only"/>
+        <ECEnumerator name="Combined" value="1" displayLabel="Combined"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StormWaterNode_NetworkDataAspect_StormWaterNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Inlet_Grate" value="0" displayLabel="Inlet Grate"/>
+        <ECEnumerator name="Inlet_Curb_Opening" value="1" displayLabel="Inlet Curb Opening"/>
+        <ECEnumerator name="Inlet_Combined" value="2" displayLabel="Inlet Combined"/>
+        <ECEnumerator name="Inlet_Slotted_Drain" value="3" displayLabel="Inlet Slotted Drain"/>
+        <ECEnumerator name="Manhole" value="4" displayLabel="Manhole"/>
+        <ECEnumerator name="Headwall" value="5" displayLabel="Headwall"/>
+        <ECEnumerator name="Pump" value="6" displayLabel="Pump"/>
+        <ECEnumerator name="Fitting" value="7" displayLabel="Fitting"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StormWaterSegment_NetworkDataAspect_StormNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Storm_Water_Only" value="0" displayLabel="Storm Water Only"/>
+        <ECEnumerator name="Combined" value="1" displayLabel="Combined"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StormWaterSegment_NetworkDataAspect_StormWaterConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Conduit" value="0" displayLabel="Conduit"/>
+        <ECEnumerator name="Filter_Conduit" value="1" displayLabel="Filter Conduit"/>
+        <ECEnumerator name="Channel" value="2" displayLabel="Channel"/>
+        <ECEnumerator name="Gutter" value="4" displayLabel="Gutter"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="StormWaterSegment_NetworkDataAspect_StormWaterSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Trunk_Line" value="0" displayLabel="Trunk Line"/>
+        <ECEnumerator name="Lateral" value="1" displayLabel="Lateral"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ThermalNode_NetworkDataAspect_ThermalNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Chilled_Water_Return" value="0" displayLabel="Chilled Water Return"/>
+        <ECEnumerator name="Chilled_Water_Supply" value="1" displayLabel="Chilled Water Supply"/>
+        <ECEnumerator name="Dual_Temperature_Water_Return" value="2" displayLabel="Dual Temperature Water Return"/>
+        <ECEnumerator name="Dual_Temperature_Water_Supply" value="3" displayLabel="Dual Temperature Water Supply"/>
+        <ECEnumerator name="High_Temperature_Hot_Water_Return" value="4" displayLabel="High Temperature Hot Water Return"/>
+        <ECEnumerator name="High_Temperature_Hot_Water_Supply" value="5" displayLabel="High Temperature Hot Water Supply"/>
+        <ECEnumerator name="Low_Temperature_Hot_Water_Return" value="6" displayLabel="Low Temperature Hot Water Return"/>
+        <ECEnumerator name="Low_Temperature_Hot_Water_Supply" value="7" displayLabel="Low Temperature Hot Water Supply"/>
+        <ECEnumerator name="Steam_Return" value="8" displayLabel="Steam Return"/>
+        <ECEnumerator name="Steam_Supply" value="9" displayLabel="Steam Supply"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ThermalNode_NetworkDataAspect_ThermalNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Aquastat" value="0" displayLabel="Aquastat"/>
+        <ECEnumerator name="Condensate_Collector" value="1" displayLabel="Condensate Collector"/>
+        <ECEnumerator name="Control_Valve" value="2" displayLabel="Control Valve"/>
+        <ECEnumerator name="Expansion_Joint" value="3" displayLabel="Expansion Joint"/>
+        <ECEnumerator name="Expansion_Loop" value="4" displayLabel="Expansion Loop"/>
+        <ECEnumerator name="Expansion_Tank" value="5" displayLabel="Expansion Tank"/>
+        <ECEnumerator name="Fitting" value="6" displayLabel="Fitting"/>
+        <ECEnumerator name="Meter_Point" value="7" displayLabel="Meter Point"/>
+        <ECEnumerator name="Production_Structure" value="8" displayLabel="Production Structure"/>
+        <ECEnumerator name="Pump" value="9" displayLabel="Pump"/>
+        <ECEnumerator name="Relief_Valve" value="10" displayLabel="Relief Valve"/>
+        <ECEnumerator name="Strainer" value="11" displayLabel="Strainer"/>
+        <ECEnumerator name="System_Valve" value="12" displayLabel="System Valve"/>
+        <ECEnumerator name="Trap" value="13" displayLabel="Trap"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+        <ECEnumerator name="DisplayLabel" value="14" displayLabel="DisplayLabel"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ThermalSegment_NetworkDataAspect_ThermalConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Conduit" value="0" displayLabel="Conduit"/>
+        <ECEnumerator name="Pressure_Pipe" value="1" displayLabel="Pressure Pipe"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ThermalSegment_NetworkDataAspect_ThermalNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Chilled_Water_Return" value="0" displayLabel="Chilled Water Return"/>
+        <ECEnumerator name="Chilled_Water_Supply" value="1" displayLabel="Chilled Water Supply"/>
+        <ECEnumerator name="Dual_Temperature_Water_Return" value="2" displayLabel="Dual Temperature Water Return"/>
+        <ECEnumerator name="Dual_Temperature_Water_Supply" value="3" displayLabel="Dual Temperature Water Supply"/>
+        <ECEnumerator name="High_Temperature_Hot_Water_Return" value="4" displayLabel="High Temperature Hot Water Return"/>
+        <ECEnumerator name="High_Temperature_Hot_Water_Supply" value="5" displayLabel="High Temperature Hot Water Supply"/>
+        <ECEnumerator name="Low_Temperature_Hot_Water_Return" value="6" displayLabel="Low Temperature Hot Water Return"/>
+        <ECEnumerator name="Low_Temperature_Hot_Water_Supply" value="7" displayLabel="Low Temperature Hot Water Supply"/>
+        <ECEnumerator name="Steam_Return" value="8" displayLabel="Steam Return"/>
+        <ECEnumerator name="Steam_Supply" value="9" displayLabel="Steam Supply"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="ThermalSegment_NetworkDataAspect_ThermalSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Main_Line" value="0" displayLabel="Main Line"/>
+        <ECEnumerator name="Service_Line" value="1" displayLabel="Service Line"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WasteWaterNode_NetworkDataAspect_WasteWaterNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Domestic" value="0" displayLabel="Domestic"/>
+        <ECEnumerator name="Industrial" value="1" displayLabel="Industrial"/>
+        <ECEnumerator name="Oily_Waste" value="2" displayLabel="Oily Waste"/>
+        <ECEnumerator name="Ships_Waste" value="3" displayLabel="Ships Waste"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WasteWaterNode_NetworkDataAspect_WasteWaterNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Clean_Out" value="0" displayLabel="Clean Out"/>
+        <ECEnumerator name="Fitting" value="1" displayLabel="Fitting"/>
+        <ECEnumerator name="Manhole" value="2" displayLabel="Manhole"/>
+        <ECEnumerator name="Meter_Point" value="3" displayLabel="Meter Point"/>
+        <ECEnumerator name="Pump" value="4" displayLabel="Pump"/>
+        <ECEnumerator name="Release_Valve" value="5" displayLabel="Release Valve"/>
+        <ECEnumerator name="System_Valve" value="6" displayLabel="System Valve"/>
+        <ECEnumerator name="Treatment_Plant" value="7" displayLabel="Treatment Plant"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+        <ECEnumerator name="Access_Point" value="8" displayLabel="Access Point"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WasteWaterSegment_NetworkDataAspect_WasteWaterConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Conduit" value="0" displayLabel="Conduit"/>
+        <ECEnumerator name="Filter_Conduit" value="1" displayLabel="Filter Conduit"/>
+        <ECEnumerator name="Pressure_Pipe" value="2" displayLabel="Pressure Pipe"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WasteWaterSegment_NetworkDataAspect_WasteWaterNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Domestic" value="0" displayLabel="Domestic"/>
+        <ECEnumerator name="Industrial" value="1" displayLabel="Industrial"/>
+        <ECEnumerator name="Oily_Waste" value="2" displayLabel="Oily Waste"/>
+        <ECEnumerator name="Ships_Waste" value="3" displayLabel="Ships Waste"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WasteWaterSegment_NetworkDataAspect_WasteWaterSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Force_Main" value="0" displayLabel="Force Main"/>
+        <ECEnumerator name="Gravity_Main" value="1" displayLabel="Gravity Main"/>
+        <ECEnumerator name="Lateral_Line" value="2" displayLabel="Lateral Line"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WaterNode_NetworkDataAspect_WaterNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Fire_Protection" value="0" displayLabel="Fire Protection"/>
+        <ECEnumerator name="NonPotable" value="1" displayLabel="NonPotable"/>
+        <ECEnumerator name="Potable" value="2" displayLabel="Potable"/>
+        <ECEnumerator name="Raw_Water" value="3" displayLabel="Raw Water"/>
+        <ECEnumerator name="Salt_Water" value="4" displayLabel="Salt Water"/>
+        <ECEnumerator name="Treated_Water" value="5" displayLabel="Treated Water"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WaterNode_NetworkDataAspect_WaterNodeType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Back_Flow_Prevention_Device" value="0" displayLabel="Back Flow Prevention Device"/>
+        <ECEnumerator name="Control_Valve" value="1" displayLabel="Control Valve"/>
+        <ECEnumerator name="Fitting" value="2" displayLabel="Fitting"/>
+        <ECEnumerator name="Hydrant" value="3" displayLabel="Hydrant"/>
+        <ECEnumerator name="Meter_Point" value="4" displayLabel="Meter Point"/>
+        <ECEnumerator name="Pressure_Reducing_Station" value="5" displayLabel="Pressure Reducing Station"/>
+        <ECEnumerator name="Production_Structure" value="6" displayLabel="Production Structure"/>
+        <ECEnumerator name="Pump" value="7" displayLabel="Pump"/>
+        <ECEnumerator name="Relief_Valve" value="8" displayLabel="Relief Valve"/>
+        <ECEnumerator name="Storage_Structure" value="9" displayLabel="Storage Structure"/>
+        <ECEnumerator name="System_Valve" value="10" displayLabel="System Valve"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WaterSegment_NetworkDataAspect_WaterConduitType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pressure_Pipe" value="0" displayLabel="Pressure Pipe"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WaterSegment_NetworkDataAspect_WaterNetworkType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Fire_Protection" value="0" displayLabel="Fire Protection"/>
+        <ECEnumerator name="NonPotable" value="1" displayLabel="NonPotable"/>
+        <ECEnumerator name="Potable" value="2" displayLabel="Potable"/>
+        <ECEnumerator name="Raw_Water" value="3" displayLabel="Raw Water"/>
+        <ECEnumerator name="Salt_Water" value="4" displayLabel="Salt Water"/>
+        <ECEnumerator name="Treated_Water" value="5" displayLabel="Treated Water"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEnumeration typeName="WaterSegment_NetworkDataAspect_WaterSegmentType_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Main_Line" value="0" displayLabel="Main Line"/>
+        <ECEnumerator name="Service_Line" value="1" displayLabel="Service Line"/>
+        <ECEnumerator name="User_Defined" value="100" displayLabel="User Defined"/>
+    </ECEnumeration>
+    <ECEntityClass typeName="BaseLink_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HMIGeometryScaledLength" typeName="double" displayLabel="Length (Scaled)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HmiDataSetGeometry_AuthorityDescription" typeName="string" displayLabel="Authority Description" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="QualityLevel" typeName="BaseLink_HmiDataSetGeometryAspect_QualityLevel_Enum" displayLabel="Quality Level" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="InvestigationLevel" typeName="BaseLink_HmiDataSetGeometryAspect_InvestigationLevel_Enum" displayLabel="Investigation Level" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="Authority" typeName="BaseLink_HmiDataSetGeometryAspect_Authority_Enum" displayLabel="Authority" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="HmiDataSetGeometry_StartX" typeName="double" displayLabel="X (Start)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HmiDataSetGeometry_StartY" typeName="double" displayLabel="Y (Start)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HmiDataSetGeometry_EndX" typeName="double" displayLabel="X (End)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="HmiDataSetGeometry_EndY" typeName="double" displayLabel="Y (End)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="NetworkData_UtilityOwner" typeName="string" displayLabel="Owner" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="NetworkData_UserDefinedElementType" typeName="string" displayLabel="Element Type (User Defined)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="NetworkData_UserDefinedNetworkType" typeName="string" displayLabel="Network Type (User Defined)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="UtiltityOperationalStatus" typeName="BaseLink_NetworkDataAspect_UtiltityOperationalStatus_Enum" displayLabel="Operational Status" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="NetworkData_UserDefinedConduitType" typeName="string" displayLabel="Conduit Type (User Defined)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_Physical_SegmentShapeTypeAspect" modifier="Abstract">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SegmentShapeType" typeName="BaseLink_Physical_SegmentShapeTypeAspect_SegmentShapeType_Enum" displayLabel="Shape" category="Utility_Footprint_Utilities_Utility_Footprint_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_Physical_SegmentShapeType_CircularAspect">
+        <BaseClass>BaseLink_Physical_SegmentShapeTypeAspect</BaseClass>
+        <ECProperty propertyName="SegmentDiameter" typeName="double" displayLabel="Diameter" category="Utility_Footprint_Utilities_Utility_Footprint_Utilities" priority="0" kindOfQuantity="cifu:LENGTH_DIAMETER"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_Physical_SegmentShapeType_NonCircularAspect">
+        <BaseClass>BaseLink_Physical_SegmentShapeTypeAspect</BaseClass>
+        <ECProperty propertyName="SegmentRise" typeName="double" displayLabel="Rise" category="Utility_Footprint_Utilities_Utility_Footprint_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="SegmentSpan" typeName="double" displayLabel="Span" category="Utility_Footprint_Utilities_Utility_Footprint_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLink_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Physical_UpstreamInvert" typeName="double" displayLabel="Invert (Start)" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_DownstreamInvert" typeName="double" displayLabel="Invert (Stop)" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_CalculatedSlope" typeName="double" displayLabel="Slope (Calculated)" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:SLOPE"/>
+        <ECProperty propertyName="Physical_ConduitUnitLength" typeName="double" displayLabel="Unit Length" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinkMicroStationID" typeName="string" displayLabel="MicroStation 3D ID" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="LinkWallThickness" typeName="double" displayLabel="Wall Thickness" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LinkMicroStation2dID" typeName="string" displayLabel="MicroStation 2D ID" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="Physical_SetInvertToDownstream" typeName="boolean" displayLabel="Set Invert to Stop?" category="Physical_Utilities_Physical_Utilities" priority="0"/>
+        <ECProperty propertyName="Physical_SetInvertToUpstream" typeName="boolean" displayLabel="Set Invert to Start?" category="Physical_Utilities_Physical_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="GlobalBase_SUE_Aspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElementID" typeName="int" displayLabel="ID" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="Label" typeName="string" displayLabel="Label" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="Notes" typeName="string" displayLabel="Notes" category="General_Utilities_General_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseLinkAspect">
+        <BaseClass>GlobalBase_SUE_Aspect</BaseClass>
+        <ECProperty propertyName="ElevationReference" typeName="string" displayLabel="Elevation Reference" category="References_Utilities_References_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="HmiDataSetGeometry_AuthorityDescription" typeName="string" displayLabel="Authority Description" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="QualityLevel" typeName="BaseNode_HmiDataSetGeometryAspect_QualityLevel_Enum" displayLabel="Quality Level" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="InvestigationLevel" typeName="BaseNode_HmiDataSetGeometryAspect_InvestigationLevel_Enum" displayLabel="Investigation Level" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="Authority" typeName="BaseNode_HmiDataSetGeometryAspect_Authority_Enum" displayLabel="Authority" category="Utility_Quality_Utilities_Utility_Quality_Utilities" priority="0"/>
+        <ECProperty propertyName="HmiDataSetGeometry_NodeRotation" typeName="double" displayLabel="Node Rotation" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="LocationPointX" typeName="double" displayLabel="Location Point X" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LocationPointY" typeName="double" displayLabel="Location Point Y" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LocationPointFeature" typeName="string" displayLabel="Location Point Feature" category="References_Utilities_References_Utilities" priority="0"/>
+        <ECProperty propertyName="LocationPointStation" typeName="double" displayLabel="Location Point Station" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="LocationPointOffset" typeName="double" displayLabel="Location Point Offset" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="VerticalOffset" typeName="double" displayLabel="Vertical Offset" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="AbsoluteRotation" typeName="double" displayLabel="Absolute Rotation" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:ANGLE"/>
+        <ECProperty propertyName="RotationFeature" typeName="string" displayLabel="Rotation Feature" category="References_Utilities_References_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="NetworkData_UtilityOwner" typeName="string" displayLabel="Owner" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="NetworkData_UserDefinedElementType" typeName="string" displayLabel="Element Type (User Defined)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="NetworkData_UserDefinedNetworkType" typeName="string" displayLabel="Network Type (User Defined)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="UtiltityOperationalStatus" typeName="BaseNode_NetworkDataAspect_UtiltityOperationalStatus_Enum" displayLabel="Operational Status" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNode_PhysicalAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="NodeLength" typeName="double" displayLabel="Length" category="Utility_Footprint_Utilities_Utility_Footprint_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="NodeWidth" typeName="double" displayLabel="Width" category="Utility_Footprint_Utilities_Utility_Footprint_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Physical_Elevation" typeName="double" displayLabel="Elevation" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="Physical_TopElevation" typeName="double" displayLabel="Elevation (Top)" category="Physical_Utilities_Physical_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="NodeMicroStationID" typeName="string" displayLabel="MicroStation 3D ID" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="NodeMicroStation2dID" typeName="string" displayLabel="MicroStation 2D ID" category="General_Utilities_General_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="BaseNodeAspect">
+        <BaseClass>GlobalBase_SUE_Aspect</BaseClass>
+        <ECProperty propertyName="BaselineFeature" typeName="string" displayLabel="Baseline Feature" category="References_Utilities_References_Utilities" priority="0"/>
+        <ECProperty propertyName="BaselineOffset" typeName="double" displayLabel="Baseline Offset" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="BaselineStation" typeName="double" displayLabel="Baseline Station" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="ElevationReference" typeName="string" displayLabel="Elevation Reference" category="References_Utilities_References_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CommunicationNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CommunicationNetworkType" typeName="CommunicationNode_NetworkDataAspect_CommunicationNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="CommNodeType" typeName="CommunicationNode_NetworkDataAspect_CommNodeType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CommunicationNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="CommunicationSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="CommunicationNetworkType" typeName="CommunicationSegment_NetworkDataAspect_CommunicationNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="CommSegmentType" typeName="CommunicationSegment_NetworkDataAspect_CommSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ComConduitType" typeName="CommunicationSegment_NetworkDataAspect_ComConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="CommunicationSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConflictNode_ConflictAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="Conflict_StartStation" typeName="double" displayLabel="Station (Start)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Conflict_StopStation" typeName="double" displayLabel="Station (Stop)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:STATION"/>
+        <ECProperty propertyName="Conflict_LeftOffset" typeName="double" displayLabel="Offset (Left)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Conflict_RightOffset" typeName="double" displayLabel="Offset (Right)" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="Conflict_ResponsibleParty" typeName="string" displayLabel="Responsible Party" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="Conflict_Conflicter" typeName="int" displayLabel="Feature A" category="Utility_Data_Subsurface_Utilities_Utility_Data_Subsurface_Utilities" priority="0"/>
+        <ECProperty propertyName="Conflict_Conflictee" typeName="int" displayLabel="Feature B" category="Utility_Data_Subsurface_Utilities_Utility_Data_Subsurface_Utilities" priority="0"/>
+        <ECProperty propertyName="Conflict_Elevation" typeName="double" displayLabel="Elevation" category="Geometry_Utilities_Geometry_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="CurrentStatus" typeName="ConflictNode_ConflictAspect_CurrentStatus_Enum" displayLabel="Current Status" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="RecommendedResolution" typeName="ConflictNode_ConflictAspect_RecommendedResolution_Enum" displayLabel="Recommended Resolution" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="OtherResolutionDescription" typeName="string" displayLabel="Other Resolution Description" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ConflictType" typeName="ConflictNode_ConflictAspect_ConflictType_Enum" displayLabel="Conflict Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="RequiresTestHole" typeName="boolean" displayLabel="Requires Test Hole?" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="NodeMicroStationID" typeName="string" displayLabel="MicroStation 3D ID" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="NodeMicroStation2dID" typeName="string" displayLabel="MicroStation 2D ID" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="ConflicteeName" typeName="string" displayLabel="Conflictee (Feature A)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ConflicterName" typeName="string" displayLabel="Conflicter (Feature B)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConflictNode_HmiDataSetGeometryAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="FeatureA_QualityLevel" typeName="ConflictNode_HmiDataSetGeometryAspect_FeatureA_QualityLevel_Enum" displayLabel="Quality Level (Feature A)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="FeatureB_QualityLevel" typeName="ConflictNode_HmiDataSetGeometryAspect_FeatureB_QualityLevel_Enum" displayLabel="Quality Level (Feature B)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ConflictNodeAspect">
+        <BaseClass>GlobalBase_SUE_Aspect</BaseClass>
+        <ECProperty propertyName="BaselineFeature" typeName="string" displayLabel="Baseline Feature" category="References_Utilities_References_Utilities" priority="0"/>
+        <ECProperty propertyName="BaselineOffset" typeName="double" displayLabel="Baseline Offset" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="BaselineStation" typeName="double" displayLabel="Baseline Station" category="References_Utilities_References_Utilities" priority="0" kindOfQuantity="cifu:ELEVATION"/>
+        <ECProperty propertyName="ElevationReference" typeName="string" displayLabel="Elevation Reference" category="References_Utilities_References_Utilities" priority="0"/>
+        <ECProperty propertyName="FeatureDefinitionA" typeName="string" displayLabel="Feature Definition (A)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="FeatureDefinitionB" typeName="string" displayLabel="Feature Definition (B)" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ElectricalNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElectricNetworkType" typeName="ElectricalNode_NetworkDataAspect_ElectricNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ElectricNodeDataType" typeName="ElectricalNode_NetworkDataAspect_ElectricNodeDataType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ElectricalNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="ElectricalSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ElectricNetworkType" typeName="ElectricalSegment_NetworkDataAspect_ElectricNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ElectricSegmentType" typeName="ElectricalSegment_NetworkDataAspect_ElectricSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ElectricConduitType" typeName="ElectricalSegment_NetworkDataAspect_ElectricConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="ElectricalSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_Physical_SegmentShapeType_CircularAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_Physical_SegmentShapeType_CircularAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_Physical_SegmentShapeType_NonCircularAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_Physical_SegmentShapeType_NonCircularAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLink_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLink_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseLinkAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseLinkAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNode_PhysicalAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNode_PhysicalAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsBaseNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="BaseNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCommunicationNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CommunicationNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCommunicationNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CommunicationNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCommunicationSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CommunicationSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsCommunicationSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="CommunicationSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConflictNode_ConflictAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConflictNode_ConflictAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConflictNode_HmiDataSetGeometryAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConflictNode_HmiDataSetGeometryAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsConflictNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConflictNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsElectricalNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ElectricalNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsElectricalNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ElectricalNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsElectricalSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ElectricalSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsElectricalSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ElectricalSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GasNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GasNetworkType" typeName="GasNode_NetworkDataAspect_GasNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="GasNodeType" typeName="GasNode_NetworkDataAspect_GasNodeType_Enum" displayLabel="Gas Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGasNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GasNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GasNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGasNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GasNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GasSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="GasNetworkType" typeName="GasSegment_NetworkDataAspect_GasNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="GasSegmentType" typeName="GasSegment_NetworkDataAspect_GasSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="GasConduitType" typeName="GasSegment_NetworkDataAspect_GasConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGasSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GasSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GasSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGasSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GasSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GenericNodeAssetAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGenericNodeAssetAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GenericNodeAssetAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="GenericSegmentAssetAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsGenericSegmentAssetAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GenericSegmentAssetAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECRelationshipClass typeName="ElementOwnsGlobalBase_SUE_Aspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GlobalBase_SUE_Aspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="POLNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="POLNetworkType" typeName="POLNode_NetworkDataAspect_POLNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="POLNodeType" typeName="POLNode_NetworkDataAspect_POLNodeType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPOLNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="POLNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="POLNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPOLNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="POLNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="POLSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="POLNetworkType" typeName="POLSegment_NetworkDataAspect_POLNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="POLSegmentType" typeName="POLSegment_NetworkDataAspect_POLSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="POLConduitType" typeName="POLSegment_NetworkDataAspect_POLConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPOLSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="POLSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="POLSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsPOLSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="POLSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ReferenceDomainElementAspect">
+        <BaseClass>GlobalBase_SUE_Aspect</BaseClass>
+        <ECProperty propertyName="DataSourceType" typeName="ReferenceDomainElementAspect_DataSourceType_Enum" displayLabel="Data Source Type" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="ReferenceDomainElement_DataSource" typeName="string" displayLabel=" Data Source" category="General_Utilities_General_Utilities" priority="0"/>
+        <ECProperty propertyName="ReferenceDomainElement_DataSourceID" typeName="string" displayLabel="Data Source ID" category="General_Utilities_General_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsReferenceDomainElementAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ReferenceDomainElementAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StormWaterNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StormNetworkType" typeName="StormWaterNode_NetworkDataAspect_StormNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="StormWaterNodeType" typeName="StormWaterNode_NetworkDataAspect_StormWaterNodeType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStormWaterNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StormWaterNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StormWaterNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStormWaterNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StormWaterNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StormWaterSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="StormNetworkType" typeName="StormWaterSegment_NetworkDataAspect_StormNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="StormWaterSegmentType" typeName="StormWaterSegment_NetworkDataAspect_StormWaterSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="StormWaterConduitType" typeName="StormWaterSegment_NetworkDataAspect_StormWaterConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStormWaterSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StormWaterSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="StormWaterSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsStormWaterSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="StormWaterSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ThermalNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ThermalNetworkType" typeName="ThermalNode_NetworkDataAspect_ThermalNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ThermalNodeType" typeName="ThermalNode_NetworkDataAspect_ThermalNodeType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsThermalNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ThermalNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ThermalNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsThermalNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ThermalNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ThermalSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="ThermalNetworkType" typeName="ThermalSegment_NetworkDataAspect_ThermalNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ThermalSegmentType" typeName="ThermalSegment_NetworkDataAspect_ThermalSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="ThermalConduitType" typeName="ThermalSegment_NetworkDataAspect_ThermalConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsThermalSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ThermalSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="ThermalSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsThermalSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ThermalSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WasteWaterNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WasteWaterNetworkType" typeName="WasteWaterNode_NetworkDataAspect_WasteWaterNetworkType_Enum" displayLabel="Waste Water Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="WasteWaterNodeType" typeName="WasteWaterNode_NetworkDataAspect_WasteWaterNodeType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWasteWaterNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WasteWaterNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WasteWaterNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWasteWaterNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WasteWaterNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WasteWaterSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WasteWaterNetworkType" typeName="WasteWaterSegment_NetworkDataAspect_WasteWaterNetworkType_Enum" displayLabel="Waste Water Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="WasteWaterSegmentType" typeName="WasteWaterSegment_NetworkDataAspect_WasteWaterSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="WasteWaterConduitType" typeName="WasteWaterSegment_NetworkDataAspect_WasteWaterConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWasteWaterSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WasteWaterSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WasteWaterSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWasteWaterSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WasteWaterSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WaterNode_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterNetworkType" typeName="WaterNode_NetworkDataAspect_WaterNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="WaterNodeType" typeName="WaterNode_NetworkDataAspect_WaterNodeType_Enum" displayLabel="Node Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWaterNode_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WaterNode_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WaterNodeAspect">
+        <BaseClass>BaseNodeAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWaterNodeAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WaterNodeAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WaterSegment_NetworkDataAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="WaterNetworkType" typeName="WaterSegment_NetworkDataAspect_WaterNetworkType_Enum" displayLabel="Network Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="WaterSegmentType" typeName="WaterSegment_NetworkDataAspect_WaterSegmentType_Enum" displayLabel="Function" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+        <ECProperty propertyName="WaterConduitType" typeName="WaterSegment_NetworkDataAspect_WaterConduitType_Enum" displayLabel="Conduit Type" category="Utility_Data_Utilities_Utility_Data_Utilities" priority="0"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWaterSegment_NetworkDataAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WaterSegment_NetworkDataAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="WaterSegmentAspect">
+        <BaseClass>BaseLinkAspect</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsWaterSegmentAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="WaterSegmentAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <PropertyCategory typeName="Connecting_Links_Utilities_Connecting_Links_Utilities" description="Connecting Links [Utilities]" displayLabel="Connecting Links [Utilities]" priority="4294888096"/>
+    <PropertyCategory typeName="General_Subsurface_Utilities_General_Subsurface_Utilities" description="&lt;General&gt; [Subsurface Utilities]" displayLabel="&lt;General&gt; [Subsurface Utilities]" priority="4294899186"/>
+    <PropertyCategory typeName="General_Utilities_General_Utilities" description="&lt;General&gt; [Utilities]" displayLabel="&lt;General&gt; [Utilities]" priority="4294899186"/>
+    <PropertyCategory typeName="Geometry_Subsurface_Utilities_Geometry_Subsurface_Utilities" description="&lt;Geometry&gt; [Subsurface Utilities]" displayLabel="&lt;Geometry&gt; [Subsurface Utilities]" priority="4294899186"/>
+    <PropertyCategory typeName="Geometry_Utilities_Geometry_Utilities" description="&lt;Geometry&gt; [Utilities]" displayLabel="&lt;Geometry&gt; [Utilities]" priority="4294899186"/>
+    <PropertyCategory typeName="Physical_Subsurface_Utilities_Physical_Subsurface_Utilities" description="Physical [Subsurface Utilities]" displayLabel="Physical [Subsurface Utilities]" priority="4294875686"/>
+    <PropertyCategory typeName="Physical_Utilities_Physical_Utilities" description="Physical [Utilities]" displayLabel="Physical [Utilities]" priority="4294875686"/>
+    <PropertyCategory typeName="References_Subsurface_Utilities_References_Subsurface_Utilities" description="References [Subsurface Utilities]" displayLabel="References [Subsurface Utilities]" priority="4294874176"/>
+    <PropertyCategory typeName="References_Utilities_References_Utilities" description="References [Utilities]" displayLabel="References [Utilities]" priority="4294874176"/>
+    <PropertyCategory typeName="Utility_Data_Subsurface_Utilities_Utility_Data_Subsurface_Utilities" description="Utility Data [Subsurface Utilities]" displayLabel="Utility Data [Subsurface Utilities]" priority="4294869646"/>
+    <PropertyCategory typeName="Utility_Data_Utilities_Utility_Data_Utilities" description="Utility Data [Utilities]" displayLabel="Utility Data [Utilities]" priority="4294869646"/>
+    <PropertyCategory typeName="Utility_Footprint_Subsurface_Utilities_Utility_Footprint_Subsurface_Utilities" description="Utility Footprint [Subsurface Utilities]" displayLabel="Utility Footprint [Subsurface Utilities]" priority="4294869646"/>
+    <PropertyCategory typeName="Utility_Footprint_Utilities_Utility_Footprint_Utilities" description="Utility Footprint [Utilities]" displayLabel="Utility Footprint [Utilities]" priority="4294869646"/>
+    <PropertyCategory typeName="Utility_Quality_Subsurface_Utilities_Utility_Quality_Subsurface_Utilities" description="Utility Quality [Subsurface Utilities]" displayLabel="Utility Quality [Subsurface Utilities]" priority="4294869646"/>
+    <PropertyCategory typeName="Utility_Quality_Utilities_Utility_Quality_Utilities" description="Utility Quality [Utilities]" displayLabel="Utility Quality [Utilities]" priority="4294869646"/>
+</ECSchema>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -2859,7 +2859,7 @@
       "name": "CifBridge",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifBridge.ecschema.xml",
       "released": false,
-      "version": "01.00.08",
+      "version": "01.00.09",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -2978,6 +2978,20 @@
       "date": "11/30/2022",
       "dynamic": "No",
       "approved": "Yes"
+    },
+    {
+      "name": "CifBridge",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifBridge.01.00.08.ecschema.xml",
+      "released": true,
+      "version": "01.00.08",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "becd987102bca3d5d9d1c178cdcaf1e17d21851e",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "CifCommon": [
@@ -2985,7 +2999,7 @@
       "name": "CifCommon",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifCommon.ecschema.xml",
       "released": false,
-      "version": "01.00.05",
+      "version": "01.00.06",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3062,6 +3076,20 @@
       "date": "11/30/2022",
       "dynamic": "No",
       "approved": "Yes"
+    },
+    {
+      "name": "CifCommon",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifCommon.01.00.05.ecschema.xml",
+      "released": true,
+      "version": "01.00.05",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "2dd5a51791f7498df858118940931a6477af2928",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "CifGeometricRules": [
@@ -3069,7 +3097,7 @@
       "name": "CifGeometricRules",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifGeometricRules.ecschema.xml",
       "released": false,
-      "version": "01.00.03",
+      "version": "01.00.04",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3118,6 +3146,20 @@
       "date": "11/30/2022",
       "dynamic": "No",
       "approved": "Yes"
+    },
+    {
+      "name": "CifGeometricRules",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifGeometricRules.01.00.03.ecschema.xml",
+      "released": true,
+      "version": "01.00.03",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "4b3163c9b82064974634eed74c51cf39fdae79b8",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "CifHydraulicAnalysis": [
@@ -3125,7 +3167,7 @@
       "name": "CifHydraulicAnalysis",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifHydraulicAnalysis.ecschema.xml",
       "released": false,
-      "version": "01.00.05",
+      "version": "01.00.06",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3202,6 +3244,20 @@
       "date": "11/30/2022",
       "dynamic": "No",
       "approved": "Yes"
+    },
+    {
+      "name": "CifHydraulicAnalysis",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifHydraulicAnalysis.01.00.05.ecschema.xml",
+      "released": true,
+      "version": "01.00.05",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "1398f03353b40d91ea55433ae0ab807d7f2fe00b",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "CifHydraulicResults": [
@@ -3209,7 +3265,7 @@
       "name": "CifHydraulicResults",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifHydraulicResults.ecschema.xml",
       "released": false,
-      "version": "01.00.05",
+      "version": "01.00.06",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3284,6 +3340,20 @@
       "verified": "Yes",
       "author": "Jonathan.DeCarlo",
       "date": "11/30/2022",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "CifHydraulicResults",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifHydraulicResults.01.00.05.ecschema.xml",
+      "released": true,
+      "version": "01.00.05",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "c65eeaa00cda04762e45d2529e4ce4ace1a09a73",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
       "dynamic": "No",
       "approved": "Yes"
     }
@@ -3391,7 +3461,7 @@
       "name": "CifSubsurface",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifSubsurface.ecschema.xml",
       "released": false,
-      "version": "01.00.05",
+      "version": "01.00.06",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3468,6 +3538,20 @@
       "date": "11/30/2022",
       "dynamic": "No",
       "approved": "Yes"
+    },
+    {
+      "name": "CifSubsurface",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifSubsurface.01.00.05.ecschema.xml",
+      "released": true,
+      "version": "01.00.05",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "3acdbed5d01fba36cb66822d1050267c9857f8c6",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "CifSubsurfaceConflictAnalysis": [
@@ -3475,7 +3559,7 @@
       "name": "CifSubsurfaceConflictAnalysis",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifSubsurfaceConflictAnalysis.ecschema.xml",
       "released": false,
-      "version": "01.00.05",
+      "version": "01.00.06",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3550,6 +3634,20 @@
       "verified": "Yes",
       "author": "Jonathan.DeCarlo",
       "date": "11/30/2022",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "CifSubsurfaceConflictAnalysis",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifSubsurfaceConflictAnalysis.01.00.05.ecschema.xml",
+      "released": true,
+      "version": "01.00.05",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "5fad4b42f813f222da41578ff59a9c178765ff86",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
       "dynamic": "No",
       "approved": "Yes"
     }
@@ -3727,7 +3825,7 @@
       "name": "CifRail",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifRail.ecschema.xml",
       "released": false,
-      "version": "01.00.04",
+      "version": "01.00.05",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3788,6 +3886,20 @@
       "verified": "Yes",
       "author": "Jonathan.DeCarlo",
       "date": "11/30/2022",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "CifRail",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifRail.01.00.04.ecschema.xml",
+      "released": true,
+      "version": "01.00.04",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "17d0163c0275815f9571021ff641df885be732bb",
+      "verified": "Yes",
+      "author": "Jonathan.DeCarlo",
+      "date": "2/7/2023",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
Release of new versions of the following Civil Connector application schemas:

CifBridge (01.00.08)
CifCommon (01.00.05)
CifGeometricRules (01.00.03)
CifHydraulicAnalysis (01.00.05)
CifHydraulicResults (01.00.05)
CifRail (01.00.04)
CifSubsurface (01.00.05)
CifSubsurfaceConflictAnalysis (01.00.05)