### PR TITLE
Fixed `ModuleNotFoundError: No module named 'distutils'` Issue

### DIFF
--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -291,7 +291,7 @@ stages:
     - script: |
         pip3 install setuptools
       displayName: 'Install SetupTools'
-      condition: and(succeeded(), eq('BuildMinion03A', variables['Agent.Name']))
+      condition: and(succeeded(), in(variables['Agent.Name'], 'BuildMinion03A', 'BuildMinion03B'))
 
     - script: $(PY_EXE) $(bb) -v $(BB_V) -a $(BB_ARCH) -s $(strategy) build
       displayName: Build

--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -288,6 +288,11 @@ stages:
         )
       displayName: 'Display Source Branch'
 
+    - script: |
+        pip3 install setuptools
+      displayName: 'Install SetupTools'
+      condition: and(succeeded(), eq('BuildMinion03A', variables['Agent.Name']))
+
     - script: $(PY_EXE) $(bb) -v $(BB_V) -a $(BB_ARCH) -s $(strategy) build
       displayName: Build
       env:


### PR DESCRIPTION
The machines having python 3.12 show this issue as this module was deprecated.