### PR TITLE
Adding the "Required" property to connector:RuleViolation

### DIFF
--- a/Domains/4-Application/Connectors/Connector.ecschema.xml
+++ b/Domains/4-Application/Connectors/Connector.ecschema.xml
@@ -3,13 +3,14 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="Connector" alias="connector" version="01.00.00" description="ECClasses used by all connectors" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="Connector" alias="connector" version="01.01.00" description="ECClasses used by all connectors" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.13" alias="bis" />
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
 
     <ECCustomAttributes>
+        <DynamicSchema xmlns="CoreCustomAttributes.01.00.03"/>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
             <SupportedUse>NotForProduction</SupportedUse>
         </ProductionStatus>
@@ -94,6 +95,7 @@
         <ECProperty propertyName="Description" typeName="string" description="A human-readable description of the rule"/>
         <ECProperty propertyName="Violation" typeName="string" description="A human-readable description of a violation of the rule"/>
         <ECProperty propertyName="Solutions" typeName="string" description="A human-readable description of how a violation of the rule can be solved. Individual solutions are separated by the newline character."/>
+        <ECProperty propertyName="Required" typeName="boolean" displayLabel="Is passing this rule required for synchronization?" description="If Required=true, all external entities that violate this rule will be excluded from the synchronization, regardless of how the rule's severity is set."/>
     </ECEntityClass>
 
 </ECSchema>

--- a/Domains/4-Application/Connectors/Released/Connector.01.01.00.ecschema.xml
+++ b/Domains/4-Application/Connectors/Released/Connector.01.01.00.ecschema.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="Connector" alias="connector" version="01.01.00" description="ECClasses used by all connectors" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.13" alias="bis" />
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+
+    <ECCustomAttributes>
+        <DynamicSchema xmlns="CoreCustomAttributes.01.00.03"/>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>NotForProduction</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+
+    <ECEntityClass typeName="RuleViolation" displayLabel="Rule Violation" description="A violation of a connector rule by an external entity">
+        <BaseClass>bis:InformationRecordElement</BaseClass>
+
+        <ECCustomAttributes>
+            <DbIndexList xmlns="ECDbMap.02.00.00">
+                <Indexes>
+                    <DbIndex>
+                        <Name>ix_connector_ruleViolation</Name>
+                        <IsUnique>False</IsUnique>
+                        <Properties>
+                            <string>Repository.id</string>
+                            <string>Kind</string>
+                            <string>Identifier</string>
+                            <string>Rule.id</string>
+                        </Properties>
+                    </DbIndex>
+                </Indexes>
+            </DbIndexList>
+        </ECCustomAttributes>
+
+        <!-- The rule that was violated -->
+        <ECNavigationProperty propertyName="Rule" relationshipName="RuleViolationRefersToDefinition" direction="forward" description="The rule that has been violated."/>
+        
+        <!-- When the violation occurred -->
+        <ECProperty propertyName="UpdateId" typeName="string" description="Identifies the update in which the violation was most recently detected. This is merely a unique identifier. It is not related to a changeset.">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03">
+                    <Show>False</Show>
+                </HiddenProperty>
+            </ECCustomAttributes>
+        </ECProperty>
+
+        <!-- The external entity that caused the violation -->
+        <ECNavigationProperty propertyName="Repository" relationshipName="RuleViolationConcernsRepository" direction="forward" description="The RepositoryLink representing the external file or repository that contains the external entity. Required."/>
+        <ECNavigationProperty propertyName="Source" relationshipName="RuleViolationConcernsSource" direction="forward" description="The ExternalSource that contains the external entity. Optional. Must be within the Repository."/>
+        <ECProperty propertyName="Kind" typeName="string" description="The kind of the external entity."/>
+        <ECProperty propertyName="Identifier" typeName="string" description="The identifier of the external entity."/>
+
+        <!-- More information about how the entity caused the violation -->
+        <ECProperty propertyName="Properties" typeName="string" description="The names of the specific properties of the external entity that caused the violation. CSV. Optional."/>
+        <ECProperty propertyName="Details" typeName="string" description="Additional information about this particular violation. Human-readable. Optional."/>
+        
+    </ECEntityClass>
+
+    <ECRelationshipClass typeName ="RuleViolationConcernsRepository" modifier="Sealed" strength="referencing" strengthDirection="forward" description="Relates a RuleViolation to the repository that contains the offending entity.">
+        <Source multiplicity="(0..*)" roleLabel="is from" polymorphic="true">
+            <Class class="RuleViolation"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel ="is source of" polymorphic="true" >
+            <Class class="bis:RepositoryLink"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName ="RuleViolationConcernsSource" modifier="Sealed" strength="referencing" strengthDirection="forward" description="Relates a RuleViolation to the ExternalSource that contains the offending entity.">
+        <Source multiplicity="(0..*)" roleLabel="is from" polymorphic="true">
+            <Class class="RuleViolation"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel ="is source of" polymorphic="true" >
+            <Class class="bis:ExternalSource"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName ="RuleViolationRefersToDefinition" modifier="Sealed" strength="referencing" strengthDirection="forward" description="Relates a RuleViolation to a RuleDefinition.">
+        <Source multiplicity="(0..*)" roleLabel="of rule" polymorphic="true">
+            <Class class="RuleViolation"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel ="has" polymorphic="true" >
+            <Class class="RuleDefinition"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECEntityClass typeName="RuleDefinition" modifier="Sealed" displayLabel="Connector Rule Definition" description="A standard, constraint, or other condition that a connector imposes on external entities before writing them to an iModel">
+        <BaseClass>bis:DefinitionElement</BaseClass>
+        <ECProperty propertyName="Description" typeName="string" description="A human-readable description of the rule"/>
+        <ECProperty propertyName="Violation" typeName="string" description="A human-readable description of a violation of the rule"/>
+        <ECProperty propertyName="Solutions" typeName="string" description="A human-readable description of how a violation of the rule can be solved. Individual solutions are separated by the newline character."/>
+        <ECProperty propertyName="Required" typeName="boolean" displayLabel="Is passing this rule required for synchronization?" description="If Required=true, all external entities that violate this rule will be excluded from the synchronization, regardless of how the rule's severity is set."/>
+    </ECEntityClass>
+
+</ECSchema>

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ All other changes made outside of a domain group directory will require review b
     },
     ```
 
+    >NOTE: If a verifier is set as a required reviewer it is ok to set `verified` to `Yes` when you create the PR.  As their approval of the PR indicates that they have verified the schema.
+
 1. Update entry to fill out all fields correctly, the only optional field is 'comment'.
 1. Run [Bis Rule Validation](#bis-rule-validation) and [iModel Schema Validation](#imodel-schema-validation) on your new schema and make sure they pass.
 1. Create a PR to merge your branch into master

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -4901,7 +4901,7 @@
       "name": "Connector",
       "path": "Domains\\4-Application\\Connectors\\Connector.ecschema.xml",
       "released": false,
-      "version": "01.00.00",
+      "version": "01.01.00",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Sam.Wilson",

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -4908,6 +4908,20 @@
       "approved": "No",
       "date": "Unknown",
       "dynamic": "No"
+    },
+    {
+      "name": "Connector",
+      "path": "Domains\\4-Application\\Connectors\\Released\\Connector.01.01.00.ecschema.xml",
+      "released": false,
+      "version": "01.01.00",
+      "comment": "",
+      "verifier": "",
+      "sha1": "9bfcf39c1d366d0433f5f845635e96190f416678",
+      "verified": "No",
+      "author": "Sam.Wilson",
+      "date": "7/15/2024",
+      "dynamic": "No",
+      "approved": "No"
     }
   ],
   "SynchroModeler": [

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -4915,13 +4915,13 @@
       "released": false,
       "version": "01.01.00",
       "comment": "",
-      "verifier": "",
+      "verifier": "Colin.Kerr",
       "sha1": "9bfcf39c1d366d0433f5f845635e96190f416678",
-      "verified": "No",
+      "verified": "Yes",
       "author": "Sam.Wilson",
       "date": "7/15/2024",
       "dynamic": "No",
-      "approved": "No"
+      "approved": "Yes"
     }
   ],
   "SynchroModeler": [

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -4912,7 +4912,7 @@
     {
       "name": "Connector",
       "path": "Domains\\4-Application\\Connectors\\Released\\Connector.01.01.00.ecschema.xml",
-      "released": false,
+      "released": true,
       "version": "01.01.00",
       "comment": "",
       "verifier": "Colin.Kerr",

--- a/tools/SchemaValidation/validateSchemas.yaml
+++ b/tools/SchemaValidation/validateSchemas.yaml
@@ -42,7 +42,7 @@ jobs:
     clean: true
 
   - task: CmdLine@2
-    displayName: 'NPM CONFIGURATION'
+    displayName: 'NPM Configuration'
     inputs:
       script: 'npm config list' 
 


### PR DESCRIPTION
In the final step of updating a model, the connector now detects and deletes rule violations involving elements that a) were skipped by a prior update and b) that were caused by external elements that have since been deleted. To support this, I added the "Required" property to connector:RuleViolation. See the description in the schema.