### PR TITLE
Fixes to md level formatting in remarks.

### DIFF
--- a/Domains/1-Common/ClassificationSystems/ClassificationSystems.remarks.md
+++ b/Domains/1-Common/ClassificationSystems/ClassificationSystems.remarks.md
@@ -11,7 +11,9 @@ In BIS, a [ClassificationSystem](#classificationsystem) consists of one or more 
 
 ![Class and Instance Diagrams](./media/classification-systems.png)
 
-## ClassificationSystem
+## Entity Classes
+
+### ClassificationSystem
 
 `ClassificationSystem` identifies the classification system to which the individual `Classifications` belong.
 For well-known and externally defined standards, the name (CodeValue) is typically enough to identify the classification system. A consuming application just needs to create or use an instance with the appropriate name. For these cases, the `ClassificationSystem` class can be used directly.
@@ -28,17 +30,9 @@ See [Overview](#classificationsystems).
 
 It is expected that any iModel will not contain all known classification systems. Instead, an iModel will only contain those classification systems that are used by that iModel and possibly only those parts of the classification system hierarchy that are used.
 
-### Mapping to and from IFC
+The combination of a `ClassificationSystem` and a `ClassificationTable` are equivalent to [IfcClassification](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcClassification.htm).
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `ClassificationTable` + `ClassificationSystem`  | (none) | `IfcClassification` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcClassification` | (none) | `ClassificationTable` + `ClassificationSystem` | (none) |
-
-## ClassificationTable
+### ClassificationTable
 
 `ClassificationTable` defines a table in a `ClassificationSystem` as defined in the original ClassificationSystem source. A Classification Table represents a division of classification system into classifications for different purposes.
 
@@ -52,17 +46,9 @@ A `ClassificationTable` will contain `Classification` and `ClassificationGroup` 
 
 See [Overview](#classificationsystems).
 
-### Mapping to and from IFC
+The combination of a `ClassificationSystem` and a `ClassificationTable` are equivalent to [IfcClassification](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcClassification.htm).
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `ClassificationTable` + `ClassificationSystem`  | (none) | `IfcClassification` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcClassification` | (none) | `ClassificationTable` + `ClassificationSystem` | (none) |
-
-## ClassificationGroup
+### ClassificationGroup
 
 A `ClassificationGroup` is a group of `Classification` elements, as grouped originally in the source classification system. The `Classification` elements are assigned to a group via `ClassificationGroupGroupsClassifications` relationship.
 
@@ -72,11 +58,9 @@ A `ClassificationGroup` element is intended to be persisted in a `bis:Definition
 
 See [Overview](#classificationsystems).
 
-### Mapping to and from IFC
-
 Is not mapped to or from IFC, as the group concept does not exist in IFC
 
-## Classification
+### Classification
 
 A `Classification` element represents one 'class' or 'category' into which the classification system classifies real-world Objects.
 
@@ -98,16 +82,8 @@ An element may be classified as multiple Classifications through the `ElementHas
 
 See [Overview](#classificationsystems).
 
-### Mapping to and from IFC
+Equivalent to [IfcClassificationReference](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcClassificationReference.htm).
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `Classification`  | (none) | `IfcClassificationReference` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcClassificationReference` | (none) | `Classification` | (none) |
-
-## ClassificationSystemOwnsClassificationTable
+### ClassificationSystemOwnsClassificationTable
 
 Following the naming convention, this relationship class should have been named `ClassificationSystemOwnsClassificationTables` (plural), but was released with the a non-compliant name that would be disruptive to change post-release.

--- a/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
+++ b/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
@@ -40,11 +40,11 @@ It defines occurence of any HVAC, electrical, sanitary or other element within a
 
 Equivalent to [IfcDistributionElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionElement.htm).
 
-The distribution element should be assigned to the finest granularity [SpatialStructureElement](./SpatialComposition.remarks.md#SpatialStructureElement) element it is fully contained in.
+The distribution element should be assigned to the finest granularity `SpatialComposition.SpatialStructureElement` element it is fully contained in.
 
-- [Space](./BuildingSpatial.remarks.md#Space) is the default container for a distributionElement
-- [Story](./BuildingSpatial.remarks.md#Story) is the container if distribution element spans multiple spaces
-- [Building](./BuildingSpatial.remarks.md#Building) is the default container when a distribution element spans multiple stories.
+- `BuildingSpatial.Space` is the default container for a distributionElement
+- `BuildingSpatial.Story` is the container if distribution element spans multiple spaces
+- `BuildingSpatial.Building` is the default container when a distribution element spans multiple stories.
 
 ### IDistributionFlowElement
 

--- a/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
+++ b/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
@@ -27,7 +27,7 @@ Equivalent to [IfcDistributionSystem](https://standards.buildingsmart.org/IFC/RE
 
 ### IDistributionElement
 
-`IDistributionElement`` is a generalization of all elements that participate in a distribution system. Typical examples of IDistributionElement are (among others):
+`IDistributionElement` is a generalization of all elements that participate in a distribution system. Typical examples of IDistributionElement are (among others):
 
 - elements within heating systems
 - elements within cooling systems

--- a/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
+++ b/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
@@ -40,11 +40,11 @@ It defines occurence of any HVAC, electrical, sanitary or other element within a
 
 Equivalent to [IfcDistributionElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionElement.htm).
 
-The distribution element should be assigned to the finest granularity `SpatialComposition.SpatialStructureElement` element it is fully contained in.
+The distribution element should be assigned to the finest granularity [SpatialStructureElement](./spatialcomposition.ecschema/#spatialstructureelement) element it is fully contained in.
 
-- `BuildingSpatial.Space` is the default container for a distributionElement
-- `BuildingSpatial.Story` is the container if distribution element spans multiple spaces
-- `BuildingSpatial.Building` is the default container when a distribution element spans multiple stories.
+- [Space](./buildingspatial.ecschema/#space) is the default container for a distributionElement
+- [Story](./buildingspatial.ecschema/#story) is the container if distribution element spans multiple spaces
+- [Building](./buildingspatial.ecschema/#building) is the default container when a distribution element spans multiple stories.
 
 ### IDistributionFlowElement
 

--- a/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
+++ b/Domains/1-Common/DistributionSystems/DistributionSystems.remarks.md
@@ -15,25 +15,19 @@ Connection point information will be added in subsequent versions of the schema.
 
 ![Class and Instance Diagrams](./media/distributionsystems.png)
 
-## DistributionSystem
+## Entity Classes
+
+### DistributionSystem
 
 A common example is a heating hot water system that consists of a pump, a tank, and an interconnected piping system for distributing hot water to terminals.
 
 A DistributionSystem groups [DistributionElements](#IDistributionElement) via the `DistributionSystemGroupsDistributionElements` relationship.
 
-### Mapping to and from IFC
+Equivalent to [IfcDistributionSystem](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionSystem.htm).
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `DistributionSystem`  | (none) | `IfcDistributionSystem` | (none) |
+### IDistributionElement
 
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcDistributionSystem` | (none) | `DistributionSystem` | (none) |
-
-## IDistributionElement
-
-IDistributionElement is a generalization of all elements that participate in a distribution system. Typical examples of IDistributionElement are (among others):
+`IDistributionElement`` is a generalization of all elements that participate in a distribution system. Typical examples of IDistributionElement are (among others):
 
 - elements within heating systems
 - elements within cooling systems
@@ -44,17 +38,7 @@ IDistributionElement is a generalization of all elements that participate in a d
 
 It defines occurence of any HVAC, electrical, sanitary or other element within a distribution system.
 
-### Mapping to and from IFC
-
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `IDistributionElement`  | (none) | `IfcDistributionElement` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcDistributionElement` | (none) | `IDistributionElement` | (none) |
-
-### Spatial Containment
+Equivalent to [IfcDistributionElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionElement.htm).
 
 The distribution element should be assigned to the finest granularity [SpatialStructureElement](./SpatialComposition.remarks.md#SpatialStructureElement) element it is fully contained in.
 
@@ -62,85 +46,41 @@ The distribution element should be assigned to the finest granularity [SpatialSt
 - [Story](./BuildingSpatial.remarks.md#Story) is the container if distribution element spans multiple spaces
 - [Building](./BuildingSpatial.remarks.md#Building) is the default container when a distribution element spans multiple stories.
 
-## IDistributionFlowElement
+### IDistributionFlowElement
 
 See [DistributionSystems](#distributionsystems).
 
-### Mapping to and from IFC
+Equivalent to [IfcDistributionFlowElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionFlowElement.htm).
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `IDistributionFlowElement`  | (none) | `IfcDistributionFlowElement` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcDistributionFlowElement` | (none) | `IDistributionFlowElement` | (none) |
-
-## IDistributionControlElement
+### IDistributionControlElement
 
 These elements are typically used to control distribution system elements and variables such as temperature, pressure, power, lighting levels and similar.
 
 See [DistributionSystems](#distributionsystems).
 
-### Mapping to and from IFC
+Equivalent to [IfcDistributionControlElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionControlElement.htm) for controlling predefined types.
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `IDistributionControlElement`  | (none) | `IfcDistributionControlElement` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcDistributionControlElement` | (for controlling predefinedtypes) | `IDistributionControlElement` | (none) |
-
-## IDistributionSensorElement
+### IDistributionSensorElement
 
 Distribution sensor elements could be used to measure variables such as temperature, humidity, pressure or flow.
 
 See [DistributionSystems](#distributionsystems).
 
-### Mapping to and from IFC
+Equivalent to [IfcDistributionControlElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionControlElement.htm) for sensing predefined types and <b><u>not</u></b> `IfcSensor`.
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `IDistributionSensorElement` | (none) | `IfcDistributionControlElement` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcDistributionControlElement` | (for sensing predefinedtypes) | `IDistributionSensorElement` | (none) |
-
-`IDistributionSensorElement` maps to `IfcDistributionControlElement` and <b><u>not</u></b> `IfcSensor`.
-
-
-## DistributionPort
+### DistributionPort
 
 A distribution port is a flow connection point of a distribution element through which a particular substance may flow.
 Distribution ports define the physical connection and substance, electricity or data flow points of a distribution flow element. Subclasses of DistributionPort should specialize distributionport in a given domain by adding relevant properties like FlowVolume for plumbing, or RatedVoltage for electrical.
 Ports are similar to openings in that they do not have any visible geometry, such geometry is captured by the parent distribution element. Ports do have placement to indicate position and orientation of the connection.
 Distribution ports are owned by the `DistributionElement` as they are essentially part of the whole definition of the element, similar to openings in a wall. `DistributionElementOwnsDistributionPorts` relationship is used for `DistributionElement` owning `DistributionPorts`.
 
-### Mapping to and from IFC
+Equivalent to [IfcDistributionPort](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcDistributionPort.htm).
 
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `DistributionPort` | (none) | `IfcDistributionPort` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcDistributionPort` | (none) | `DistributionPort` | (none) |
-
-
-## PortConnection
+### PortConnection
 
 A `PortConnection` defines a physical connection between 2 DistributionPorts. In the case where a connection is realized by some other physical element, the realizing element could be found using `PortConnectionIsRealizedByPhysicalElements` relationship.
 
 a PortConnection is always between 2 distribution ports, however this constraint may be removed if a suitable use case is found.
 
-### Mapping to and from IFC
-
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `PortConnection` | (none) | `IfcRelConnectsPorts` | (none) |
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcRelConnectsPorts` | (none) | `PortConnection` | (none) |
+Equivalent to [IfcRelConnectsPorts](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelConnectsPorts.htm).

--- a/Domains/1-Common/LinearReferencing/LinearReferencing.remarks.md
+++ b/Domains/1-Common/LinearReferencing/LinearReferencing.remarks.md
@@ -20,25 +20,25 @@ The following class-diagram depicts the core aspect classes in the LinearReferen
 
 A Linear-Element is a one-dimensional object that serves as the axis along which measurements are made.
 
-Equivalent to [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifclinearpositioningelement.htm).
+Equivalent to [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcLinearPositioningElement.htm).
 
 ### ILinearlyLocated
 
-Implementations of the `ILinearlyLocated` mix-in are equivalent to [IfcLinearPlacement](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifclinearplacement.htm).
+Implementations of the `ILinearlyLocated` mix-in are equivalent to [IfcLinearPlacement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcLinearPlacement.htm).
 
 ### ILinearlyLocatedAlongILinearElement
 
-Equivalent to [IfcProduct.PositionedRelativeTo](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcproduct.htm) referencing an [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifclinearpositioningelement.htm) via [IfcRelPositions.RelatingPositioningElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcrelpositions.htm).
+Equivalent to [IfcProduct.PositionedRelativeTo](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcProduct.htm) referencing an [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcLinearPositioningElement.htm) via [IfcRelPositions.RelatingPositioningElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelPositions.htm).
 
-Note that IFC further requires an individual reference to the appropriate [IfcCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifccurve.htm) from each [IfcPointByDistanceExpression](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpointbydistanceexpression.htm) via its `BasisCurve` attribute. In contrast, the LinearReferencing BIS schema considers such curves an implementation detail behind a concrete `lr:ILinearElement` realization in a particular domain, and therefore, it does not capture it.
+Note that IFC further requires an individual reference to the appropriate [IfcCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCurve.htm) from each [IfcPointByDistanceExpression](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPointByDistanceExpression.htm) via its `BasisCurve` attribute. In contrast, the LinearReferencing BIS schema considers such curves an implementation detail behind a concrete `lr:ILinearElement` realization in a particular domain, and therefore, it does not capture it.
 
 ### ILinearLocationLocatesElement
 
-Equivalent to [IfcLinearPlacement.PlacesObject](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcobjectplacement.htm).
+Equivalent to [IfcLinearPlacement.PlacesObject](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcLinearPlacement.htm).
 
 ### IReferent
 
-Equivalent to [IfcReferent](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcreferent.htm). Note that IfcReferent is an [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifclinearpositioningelement.htm), thus references to it use the same [IfcRelPositions.RelatingPositioningElement] than references to [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifclinearpositioningelement.htm). On the other hand, a `lr:IReferent` is referenced from either a lr:LinearlyReferencedAtLocation or lr:LinearlyReferencedFromToLocation multi-aspects via their corresponding navigation properties.
+Equivalent to [IfcReferent](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcReferent.htm). Note that IfcReferent is an [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcLinearPositioningElement.htm), thus references to it use the same [IfcRelPositions.RelatingPositioningElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelPositions.htm) than references to [IfcLinearPositioningElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcLinearPositioningElement.htm). On the other hand, a `lr:IReferent` is referenced from either a lr:LinearlyReferencedAtLocation or lr:LinearlyReferencedFromToLocation multi-aspects via their corresponding navigation properties.
 
 ### LinearlyLocatedAttribution
 
@@ -46,13 +46,13 @@ Instances of subclasses of `LinearlyLocatedAttribution` must be contained in eit
 
 ### LinearlyReferencedAtLocation
 
-Equivalent to [IfcPointByDistanceExpression](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpointbydistanceexpression.htm).
+Equivalent to [IfcPointByDistanceExpression](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPointByDistanceExpression.htm).
 
 ### DistanceExpression
 
 The `DistanceExpression` structure allows measurements to be captured in absolute terms (with respect to the start of the Linear-Element) or relative to an `lr:IReferent`, or both.
 
-The `DistanceExpression` structure is equivalent to [IfcPointByDistanceExpression](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpointbydistanceexpression.htm). 
+The `DistanceExpression` structure is equivalent to [IfcPointByDistanceExpression](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPointByDistanceExpression.htm). 
 
 The `LateralOffsetFromILinearElement` and `VerticalOffsetFromILinearElement` values are assumed to be measured perpendicularly from the tangent on the Linear-Element calculated at the location indicated by `DistanceAlongFromStart`.
 
@@ -60,4 +60,4 @@ Values in the `LateralOffsetFromILinearElement` are assumed to be positive for l
 
 Values in the `VerticalOffsetFromILinearElement` are assumed to be positive for vertical offsets above the Linear-Element and negative for vertical offsets below it.
 
-These assumptions are equivalent to a [IfcAxis2PlacementLinear](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcaxis2placementlinear.htm) with its `Axis` and `RefDirection` attributes describing a perpendicular to the tangent at the linear location of interest along the [BasisCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpointbydistanceexpression.htm).
+These assumptions are equivalent to a [IfcAxis2PlacementLinear](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcAxis2PlacementLinear.htm) with its `Axis` and `RefDirection` attributes describing a perpendicular to the tangent at the linear location of interest along the [BasisCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPointByDistanceExpression.htm).

--- a/Domains/1-Common/Profiles/Profiles.remarks.md
+++ b/Domains/1-Common/Profiles/Profiles.remarks.md
@@ -2,41 +2,41 @@
 remarksTarget: Profiles.ecschema.md
 ---
 
-# **Profiles**
+# Profiles
 
 Profiles schema defines classes that represent two dimensional cross sections, used to define geometric shapes. Profiles may be used to extrude structural components like beams and columns.
 
 Most often used Profiles are standard and defined by a specific [Standards Organization](#standardsorganization). Standard Profiles are always shared. Standard profiles should only be deleted in case a mistake was made when creating standard Profile.
 
-## **Entity Classes**
+## Entity Classes
 
-### **Profile**
+### Profile
 
 Base class of all profile definitions.
 Profile may be a [SinglePerimeterProfile](#singleperimeterprofile) or [CompositeProfile](#compositeprofile).
 
-### **StandardsOrganization**
+### StandardsOrganization
 
 Defines standard [Profiles](#profile). This should always be sub-modeled by a model which stores all manufacturers that produce the actual structural members defined by profile rules of standard organization.
 
-### **Manufacturer**
+### Manufacturer
 
 Produces structural members defined by a standard [Profile]. Manufacturer is always stored in a model that models [standards organization](#standardsorganization) whichs' rules are used to define profiles. Manufacturer is always sub-modeled and it's model contains revisions for profiles.
 
-### **Revision**
+### Revision
 
 Stores standard [profiles](#profile) that are used to produce structural members by some specific [manufacturer](#manufacturer).
 
-### **SinglePerimeterProfile**
+### SinglePerimeterProfile
 
 This profile subclass is used to denote a [Profile](#profile) that is composed out of a single perimeter (area). SinglePerimeterProfiles can be referenced by [CompositeProfile](#compositeprofile) to form a [Profile](#profile) with multiple disjoint areas.
 
-### **ParametricProfile**
+### ParametricProfile
 
 [Profile](#profile) whose geometry is defined by a set of properties such as ``Width``, ``Depth``, ``Thickness`` etc.
 In addition, such Profiles have a bounding box which is centered at the center of the coordinate system i.e. (x: 0, y: 0).
 
-### **CShapeProfile**
+### CShapeProfile
 **Derivative properties:**
 - `FlangeInnerEdgeLength` = `FlangeWidth` - `WebThickness`
 - `FlangeSlopeHeight` = `FlangeInnerEdgeLength` * Tan(`FlangeSlope`)
@@ -67,7 +67,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![CShape (only mandatory properties)](media/ProfilePictures/CShape1.png)
 ![CShape (all properties)](media/ProfilePictures/CShape2.png)
 
-### **AsymmetricIShapeProfile**
+### AsymmetricIShapeProfile
 **Derivative properties:**
 - `WebEdgeLength` = `Depth` - `TopFlangeThickness` - `BottomFlangeThickness`
 - `TopFlangeInnerEdgeLength` = (`TopFlangeWidth` - `WebThickness`) / 2
@@ -117,7 +117,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![AsymmetricIShape (only mandatory properties)](media/ProfilePictures/AsymmetricIShape1.png)
 ![AsymmetricIShape (all properties)](media/ProfilePictures/AsymmetricIShape2.png)
 
-### **IShapeProfile**
+### IShapeProfile
 **Derivative properties:**
 - `FlangeInnerEdgeLength` = (`FlangeWidth` - `WebThickness`) / 2
 - `FlangeSlopeHeight` = `FlangeInnerEdgeLength` * Tan(`FlangeSlope`)
@@ -148,7 +148,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![IShape (only mandatory properties)](media/ProfilePictures/IShape1.png)
 ![IShape (all properties)](media/ProfilePictures/IShape2.png)
 
-### **TShapeProfile**
+### TShapeProfile
 **Derivative properties:**
 - `FlangeInnerEdgeLength` = (`FlangeWidth` - `WebThickness`) / 2
 - `FlangeSlopeHeight` = `FlangeInnerEdgeLength` * Tan(`FlangeSlope`)
@@ -188,7 +188,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![TShape (only mandatory properties)](media/ProfilePictures/TShape1.png)
 ![TShape (all properties)](media/ProfilePictures/TShape2.png)
 
-### **LShapeProfile**
+### LShapeProfile
 **Derivative properties:**
 - `HorizontalLegInnerEdgeLength` = `Width` - `Thickness`
 - `HorizontalLegSlopeHeight` = `HorizontalLegInnerEdgeLength` * Tan(`LegSlope`)
@@ -220,7 +220,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![LShape (only mandatory properties)](media/ProfilePictures/LShape1.png)
 ![LShape (all properties)](media/ProfilePictures/LShape2.png)
 
-### **TTShapeProfile**
+### TTShapeProfile
 **Derivative properties:**
 - `FlangeInnerFaceLength` = (`FlangeWidth` - 2 * `WebThickness` - `WebSpacing`) / 2
 - `FlangeSlopeHeight` = `FlangeInnerFaceLength` * Tan(`FlangeSlope`)
@@ -266,7 +266,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![TTShape (only mandatory properties)](media/ProfilePictures/TTShape1.png)
 ![TTShape (all properties)](media/ProfilePictures/TTShape2.png)
 
-### **SchifflerizedLShapeProfile**
+### SchifflerizedLShapeProfile
 **Constraints:**
 - `LegLength` must be greater than zero
 - `Thickness`
@@ -286,7 +286,7 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![Schifflerized (only mandatory properties)](media/ProfilePictures/Schifflerized1.png)
 ![Schifflerized (all properties)](media/ProfilePictures/Schifflerized2.png)
 
-### **ZShapeProfile**
+### ZShapeProfile
 **Derivative properties:**
 - `FlangeInnerEdgeLength` = (`FlangeWidth` - `WebThickness`) / 2
 - `FlangeSlopeHeight` = `FlangeInnerEdgeLength` * Tan(`FlangeSlope`)
@@ -317,12 +317,12 @@ In addition, such Profiles have a bounding box which is centered at the center o
 ![ZShape (only mandatory properties)](media/ProfilePictures/ZShape2.png)
 ![ZShape (all properties)](media/ProfilePictures/ZShape1.png)
 
-### **DerivedProfile**
+### DerivedProfile
 [SinglePerimeterProfile](#singleperimeterprofile) that is based on another [SinglePerimeterProfile](#singleperimeterprofile) with applied standard transformations (scale, rotation, translation, mirror). This [Profile](#profile) is defined for compatibility reasons with [IFC](#https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/) and its **usage is not recommended**.
 
 Note that deletion of the referenced [SinglePerimeterProfile](#singleperimeterprofile) is prohibited if there are [DerivedProfiles](#derivedprofile) that reference it.
 
-### **CenterLineCShapeProfile**
+### CenterLineCShapeProfile
 **Constraints:**
 - `FlangeWidth` must be greater than zero
 - `Depth` must be greater than zero
@@ -341,7 +341,7 @@ Note that deletion of the referenced [SinglePerimeterProfile](#singleperimeterpr
 ![CenterLineCShape (only mandatory properties)](media/ProfilePictures/CenterCShape1.png)
 ![CenterLineCShape (all properties)](media/ProfilePictures/CenterCShape2.png)
 
-### **CenterLineLShapeProfile**
+### CenterLineLShapeProfile
 **Constraints:**
 - `Width` must be greater than zero
 - `Depth` must be greater than zero
@@ -360,7 +360,7 @@ Note that deletion of the referenced [SinglePerimeterProfile](#singleperimeterpr
 ![CenterLineLShape (only mandatory properties)](media/ProfilePictures/CenterLShape1.png)
 ![CenterLineLShape (all properties)](media/ProfilePictures/CenterLShape2.png)
 
-### **CenterLineZShapeProfile**
+### CenterLineZShapeProfile
 **Constraints:**
 - `FlangeWidth` must be greater than zero
 - `Depth` must be greater than zero
@@ -382,7 +382,7 @@ Note that deletion of the referenced [SinglePerimeterProfile](#singleperimeterpr
 ![CenterLineZShape (only mandatory properties)](media/ProfilePictures/CenterZShape1.png)
 ![CenterLineZShape (all properties)](media/ProfilePictures/CenterZShape2.png)
 
-### **BentPlateProfile**
+### BentPlateProfile
 **Derivative properties:**
 - `MaximumWallThickness` = Min(`Width` - `BendOffset`, `BendOffset`) * Tan(`BendAngle` / 2) * 2
 
@@ -403,11 +403,11 @@ Note that deletion of the referenced [SinglePerimeterProfile](#singleperimeterpr
 
 ![BentPlate](media/ProfilePictures/BentPlate.png)
 
-### **CompositeProfile**
+### CompositeProfile
 
 Abstract [Profile](#profile) class that is comprised of multiple [SinglePerimeterProfiles](#singleperimeterprofile). See [ArbitraryCompositeProfile](#arbitrarycompositeprofile), [DoubleLShapeProfile](#doublelshapeprofile) and [DoubleCShapeProfile](#doublecshapeprofile) for instantiable composite [Profiles](#profile).
 
-### **ArbitraryCompositeProfile**
+### ArbitraryCompositeProfile
 Instantiable [CompositeProfile](#compositeprofile) that is used to define an arbitrary [Profile](#profile) with multiple areas.
 
 This Profile is constructed by inserting [ArbitraryCompositeProfileAspects](#arbitrarycompositeprofileaspects) that reference and transform [SinglePerimeterProfiles](#singleperimeterprofile). [ArbitraryCompositeProfile](#arbitrarycompositeprofile) can reference the same [SinglePerimeterProfile](#singleperimeterprofile) multiple times, but apply different transformations.
@@ -418,13 +418,13 @@ This Profile is constructed by inserting [ArbitraryCompositeProfileAspects](#arb
   - [RectangleProfile](#rectangleprofile) - referenced twice with different `Offset`.
   - ![ArbitraryComposite (cross)](media/ProfilePictures/ArbitraryComposite1.png)
 
-### **ArbitraryCompositeProfileAspect**
+### ArbitraryCompositeProfileAspect
 
 Aspect that is used by [ArbitraryCompositeProfile](#arbitrarycompositeprofile) to reference [SinglePerimeterProfile](#singleperimeterprofile) from which it is composed.
 
 This aspect also includes fields for transforming the referenced [SinglePerimeterProfile](#singleperimeterprofile) when creating the geometry of [ArbitraryCompositeProfile](#arbitrarycompositeprofile).
 
-### **DoubleLShapeProfile**
+### DoubleLShapeProfile
 
 Instantiable [CompositeProfile](#compositeprofile) that models a Double L shape profile where the single [LShapeProfiles](#lshapeprofile) are placed back to back with specified gap between them. This [Profile](#profile) references and requires a [LShapeProfile](#lshapeprofile) to exist in the iModel.
 
@@ -436,7 +436,7 @@ Note that deletion of the referenced [LShapeProfile](#lshapeprofile) is prohibit
 ![DoubleLShape (DoubleLLongLegs)](media/ProfilePictures/DoubleLLongLegs.png)
 ![DoubleLShape (DoubleLShortLegs)](media/ProfilePictures/DoubleLShortLegs.png)
 
-### **DoubleCShapeProfile**
+### DoubleCShapeProfile
 Instantiable [CompositeProfile](#compositeprofile) that models a Double C shape profile where the single [CShapeProfiles](#cshapeprofile) are placed back to back with specified gap between them. This [Profile](#profile) references and requires a [CShapeProfile](#cshapeprofile) to exist in the iModel.
 
 Note that deletion of the referenced [CShapeProfile](#cshapeprofile) is prohibited if there are [DoubleCShapeProfiles](#doublelshapeprofile) that reference it.
@@ -446,7 +446,7 @@ Note that deletion of the referenced [CShapeProfile](#cshapeprofile) is prohibit
 
 ![DoubleCShape (DoubleLShortLegs)](media/ProfilePictures/DoubleCShape.png)
 
-### **ArbitraryShapeProfile**
+### ArbitraryShapeProfile
 
 A [SinglePerimeterProfile](#singleperimeterprofile) whose geometry is defined by an arbitrary single perimeter. Geometry of [ArbitraryShapeProfile](#arbitraryshapeprofile) can have voids i.e. it
 can be formed using a [ParityRegion](https://www.itwinjs.org/reference/core-geometry/curve/parityregion/) (see example of a Profile with a void).
@@ -466,7 +466,7 @@ can be formed using a [ParityRegion](https://www.itwinjs.org/reference/core-geom
 ([LineString](https://www.itwinjs.org/reference/core-geometry/curve/linestring3d/)) and the `Shape` of an [IShapeProfile](#ishapeprofile).
   - ![ArbitraryShape (IShapeProfile encasing)](media/ProfilePictures/ArbitraryShape2.png)
 
-### **ArbitraryCenterLineProfile**
+### ArbitraryCenterLineProfile
 
 Extended [ArbitraryShapeProfile](#arbitraryshapeprofile) with an additional constraint that the defined single perimeter (area) must have a non self intersecting centerline. Geometry of such [Profile](#proflile) is created by applying a constant thickness to the centerline.
 
@@ -483,20 +483,20 @@ Extended [ArbitraryShapeProfile](#arbitraryshapeprofile) with an additional cons
   - must not self intersect
   - must be planar and lie on the XY plane
 
-### **EllipseProfile**
+### EllipseProfile
 **Constraints:**
 - `XRadius` must be greater tan zero
 - `YRadius` must be greater tan zero
 
 ![Ellipse](media/ProfilePictures/Ellipse.png)
 
-### **CircleProfile**
+### CircleProfile
 **Constraints:**
 - `Radius` must be greater tan zero
 
 ![Circle](media/ProfilePictures/Circle.png)
 
-### **HollowCircleProfile**
+### HollowCircleProfile
 **Constraints:**
 - `Radius` must be greater than zero
 - `WallThickness`
@@ -505,14 +505,14 @@ Extended [ArbitraryShapeProfile](#arbitraryshapeprofile) with an additional cons
 
 ![HollowCircle](media/ProfilePictures/HollowCircle.png)
 
-### **RectangleProfile**
+### RectangleProfile
 **Constraints:**
 - `Width` must be greater than zero
 - `Depth` must be greater than zero
 
 ![Rectangle](media/ProfilePictures/Rectangle.png)
 
-### **RoundedRectangleProfile**
+### RoundedRectangleProfile
 **Constraints:**
 - `Width` must be greater than zero
 - `Depth` must be greater than zero
@@ -523,7 +523,7 @@ Extended [ArbitraryShapeProfile](#arbitraryshapeprofile) with an additional cons
 
 ![RoundedRectangle](media/ProfilePictures/RoundedRectangle.png)
 
-### **HollowRectangleProfile**
+### HollowRectangleProfile
 **Constraints:**
 - `Width` must be greater than zero
 - `Depth` must be greater than zero
@@ -544,7 +544,7 @@ Extended [ArbitraryShapeProfile](#arbitraryshapeprofile) with an additional cons
 ![HollowRectangle (only mandatory properties)](media/ProfilePictures/HollowRectangle1.png)
 ![HollowRectangle (all properties)](media/ProfilePictures/HollowRectangle2.png)
 
-### **TrapezoidProfile**
+### TrapezoidProfile
 **Constraints:**
 - `TopWidth` must be greater than zero
 - `BottomWidth` must be greater than zero
@@ -552,29 +552,29 @@ Extended [ArbitraryShapeProfile](#arbitraryshapeprofile) with an additional cons
 
 ![Trapezoid](media/ProfilePictures/Trapezoid.png)
 
-### **RegularPolygonProfile**
+### RegularPolygonProfile
 **Constraints:**
 - `SideCount` must be greater or equal to `3` and less or equal to `32`
 - `SideLength` must be greater than zero
 
 ![RegularPolygon (all properties)](media/ProfilePictures/RegularPolygon.png)
 
-### **CapsuleProfile**
+### CapsuleProfile
 **Constraints:**
 - `Width` must be greater than zero
 - `Depth` must be greater than zero
 
 ![Capsule](media/ProfilePictures/Capsule.png)
 
-## **Mixin Classes**
+## Mixin Classes
 
-### **ICenterLineProfile**
+### ICenterLineProfile
 
 Mixin class used to define [Profiles](#profile) with a non self intersecting centerline and a constant thickness. These [Profiles](#profile) are often used to model cold-formed sections. See [CenterLineCShapeProfile](#centerlinecshapeprofile), [CenterLineLShapeProfile](#centerlinelshapeprofile), [CenterLineZShapeProfile](#centerlinezshapeprofile).
 
-## **Struct Classes**
+## Struct Classes
 
-### **CardinalPoint**
+### CardinalPoint
 
 All [Profiles](#profile) have an array of CardinalPoints containing 19 predefined standard cardinal points. In addition, users may define their own custom cardinal points and append them to the end of the array - in such case the name of the custom CardinalPoint must not clash with names of standard cardinal points.
 
@@ -599,13 +599,13 @@ Standard Cardinal points are:
 - **RightInLineWithShearCenter** - Most right point of the profiles geometry thats in-line with **ShearCenter**
 - **TopInLineWithShearCenter** - Most top point of the profiles geometry thats in-line with **ShearCenter**
 
-## **Enumerations**
+## Enumerations
 
-### **DoubleLShapeProfileType**
+### DoubleLShapeProfileType
 
 Enumeration used to specify how [DoubleLShapeProfiles](#doublelshapeprofile) geometry is created - which "legs" of the [LShapeProfile](#lshapeprofile) are placed back to back.
 
-## **Standard Profiles**
+## Standard Profiles
 
 Most often used Profiles are standard and defined in a catalog. This is defined by a Profile and Code hierarchy representing four components:
 

--- a/Domains/1-Common/SpatialComposition/SpatialComposition.remarks.md
+++ b/Domains/1-Common/SpatialComposition/SpatialComposition.remarks.md
@@ -5,11 +5,11 @@ remarksTarget: SpatialComposition.ecschema.md
 
 # SpatialComposition
 
-This schema contains classes for modeling the Spatial Structure of infrastructure. BIS generally follows IFC's "spatial structure" concepts described by [IfcSpatialStructureElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcspatialstructureelement.htm)
+This schema contains classes for modeling the Spatial Structure of infrastructure. BIS generally follows IFC's "spatial structure" concepts described by [IfcSpatialStructureElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpatialStructureElement.htm)
 
 We aim for a 1:1 bi-directional instance mapping (not *class* mapping!) with IFC.  Round-trip transformations may result in changes that provide an *equivalent*, but not *identical* IFC model.
 
-The hierarchy of [SpatialStructureElements](#spatialstructureelement) is built using the [SpatialStructureElementAggregatesElements](#spatialstructureelementaggregateselements) relationship, similar to [IfcRelAggregates](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifckernel/lexical/ifcrelaggregates.htm). The "source" Element of the relationship is an "Aggregator" that aggregates parts that are essentially a different representation of the aggregator, but at a finer granularity.
+The hierarchy of [SpatialStructureElements](#spatialstructureelement) is built using the [SpatialStructureElementAggregatesElements](#spatialstructureelementaggregateselements) relationship, similar to [IfcRelAggregates](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelAggregates.htm). The "source" Element of the relationship is an "Aggregator" that aggregates parts that are essentially a different representation of the aggregator, but at a finer granularity.
 
 A Spatial Structure can define as many levels of hierarchy as needed.
 
@@ -40,25 +40,27 @@ Generally, the levels of a Spatial Structure will follow the order: Region, Site
 
 BIS does not have a direct equivalent of IFC's controversial "CompositionType" attribute, which indicates that a given instance of IfcSpatialStructureElement represents a 'complex', an 'element' (a discrete individual), or a "part" (a portion of) for a given entity. BIS allows nesting of Regions within Regions, Sites within Sites, Facilities within Facilities, etc. to cover use-cases like a "building complex" or a "sub-building".
 
-## SpatialStructureElementAggregatesElements
+## Entity Classes
 
-Equivalent to [IfcRelAggregates](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifckernel/lexical/ifcrelaggregates.htm).
+### SpatialStructureElementAggregatesElements
+
+Equivalent to [IfcRelAggregates](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelAggregates.htm).
 
 Forms a strict hierarchy (A Spatial Structure Element can only be aggregated by a single 'aggregator')
 
 See [Schema Overview](#spatialcomposition) for more information.
 
-## SpatialStructureElement
+### SpatialStructureElement
 
-Equivalent to [IfcSpatialStructureElement](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcspatialstructureelement.htm).
+Equivalent to [IfcSpatialStructureElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpatialStructureElement.htm).
 
 See [Schema Overview](#spatialcomposition) for more information.
 
-## SpatialStructureElementType
+### SpatialStructureElementType
 
 These types allow projects in different localities to define the types of Spatial Structure Elements that are relevant to them.
 
-## ISpatialOrganizer
+### ISpatialOrganizer
 
 The organization could be according to any "criteria" or "dimension".
 
@@ -66,23 +68,23 @@ Currently only used by [SpatialStructureElement](#spatialstructureelement) and [
 
 See [Schema Overview](#spatialcomposition) for more context.
 
-## SpatialOrganizerHoldsSpatialElements
+### SpatialOrganizerHoldsSpatialElements
 
 The "holds" relationship is used to organize `bis:SpatialElement`s into strict categories, such that a given `bis:SpatialElement` is only "held" by no more than one ["organizer"](#ispatialorganizer).
 
 The scope of the "organization" (the scope within which the one-SpatialElement-per-Organizer rule can be checked) will vary depending on the class mixing-in [ISpatialOrganizer](#ispatialorganizer).
 
-As used by [SpatialStructureElement](#spatialstructureelement) and [Zone](#zone), `SpatialOrganizerHoldsSpatialElements` is equivalent to [IfcRelContainedInSpatialStructure](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcrelcontainedinspatialstructure.htm) (navigated in reverse).
+As used by [SpatialStructureElement](#spatialstructureelement) and [Zone](#zone), `SpatialOrganizerHoldsSpatialElements` is equivalent to [IfcRelContainedInSpatialStructure](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelContainedInSpatialStructure.htm) (navigated in reverse).
 
 In that context, in both IFC and BIS, "holds" does *not* mean geometric spatial containment, though `bis:SpatialElement`s that are spatially contained within a given "Spatial Structure Element" are *likely* to be "held" by that "Spatial Structure Element" *unless* they have been assigned (for logical reasons) to some other "Spatial Structure Element" that is deeper in the hierarchy. For example, an ElevatorShaft might be spatially contained only by the entire Building, but assigned to be "held" by the "Basement" Storey.  Generally, if a `bis:SpatialElement` is completely contained within a `Space`, it will be "held" by that `Space`, but Elements outside of the `Space` (like the "outdoor" half of a split-system Air Conditioner) for a `Space` might also be "held" by that `Space`.
 
 See [Schema Overview](#spatialcomposition) for more context.
 
-## SpatialOrganizerReferencesSpatialElements
+### SpatialOrganizerReferencesSpatialElements
 
 The "references" relationship is used by ["organizers"](#ispatialorganizer) that wish to organize `bis:SpatialElement`s loosely, such that a given `bis:SpatialElement` can be "referenced" by more than one "organizer".
 
-As used by [SpatialStructureElement](#spatialstructureelement) and [Zone](#zone), `SpatialOrganizerReferencesSpatialElements` is equivalent to [IfcRelReferencedInSpatialStructure](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcrelreferencedinspatialstructure.htm) (navigated in reverse.)
+As used by [SpatialStructureElement](#spatialstructureelement) and [Zone](#zone), `SpatialOrganizerReferencesSpatialElements` is equivalent to [IfcRelReferencedInSpatialStructure](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRelReferencedInSpatialStructure.htm) (navigated in reverse.)
 
 In that context, in both IFC and BIS, the precise meaning of the association is up to the author of the data. It may or may not correlate with geometric spatial intersection.
 
@@ -90,44 +92,44 @@ For example, an ElevatorShaft Element may be "referenced by" all of the Storeys 
 
 See [Schema Overview](#spatialcomposition) for more context.
 
-## Region
+### Region
 
-Has no direct equivalent in IFC, but can be represented as a large [IfcSite](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcsite.htm).
+Has no direct equivalent in IFC, but can be represented as a large [IfcSite](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSite.htm).
 
 Anticipated to use [RegionType](#regiontype) to distinguish highly variable types of Regions, e.g. city, district, municipality, county, state, Land, provence, country, etc.
 
-## Site
+### Site
 
-Equivalent to [IfcSite](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcsite.htm).
+Equivalent to [IfcSite](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSite.htm).
 
 See [SiteType](#sitetype).
 
-## Facility
+### Facility
 
-Equivalent to [IfcFacility](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcfacility.htm).
+Equivalent to [IfcFacility](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacility.htm).
 
 See [FacilityType](#facilitytype).
 
 ## FacilityPart
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcfacilitypart.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm).
 
 See [FacilityPartType](#facilityparttype).
 
-## Space
+### Space
 
-Equivalent to [IfcSpace](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcproductextension/lexical/ifcspace.htm).
+Equivalent to [IfcSpace](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpace.htm).
 
 See [SpaceType](#spacetype).
 
-## ZonalSystem
+### ZonalSystem
 
-Equivalent to [IfcZone](http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcZone.htm). A `ZonalSystem` (as a `bis:PhysicalSystem`), does not have its own geometry, groups its members via the `bis:PhysicalSystemGroupsMembers` relationship and can "service" `bis:SpatialElement`s via `bis:PhysicalSystemServicesSpatialElements` relationship.
+Equivalent to [IfcZone](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcZone.htm). A `ZonalSystem` (as a `bis:PhysicalSystem`), does not have its own geometry, groups its members via the `bis:PhysicalSystemGroupsMembers` relationship and can "service" `bis:SpatialElement`s via `bis:PhysicalSystemServicesSpatialElements` relationship.
 Examples include a tenancy zone, security zone, etc.
 
 ## Zone
 
-Equivalent to [IfcSpatialZone](http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcSpatialZone.htm). 
+Equivalent to [IfcSpatialZone](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpatialZone.htm). 
 
 A `Zone` (as a `bis:SpatialLocationElement`) has its own geometry for expressing a spatial region and (as an [ISpatialOrganizer](#ispatialorganizer)) can organize other `bis:SpatialElements` for any purpose.
 Examples include a lighting zone, construction zone, loading area, circulation zone, etc.
@@ -135,19 +137,19 @@ Examples include a lighting zone, construction zone, loading area, circulation z
 As a [ISpatialOrganizer](#ispatialorganizer), a `Zone` represents a category for organizing spatial elements. The [ZoneType](#zonetype) defines the "criteria" or "dimension" for organizing.
 In general, a `Zone` will only use the [`SpatialOrganizerReferencesSpatialElements`](#spatialorganizerreferencesspatialelements) relationship, but the "holds" relationship is also available for special cases.
 
-## ZoneType
+### ZoneType
 
 Used with [Zone](#zone) to define a criteria to use for organizing `bis:SpatialElement`s that is "orthogonal" to the primary spatial breakdown structure.
 
 For example, `Zones` of `ZoneType` "Tenancy" carve up the space according to which tenant has leased which area.
 
-## CompositeElement
+### CompositeElement
 
 Deprecated.
 
 Instead, use the [SpatialStructureElement](#spatialstructureelement) class that is a subclass of this class for backwards compatibility.
 
-## ICompositeBoundary
+### ICompositeBoundary
 
 Deprecated.
 
@@ -156,7 +158,7 @@ Often the original data is in the form of points on the map, a metes and bounds 
 
 `ICompositeBoundary` is a mixin class and does not have a mapping to or from IFC.
 
-## ICompositeVolume
+### ICompositeVolume
 
 Deprecated.
 
@@ -164,7 +166,7 @@ Mixin used to indicate that the element is of volumetric type which is most comm
 
 `ICompositeVolume` is a mixin class and does not have a mapping to or from IFC.
 
-## CompositeOverlapsSpatialElements
+### CompositeOverlapsSpatialElements
 
 Deprecated.
 

--- a/Domains/2-DisciplinePhysical/Building/BuildingSpatial/BuildingSpatial.remarks.md
+++ b/Domains/2-DisciplinePhysical/Building/BuildingSpatial/BuildingSpatial.remarks.md
@@ -9,57 +9,29 @@ This schema contains the concrete classes that are used to model the spatial str
 
 Due to the importance of IFC in coordinating spatial structure, the classes in the schema are intended to have a 1:1 instance mapping (not *class* mapping!) with IFC that will work for transformations in either direction.  It is expected that round-trip transformations may result in changes that provide an *equivalent*, but not *identical* model.
 
-## Building
+## Entity Classes
+
+### Building
 
 A `Building` represents a structure that provides shelter for its occupants or contents and stands in one place. The building is also used to provide a basic element within the spatial structure hierarchy for the components of a building project (together with site, story, and space).
 
-### Usage
-
 <!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-A `Building` is recommended to be placed in the sub-model of a `Site`. A `Building` may also compose a `Site`. Decomposes into `Story` or `Space` elements.
+A `Building` is typically aggregated by a `Site`. A `Building` may also compose a `Site`. Decomposes into `Story` or `Space` elements.
 
-### Mapping to and from IFC
-
-| From BIS    | Condition | To IFC    | Condition |
-| ----------- | --------- | --------- | --------- |
-| `Building`  | (none) | `IfcBuilding` | CompositionType == ELEMENT |
-
+Equivalent to [IfcBuilding](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBuilding.htm) with CompositionType == ELEMENT.
 
 <!-- the COMPLEX or PARTIAL type we do not immediately need, could be introduced in future versions of the schema -->
 
-<!-- additional mapping notes go here -->
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcBuilding` | CompositionType == ELEMENT | `Building` | (none) |
-
-<!-- additional mapping notes go here -->
-## Space
+### Space
 
 A `Space` represents a volume bounded actually or theoretically. Spaces are volumes that provide for certain functions within a CompositeElement.
 The `Space` is used to build the spatial structure of a building (that serves as the primary project breakdown and is required to be hierarchical). The composite elements are linked together by using the relationship `CompositeComposesSubComposites`.
 
-### Usage
+A `Space` is typically aggregated by a `Story` or another `Space`. `Space` elements compose stories and other spaces, and they may also decompose into spaces.
 
-A `Space` is recommended to be placed in the sub-model of a `Story` or another `Space`. `Space` elements compose stories and other spaces, and they may also decompose into spaces.
+Equivalent to [IfcSpace](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpace.htm) with CompositionType != COMPLEX.
 
-### Mapping to and from IFC
-
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| `Space` | (none) | `IfcSpace` | (CompositionType != COMPLEX) |
-
-<!--   -->
-
-<!-- additional mapping notes go here -->
-
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| `IfcSpace`| (none) | `Space` | (none) |
-
-<!-- additional mapping notes go here -->
-
-## Story
+### Story
 
 The building `Story` typically represents a (nearly) horizontal aggregation of spaces that are vertically bound.
 
@@ -67,51 +39,30 @@ A story is (if specified) associated to a building.
 
 The `Story` is used to build the spatial structure of a building (that serves as the primary project breakdown and is required to be hierarchical). The spatial composition elements are linked together by using the objectified relationship `CompositeComposesSubComposites`.
 
-### Usage
-
 <!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
 
-A `Story` is recommended to be placed in the sub-model of a `Building`. `Story` elements compose a `Building`, they also decompose into `Space` elements.
+A `Story` is typically aggregated by a `Building`. `Story` elements compose a `Building`, they also decompose into `Space` elements.
 
-### Mapping to and from IFC
+`Story` is abstract, and hence there is never a need to map to or from [IfcBuildingStorey](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBuildingStorey.htm) instances.
 
-`Story` is abstract, and hence there is never a need to map to or from `IfcBuildingStorey` instances.
-
-## ElevationStory
+### ElevationStory
 
 `ElevationStory` is bounded by elevations and sometimes other boundary properties. Typically represents a (nearly) horizontal aggregation of spaces that are vertically bound.
 
 <!-- there's only 2 reasons we're not mentioning Grids:ElevationGridSurface instead of "elevations" here 1- it's because grids have not been marked "released" yet. 2-we don't have reference to grids here __yet__ --->
 
-### Usage
-
 <!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
 
-An `ElevationStory` is recommended to be placed in the sub-model of a `Building`. `ElevationStory` elements compose a `Building`, they also decompose into spaces.
+An `ElevationStory` is typically aggregated by a `Building`. `ElevationStory` elements compose a `Building`, they also decompose into spaces.
 
-### Mapping to and from IFC
-
-`ElevationStory` is abstract, and hence there is never a need to map to or from `IfcBuildingStorey` instances.
+`ElevationStory` is abstract, and hence there is never a need to map to or from [IfcBuildingStorey](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBuildingStorey.htm) instances.
 
 ## RegularStory
 
 A `RegularStory` is bounded by top and bottom elevations. Typically represents a (nearly) horizontal aggregation of spaces that are vertically bound.
 
-### Usage
+An `RegularStory` is typically aggregated by a `Building`. `RegularStory` elements compose a `Building`, they also decompose into spaces.
 
-
-An `RegularStory` is recommended to be placed in the sub-model of a `Building`. `RegularStory` elements compose a `Building`, they also decompose into spaces.
-
-### Mapping to and from IFC
-
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| RegularStory      | (any) | IfcBuildingStorey | CompositionType == ELEMENT |
-
-<!-- additional mapping notes go here -->
-
-| From IFC | Condition | To BIS | Condition |
-| --------- | --------- | --------- | --------- |
-| IfcBuildingStorey             | CompositionType == ELEMENT | RegularStory | (none) |
+Equivalent to [IfcBuildingStorey](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBuildingStorey.htm) with CompositionType == ELEMENT.
 
 <!-- for CompositionType != ELEMENT, we expect other subclasses of either Story or ElevationStory, i.e. SplitStory for type=PARTIAL. those subclasses would be added in the future versions of the schema. some other subclasses are also controversial, that's why we're leaving them out. i.e. SharedStory @ speedikon -->

--- a/Domains/2-DisciplinePhysical/Civil/BridgePhysical/BridgePhysical.remarks.md
+++ b/Domains/2-DisciplinePhysical/Civil/BridgePhysical/BridgePhysical.remarks.md
@@ -15,7 +15,7 @@ NOTE: Currently under development. This schema should not be used for production
 
 Instances of `BearingType` provide an additional classification that can be applied to `Bearing`s. Examples include Cylindrical, Spherical and Elastomeric. An instance of `BearingType` can optionally specify a single *Physical Material* via its `PhysicalMaterial` property.
 
-Equivalent to [IfcBearingType](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbearingtype.htm).
+Equivalent to [IfcBearingType](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBearingType.htm).
 
 ### Bearing
 
@@ -25,13 +25,13 @@ The purpose of a bearing is to allow controlled movement and thereby reduce the 
 
 `Bearing`s must be contained in `PhysicalModel`s.
 
-Equivalent to [IfcBearing](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbearing.htm).
+Equivalent to [IfcBearing](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBearing.htm).
 
 ### BearingSeatType
 
 Instances of `BearingSeatType` provide an additional classification that can be applied to `BearingSeat`s. Examples include Grout-pad and Beam-seat. An instance of `BearingSeatType` can optionally specify a single *Physical Material* via its `PhysicalMaterial` property.
 
-Equivalent to [IfcPlateType](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcplatetype.htm).
+Equivalent to [IfcPlateType](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPlateType.htm).
 
 ### BearingSeat
 
@@ -39,7 +39,7 @@ Equivalent to [IfcPlateType](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/
 
 `BearingSeat`s must be contained in `PhysicalModel`s.
 
-Equivalent to [IfcPlate](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcplate.htm).
+Equivalent to [IfcPlate](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPlate.htm).
 
 ### PierType
 
@@ -51,7 +51,7 @@ Instances of `PierType` provide an additional classification that can be applied
 
 `Pier`s must be contained in `PhysicalModel`s.
 
-Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.PIER](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassemblytypeenum.htm).
+Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.PIER](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssemblyTypeEnum.htm).
 
 ### AbutmentType
 
@@ -63,7 +63,7 @@ Instances of `AbutmentType` provide an additional classification that can be app
 
 `Abutment`s must be contained in `PhysicalModel`s.
 
-Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.ABUTMENT](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassemblytypeenum.htm).
+Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.ABUTMENT](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssemblyTypeEnum.htm).
 
 ### WingWallType
 
@@ -85,7 +85,7 @@ Instances of `AbutmentType` provide an additional classification that can be app
 
 `CrossFrame`s must be contained in `PhysicalModel`s.
 
-Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.CROSS_BRACING](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassemblytypeenum.htm).
+Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.CROSS_BRACING](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssemblyTypeEnum.htm).
 
 ### GirderType
 
@@ -97,4 +97,4 @@ Instances of `GirderType` provide an additional classification that can be appli
 
 `Girder`s must be contained in `PhysicalModel`s.
 
-Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.GIRDER](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcelementassemblytypeenum.htm).
+Equivalent to [IfcElementAssembly](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssembly.htm) with its PredefinedType attribute set to [IfcElementAssemblyTypeEnum.GIRDER](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementAssemblyTypeEnum.htm).

--- a/Domains/2-DisciplinePhysical/Civil/RoadRailAlignment/RoadRailAlignment.remarks.md
+++ b/Domains/2-DisciplinePhysical/Civil/RoadRailAlignment/RoadRailAlignment.remarks.md
@@ -22,13 +22,13 @@ The `Alignment` class inherits its `LengthValue` property from the `ILinearEleme
 
 An `Alignment` stores its visible geometry, typically a 3D approximation calculated as a stroked line-string, in its `GeometryStream` encoded as a *Path*.
 
-Equivalent to [IfcAlignment](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcalignment.htm). The 3D approximation stored in its `GeometryStream` is equivalent to an [IfcGradientCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcgradientcurve.htm).
+Equivalent to [IfcAlignment](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcAlignment.htm). The 3D approximation stored in its `GeometryStream` is equivalent to an [IfcGradientCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcGradientCurve.htm).
 
 ### AlignmentType
 
 Instances of `AlignmentType` provide an additional classification that can be applied to `Alignment`s.
 
-Equivalent to [IfcAlignmentTypeEnum](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcalignmenttypeenum.htm).
+Equivalent to [IfcAlignmentTypeEnum](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcAlignmentTypeEnum.htm).
 
 ### DesignAlignments
 
@@ -54,22 +54,22 @@ A `HorizontalAlignment` stores its visual geometry separately from geometry used
 
 The Z-coordinate of all of these primitives shall be zero.
 
-Equivalent to [IfcAlignment.Axis](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcalignment.htm) set to either an [IfcGradientCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcgradientcurve.htm) (via its `BaseCurve` attribute), an [IfcCompositeCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifccompositecurve.htm) or an [IfcPolyline](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpolyline.htm).
+Equivalent to [IfcAlignment.Axis](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcAlignment.htm) set to either an [IfcGradientCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcGradientCurve.htm) (via its `BaseCurve` attribute), an [IfcCompositeCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCompositeCurve.htm) or an [IfcPolyline](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPolyline.htm).
 
-Individual segments along the `HorizontalAlignment` encoded as a *Path* are equivalent to [IfcCompositeCurveSegment](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifccompositecurvesegment.htm)s with the following *Parent Curve*s:
+Individual segments along the `HorizontalAlignment` encoded as a *Path* are equivalent to [IfcCompositeCurveSegment](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCompositeCurveSegment.htm)s with the following *Parent Curve*s:
 
-- Linear segments encoded as *LineSegment3d* are equivalent to [IfcPolyline](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpolyline.htm).
-- Circular arc segments encoded as *Arc3d* are equivalent to [IfcTrimmedCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifctrimmedcurve.htm) based on an [IfcCircle](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifccircle.htm).
-- Transition segments (spirals) encoded as *TransitionSpiral3d* are equivalent to the corresponding [IfcSpiral](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifcspiral.htm) subclasses as follows:
+- Linear segments encoded as *LineSegment3d* are equivalent to [IfcPolyline](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPolyline.htm).
+- Circular arc segments encoded as *Arc3d* are equivalent to [IfcTrimmedCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcTrimmedCurve.htm) based on an [IfcCircle](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCircle.htm).
+- Transition segments (spirals) encoded as *TransitionSpiral3d* are equivalent to the corresponding [IfcSpiral](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpiral.htm) subclasses as follows:
 
 | *TransitionSpiral3d* subclass | *TransitionSpiral3d* subtype | IFC-equivalent |
 | ----------------------------- | ---------------------------- | -------------- |
-| *IntegratedSpiral3d* | "clothoid" | [IfcClothoid](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifcclothoid.htm) |
-| *IntegratedSpiral3d* | "cosine" | [IfcCosine](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifccosine.htm) |
-| *IntegratedSpiral3d* | "sine" | [IfcSine](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifcsine.htm) |
-| *IntegratedSpiral3d* | "biquadratic" | [IfcSecondOrderPolynomialSpiral](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifcsecondorderpolynomialspiral.htm) |
-| *IntegratedSpiral3d* | "bloss" | [IfcThirdOrderPolynomialSpiral](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifcthirdorderpolynomialspiral.htm) |
-| *IntegratedSpiral3d* | "vienna" | [IfcSeventhOrderPolynomialSpiral](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC4/HTML/link/ifcseventhorderpolynomialspiral.htm) |
+| *IntegratedSpiral3d* | "clothoid" | [IfcClothoid](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcClothoid.htm) |
+| *IntegratedSpiral3d* | "cosine" | [IfcCosine](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCosine.htm) |
+| *IntegratedSpiral3d* | "sine" | [IfcSine](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSine.htm) |
+| *IntegratedSpiral3d* | "biquadratic" | [IfcSecondOrderPolynomialSpiral](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSecondOrderPolynomialSpiral.htm) |
+| *IntegratedSpiral3d* | "bloss" | [IfcThirdOrderPolynomialSpiral](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcThirdOrderPolynomialSpiral.htm) |
+| *IntegratedSpiral3d* | "vienna" | [IfcSeventhOrderPolynomialSpiral](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSeventhOrderPolynomialSpiral.htm) |
 | *DirectSpiral3d* | any | Not Available |
 
 ### VerticalAlignment
@@ -88,9 +88,9 @@ The X-coordinate of all of these primitives shall indicate *distance along* meas
 
 It is not uncommon for a `VerticalAlignment` instance to capture *elevations* only for a partial range of its corresponding `HorizontalAlignment` instance. Note that the opposite situation, a `VerticalAlignment` instance capturing *elevations* before or after the range of its corresponding `HorizontalAlignment`, while possible in theory is typically considered invalid in practice. This schema leaves the decision to validate against such case to particular implementations, however.
 
-Equivalent to [IfcAlignment.Axis](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcalignment.htm) set to an [IfcGradientCurve](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcgradientcurve.htm) (via its `Segments` attribute).
+Equivalent to [IfcAlignment.Axis](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcAlignment.htm) set to an [IfcGradientCurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcGradientCurve.htm) (via its `Segments` attribute).
 
-Individual segments along the `VerticalAlignment` encoded as a *Path* are equivalent to [IfcCurveSegment](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifccurvesegment.htm)s.
+Individual segments along the `VerticalAlignment` encoded as a *Path* are equivalent to [IfcCurveSegment](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCurveSegment.htm)s.
 
 ### AlignmentStation
 
@@ -98,4 +98,4 @@ Individual segments along the `VerticalAlignment` encoded as a *Path* are equiva
 
 `AlignmentStation`s are linearly-located elements along an `Alignment`. They shall carry the *distance along* measurement in a `LinearlyReferencedAtLocation` aspect whereas the mapped *station value* shall be stored in their `Station` property. `Alignment`s shall define its initial *station value* in their `StartStation` property.
 
-Equivalent to [IfcReferent](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcreferent.htm) with a non-zero `StartDistance` attribute and relative measurements used by linear-locations referencing it.
+Equivalent to [IfcReferent](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcReferent.htm) with a non-zero `StartDistance` attribute and relative measurements used by linear-locations referencing it.

--- a/Domains/2-DisciplinePhysical/Civil/SpatialComposition/BridgeSpatial/BridgeSpatial.remarks.md
+++ b/Domains/2-DisciplinePhysical/Civil/SpatialComposition/BridgeSpatial/BridgeSpatial.remarks.md
@@ -17,13 +17,13 @@ As a subclass of `spcomp:Facility`, a `Bridge` instance provides the basic eleme
 
 `Bridge`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*.
 
-Equivalent to [IfcBridge](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridge.htm).
+Equivalent to [IfcBridge](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridge.htm).
 
 ### BridgeType
 
 Instances of `BridgeType` provide an additional classification that can be applied to `Bridge`s.
 
-Equivalent to [IfcBridgeTypeEnum](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgetypeenum.htm).
+Equivalent to [IfcBridgeTypeEnum](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgeTypeEnum.htm).
 
 ### Substructure
 
@@ -31,34 +31,34 @@ A `Bridge` instance typically aggregates only one instance of `Substructure`.
 
 `Substructure`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.SUBSTRUCTURE](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgeparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.SUBSTRUCTURE](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgePartTypeEnum.htm).
 
 ### Superstructure
 
 `Superstructure`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.SUPERSTRUCTURE](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgeparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.SUPERSTRUCTURE](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgePartTypeEnum.htm).
 
 ### Deck
 
 `Deck`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.DECK](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgeparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.DECK](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgePartTypeEnum.htm).
 
 ### DeckSegment
 
 `DeckSegment`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.DECK_SEGMENT](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgeparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.DECK_SEGMENT](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgePartTypeEnum.htm).
 
 ### Pier
 
 `Pier`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.PIER](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgeparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.PIER](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgePartTypeEnum.htm).
 
 ### Abutment
 
 `Abutment`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.ABUTMENT](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcbridgeparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcBridgePartTypeEnum.ABUTMENT](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBridgePartTypeEnum.htm).

--- a/Domains/2-DisciplinePhysical/Civil/SpatialComposition/RoadSpatial/RoadSpatial.remarks.md
+++ b/Domains/2-DisciplinePhysical/Civil/SpatialComposition/RoadSpatial/RoadSpatial.remarks.md
@@ -17,7 +17,7 @@ As a subclass of `spcomp:Facility`, a `Road` instance provides the basic element
 
 `Road`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*.
 
-Equivalent to [IfcRoad](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroad.htm).
+Equivalent to [IfcRoad](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoad.htm).
 
 ### RoadwayPlateau
 
@@ -25,7 +25,7 @@ A `Road` instance typically aggregates only one instance of `RoadwayPlateau`.
 
 `RoadwayPlateau`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.ROADWAYPLATEAU](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.ROADWAYPLATEAU](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### CentralReserve
 
@@ -33,7 +33,7 @@ In the typical case, a `CentralReserve` instance models the area that separates 
 
 `CentralReserve`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.CENTRALRESERVE](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.CENTRALRESERVE](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### CentralReservePart
 
@@ -47,7 +47,7 @@ A `Road` instance typically aggregates two instances of `RoadSide`. `JunctionEle
 
 `RoadSide`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.ROADSIDE](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.ROADSIDE](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### RoadSidePart
 
@@ -55,7 +55,7 @@ Examples of `RoadSidePart` may be side slopes, roadside ditches, back slopes, bu
 
 `RoadSidePart`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.ROADSIDEPART](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.ROADSIDEPART](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### Roadway
 
@@ -65,7 +65,7 @@ A `RoadwayPlateau` instance typically aggregates one or more instances of `Roadw
 
 `Roadway`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s. An instance of `Roadway` may hold the `bis:PhysicalElement`s (e.g. `Course`s) directly underneath it, as part of the road's *pavement* structure.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.CARRIAGEWAY](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.CARRIAGEWAY](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### TrafficLane
 
@@ -73,7 +73,7 @@ A `Roadway` instance typically aggregates one or more instances of `TrafficLane`
 
 `TrafficLane`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*. An instance of `TrafficLane` may hold the `bis:PhysicalElement`s (e.g. *Course*s) directly underneath it, as part of the road's *pavement* structure.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.TRAFFICLANE](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart]https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.TRAFFICLANE](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### Shoulder
 
@@ -83,7 +83,7 @@ Instances of `Shoulder` are typically aggregated by an instance of `RoadwayPlate
 
 `Shoulder`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*. An instance of `Shoulder` may hold the `bis:PhysicalElement`s (e.g. *Course*s) directly underneath it, as part of the road's *pavement* structure.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.SHOULDER](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.SHOULDER](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### Sidewalk
 
@@ -93,7 +93,7 @@ A `RoadwayPlateau` instance typically aggregates zero or more instances of `Side
 
 `Sidewalk`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s and can be linearly located, typically along an *Alignment*. An instance of `Sidewalk` typically holds the `bis:PhysicalElement`s (e.g. *Course*s) comprising its *pavement* structure.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.SIDEWALK](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.SIDEWALK](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).
 
 ### JunctionElement
 
@@ -107,4 +107,4 @@ A `Road` instance typically aggregates zero or more instances of `Intersection`.
 
 `Intersection`s must be contained in `SpatialLocationModel`s or `PhysicalModel`s. An instance of `Intersection` typically holds the `bis:PhysicalElement`s (e.g. *Course*s) comprising its *pavement* structure.
 
-Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcfacilitypart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.INTERSECTION](https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcroadparttypeenum.htm).
+Equivalent to [IfcFacilityPart](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacilityPart.htm) with its PredefinedType attribute set to [IfcRoadPartTypeEnum.INTERSECTION](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRoadPartTypeEnum.htm).

--- a/Domains/2-DisciplinePhysical/Earthwork/Earthwork.remarks.md
+++ b/Domains/2-DisciplinePhysical/Earthwork/Earthwork.remarks.md
@@ -14,7 +14,7 @@ Contains the classes modeling earthwork activities in BIS. Earthwork involves th
 
 Instances of `FillType` provide an additional classification that can be applied to `Fill`s. Examples include Embankment, Slope Fill or Back Fill. An instance of `FillType` can optionally specify a single *Physical Material* via its `PhysicalMaterial` property.
 
-Equivalent to [IfcEarthworksFillTypeEnum](http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcEarthworksFillTypeEnum.htm).
+Equivalent to [IfcEarthworksFillTypeEnum](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcEarthworksFillTypeEnum.htm).
 
 ### Fill
 
@@ -24,13 +24,13 @@ Examples of `Fill` include subgrade or a parts of a structure above it (such as 
 
 `Fill`s must be contained in `PhysicalModel`s. Instances of `Fill`, by default, shall use the Domain-ranked `ew:Volume` category.
 
-Equivalent to [IfcEarthworksFill](http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcEarthworksFill.htm).
+Equivalent to [IfcEarthworksFill](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcEarthworksFill.htm).
 
 ### CutType
 
 Instances of `CutType` provide an additional classification that can be applied to `Cut`s. Examples include Excavation, Trench or Dredging. An instance of `CutType` can optionally specify a single *Physical Material* to be removed via its `PhysicalMaterial` property.
 
-Equivalent to [IfcEarthworksCutTypeEnum](http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcEarthworksCutTypeEnum.htm).
+Equivalent to [IfcEarthworksCutTypeEnum](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcEarthworksCutTypeEnum.htm).
 
 ### Cut
 
@@ -40,7 +40,7 @@ The material excavated, modeled by `Cut`s, can later be used as fill or discarde
 
 `Cut`s must be contained in `PhysicalModel`s. Instances of `Cut`, by default, shall use the Domain-ranked `ew:Volume` category.
 
-Equivalent to [IfcEarthworksCut](http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcEarthworksCut.htm) with the main difference that IFC's equivalent does not model the material excavated, only the resulting void from modification of existing terrain.
+Equivalent to [IfcEarthworksCut](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcEarthworksCut.htm) with the main difference that IFC's equivalent does not model the material excavated, only the resulting void from modification of existing terrain.
 
 ### SurfaceGradeType
 

--- a/Domains/2-DisciplinePhysical/Fasteners/Fasteners.remarks.md
+++ b/Domains/2-DisciplinePhysical/Fasteners/Fasteners.remarks.md
@@ -9,265 +9,40 @@ This schema contains classes that are used to model the real-world physical enti
 
 Due to the importance of IFC in coordinating physical infrastructure, the classes in the schema are intended to have a 1:1 instance mapping (not *class* mapping!) with IFC that will work for transformations in either direction.  It is expected that round-trip transformations may result in changes that provide an *equivalent*, but not *identical* model.
 
-## FastenerComponent
+## Entity Classes
+
+### FastenerComponent
 
 `FastenerComponent` is used to represent a `StructuralComponent` that is used (often with other `FastenerComponent`s) to fasten  `PhysicalElement`s together.
 
-### Usage
-
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
 <!-- ********** FastenerComponent hierarchy starts here ********** -->
 
-## Bolt
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
+### Bolt
 
 `Bolt`s are almost always of standard manufacture and hence are almost always associated with a `BoltType`s through the `BoltIsOfBoltType` relationship.
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
 
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## Washer
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
+### Washer
 
 `Washer`s are almost always of standard manufacture and hence are almost always associated with a `WasherType`s through the `WasherIsOfWasherType` relationship.
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
 
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## Nut
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
+### Nut
 
 `Nut`s are almost always of standard manufacture and hence are almost always associated with a `NutType`s through the `NutIsOfNutType` relationship.
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
 
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## Weld
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
+### Weld
 
 `Weld`s are not manufactured, but are almost always classified by type (which includes size) and hence are almost always associated with a `WeldType`s through the `WeldIsOfWeldType` relationship.
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
 
 <!-- ********** FastenerComponentType hierarchy starts here ********** -->
 
-## FastenerComponentType
+### FastenerComponentType
 
 Most `FastenerComponent`s are standard manufactured items and hence are defined via a `FastenerComponentIsOfFastenerType` relationship to a `FastenerType`.
 
 An example of a `FastenerComponentType` is a *Galvanized 3/4" A325 bolt, 3" long*.
 
-### Usage
-
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## BoltType
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
-
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## WasherType
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
-
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## NutType
-
-xxxxxxxxxxx overview info xxxxxxxx
-
-### Usage
-
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-## WeldType
+### WeldType
 
 `WeldType` is used to represent the material, shape and the nominal size of a `Weld`. The welding process is sometimes included also. `WeldType` does not include the *length* of a weld, that is specified in the `Weld`s that are related to the `WeldType`.
 
 An example of a WeldType is a *1/4" fillet weld with E70XX electrodes*.
-
-### Usage
-
-<!-- add notes about usage here. Placement in models. Parent-child issues; ElementAspects, key relationships. --->
-xxxxxxxxxxx usage info xxxxxxxx
-
-### Mapping to and from IFC
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From BIS  | Condition | To IFC    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->
-
-<!-- OK to remove this table if a simple sentence explains better. --->
-| From IFC  | Condition | To BIS    | Condition |
-| --------- | --------- | --------- | --------- |
-| xxxxxxxxx | xxxxxxxxxx | xxxxxxxx | xxxxxxxxx |
-
-<!-- additional mapping notes go here -->

--- a/Standard/BisCustomAttributes.remarks.md
+++ b/Standard/BisCustomAttributes.remarks.md
@@ -5,25 +5,27 @@ remarksTarget: BisCustomAttributes.ecschema.md
 
 # BisCustomAttributes
 
-## SchemaLayer
+## Enumerations
+
+### SchemaLayer
 
 A schema at a particular layer can only reference schemas at the same layer or lower.
 
-### Core
+#### Core
 
-Core is the lowest layer in the BIS schema hierarchy. It includes schemas such as *BisCore*, *Analytic* and *Functional*.
+It includes schemas such as *BisCore*, *Analytic* and *Functional*.
 
-### Common
+#### Common
 
 The Common layer is laid out right above Core. Examples of BIS schemas at this layer include *ClassificationSystems*, *NetworkTopology* and *SpatialComposition*.
 
-### DisciplinePhysical
+#### DisciplinePhysical
 
 The Discipline-Physical layer is defined above Common. Examples of BIS schemas at this layer include *Earthwork*, *RoadSpatial* and *StructuralPhysical*.
 
-### DisciplineOther
+#### DisciplineOther
 
-The Discipline-Other layer is defined above Discipline-Physical. Examples of BIS schemas at this layer include *StructuralAnalytical* and *StructuralDesign*.
+The Discipline-Other layer is defined above Discipline-Physical. Examples of BIS schemas at this layer include *StructuralAnalysis*, *IoTDeviceFunctional* and *GeologicalModel*.
 
 ### Application
 
@@ -31,6 +33,8 @@ Application is the highest layer in the BIS schema hierarchy. Examples of BIS sc
 
 Other technology-specific schemas not meant to be referenced by other schemas belong to this layer. Examples include *PresentationRules*, *PointCloud* and *ScalableMesh*.
 
-## SchemaLayerInfo
+## Custom Attribute Classes
+
+### SchemaLayerInfo
 
 BIS schemas should be tagged with the `SchemaLayerInfo` `CustomAttribute` to enable validation and error checking related to schema-references.

--- a/Standard/CoreCustomAttributes.remarks.md
+++ b/Standard/CoreCustomAttributes.remarks.md
@@ -5,15 +5,15 @@ remarksTarget: CoreCustomAttributes.ecschema.md
 
 # CoreCustomAttributes
 
-## ProductionStatusValue
+## Enumerations
 
-The `ProductionStatusValue` enumerations are use in the `ProductionStatus` `CustomAttribute` to declare the schema author's intended and supported workflows for the schema.
+### ProductionStatusValue
 
-### Production
+#### Production
 
 `Production` declares that this schema is suitable for use in production workflows. Data created using this schema will be supported long-term (possibly through transformation).
 
-### FieldTesting
+#### FieldTesting
 
 `FieldTesting` declares that this schema is suitable for field testing of production workflows. Data created using this schema may not be supported long-term and may not be upgradable.
 
@@ -21,23 +21,25 @@ The `ProductionStatusValue` enumerations are use in the `ProductionStatus` `Cust
 
 `NotForProduction` declares that this schema is under development and should never be used for production workflows or by end users at all. Data created with this schema is not supported and may not be upgradable.
 
-### Deprecated
+#### Deprecated
 
 `Deprecated` declares that this schema is no longer recommended for production workflows. Better alternatives exist and should be used instead. `Deprecated` schemas must have been in `Production` at some previous point in time. Note that the `Deprecated` `CustomAttribute` should also be used, and can be used to provide a detailed message.
 
-## ProductionStatus
+## Custom Attribute Classes
 
-The `ProductionStatus` `CustomAttribute` is used by the schema author to declare the suitability of a schema for use in production and other workflows. When a schema is tagged with `ProductionStatus`, the iModel technology stack (or other technology stacks in other circumstances) can proactively prevent schemas from being used in unsupported workflows. The two most obvious usages of this `CustomAttribute` are:
+### ProductionStatus
+
+When a schema is tagged with `ProductionStatus`, the iModel technology stack (or other technology stacks in other circumstances) can proactively prevent schemas from being used in unsupported workflows. The two most obvious usages of this `CustomAttribute` are:
 
 - Preventing development (`NotForProduction`) schemas from being released to customers.
 - Preventing `FieldTesting` schemas from being used in customer's production workflows.
 
 All schemas should be tagged with the `ProductionStatus` `CustomAttribute` to enable this error checking.
 
-### SupportedUse
+#### SupportedUse
 
-The SupportedUse property is used to specify the appropriate `ProductionStatusValue` for the schema. Note that selection of the `Production` for a schema implies a commitment to provide a smooth upgrade for data as the schema changes over time.
+Note that selection of the `Production` for a schema implies a commitment to provide a smooth upgrade for data as the schema changes over time.
 
-### Checksum
+#### Checksum
 
-The Checksum property is set to ensure the schema is not modified after the `ProductionStatus` `CustomAttribute` is applied to it. This property does not need to be set in `NotForProduction` schemas.
+This property does not need to be set in `NotForProduction` schemas.


### PR DESCRIPTION
Several schema remarks contained sections at the wrong md level, leading to those sections to be left out from the final schema documentation.

Updated links to IFC docs now that their final 4.3 version is released.