### PR TITLE
Fix iModelNativeTests Pipeline

### DIFF
--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -89,6 +89,7 @@ stages:
     - template: build/templates/prebuild.yml@imodel-native-internal
       parameters:
         otherRepo: imodel-native
+        nativePR: 'main'
 
     - script: $(PY_EXE) $(CALL_BB_PATH) pull $(BB_V) -a $(BB_ARCH) $(STRATEGY_OVERRIDE)
       displayName: Pull
@@ -257,6 +258,7 @@ stages:
     - template: build/templates/prebuild.yml@imodel-native-internal
       parameters:
         otherRepo: imodel-native
+        nativePR: 'main'
 
     - script: $(PY_EXE) $(CALL_BB_PATH) pull -v $(BB_V) -a $(BB_ARCH) -s $(strategy)
       displayName: Pull


### PR DESCRIPTION
The pipeline is currently failing as the default value of this parameter was removed from the template.