### PR TITLE
Revert StructuralAnalysis version number back to 01.00.02

### DIFF
--- a/Domains/3-DisciplineOther/StructuralAnalysis/StructuralAnalysis.ecschema.xml
+++ b/Domains/3-DisciplineOther/StructuralAnalysis/StructuralAnalysis.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="StructuralAnalysis" alias="sa" version="01.00.03" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="Structural Analysis" description="Structural Analysis Schema.">
+<ECSchema schemaName="StructuralAnalysis" alias="sa" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="Structural Analysis" description="Structural Analysis Schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -586,7 +586,7 @@
       "name": "StructuralAnalysis",
       "path": "Domains\\3-DisciplineOther\\StructuralAnalysis\\StructuralAnalysis.ecschema.xml",
       "released": false,
-      "version": "01.00.03",
+      "version": "01.00.02",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",


### PR DESCRIPTION
01.00.02 was never released.
01.00.02 dev schema version was updated to 01.00.03 unintentionally. This PR just reverts the version back to unreleased 01.00.02