### PR TITLE
iModelNativeTests pipeline fix and path filters

### DIFF
--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -227,8 +227,8 @@ stages:
         nodeVersion: 18.12.x
         runRushAudit: false
         rushBuildCacheEnabled: 0
-        currentBranch: imodel02
-        targetBranch: imodel02
+        currentBranch: master
+        targetBranch: master
 
 - stage: iModeEvolution
   displayName: iModeEvolution Tests

--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -6,6 +6,11 @@ pr:
   branches:
     include:
       - master
+  paths:
+    exclude:
+      - .github/CODEOWNERS
+      - docs/**
+      - cmaps/**
 
 resources:
   repositories:

--- a/tools/testRunner.yaml
+++ b/tools/testRunner.yaml
@@ -13,7 +13,7 @@ pr:
       - master
   paths:
     include:
-      - tools/*
+      - tools/**
 
 workspace:
   clean: all

--- a/tools/testRunner.yaml
+++ b/tools/testRunner.yaml
@@ -11,9 +11,9 @@ pr:
   branches:
     include:
       - master
-  # paths:
-  #   include:
-  #     - tools/*
+  paths:
+    include:
+      - tools/*
 
 workspace:
   clean: all


### PR DESCRIPTION
This PR contains following changes:

- The core-build template should be using the `master` branch.
- `BIS Schemas Tools Test` pipeline execute the tooling tests and it should not be executed with irrelevant changes. 