### PR TITLE
Skip `Rush Audit` Step for iTwinjs-Core Tests and Docs Pipelines

### DIFF
--- a/tools/MarkdownGeneration/generate-docs.yaml
+++ b/tools/MarkdownGeneration/generate-docs.yaml
@@ -174,4 +174,5 @@ stages:
     - template: common/config/azure-pipelines/jobs/docs-build.yaml@itwinjs-core
       parameters:
         checkout: itwinjs-core
+        ignoreAudit: true
         useCurrentBisDocsArtifact: true

--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -219,6 +219,7 @@ stages:
     - template: common/config/azure-pipelines/templates/core-build.yaml@itwinjs-core
       parameters:
         nodeVersion: 18.12.x
+        runRushAudit: false
         rushBuildCacheEnabled: 0
 
 - stage: iModeEvolution


### PR DESCRIPTION
To avoid unnecessary blockage of PR's, we are skipping this step.