### PR TITLE
Modifications to support Cant Station Points properties with appropriate units

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
@@ -325,16 +325,16 @@
         <ECProperty propertyName="CantStationPoint_DesignSpeed" typeName="double" displayLabel="Design Speed" category="CantStationPoint_Cant_Station_Point" priority="299997" kindOfQuantity="cifu:VELOCITY"/>
         <ECProperty propertyName="CantStationPoint_Radius" typeName="double" displayLabel="Radius" category="CantStationPoint_Cant_Station_Point" priority="299996" kindOfQuantity="cifu:LENGTH"/>
         <ECProperty propertyName="CantStationPoint_Length" typeName="double" displayLabel="Length" category="CantStationPoint_Cant_Station_Point" priority="299995" kindOfQuantity="cifu:LENGTH"/>
-        <ECProperty propertyName="CantStationPoint_EqilibriumCant" typeName="double" displayLabel="Equilibrium Cant" category="CantStationPoint_Cant_Station_Point" priority="299994" kindOfQuantity="cifu:LENGTH"/>
-        <ECProperty propertyName="CantStationPoint_AppliedCant" typeName="double" displayLabel="Applied Cant" category="CantStationPoint_Cant_Station_Point" priority="299993" kindOfQuantity="cifu:LENGTH"/>
-        <ECProperty propertyName="CantStationPoint_CantDeficiency" typeName="double" displayLabel="Cant Deficiency" category="CantStationPoint_Cant_Station_Point" priority="299992" kindOfQuantity="cifu:LENGTH"/>
-        <ECProperty propertyName="CantStationPoint_LateralAcceleration" typeName="string" displayLabel="Non-compensating Lateral Acceleration" category="CantStationPoint_Cant_Station_Point" priority="299991"/>
-        <ECProperty propertyName="CantStationPoint_AppliedRateOfChange" typeName="string" displayLabel="Applied Rate of Change" category="CantStationPoint_Cant_Station_Point" priority="299990"/>
-        <ECProperty propertyName="CantStationPoint_DeficiencyRateOfChange" typeName="string" displayLabel="Deficiency Rate of Change" category="CantStationPoint_Cant_Station_Point" priority="299989"/>
+        <ECProperty propertyName="CantStationPoint_EqilibriumCant" typeName="double" displayLabel="Equilibrium Cant" category="CantStationPoint_Cant_Station_Point" priority="299994" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="CantStationPoint_AppliedCant" typeName="double" displayLabel="Applied Cant" category="CantStationPoint_Cant_Station_Point" priority="299993" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="CantStationPoint_CantDeficiency" typeName="double" displayLabel="Cant Deficiency" category="CantStationPoint_Cant_Station_Point" priority="299992" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="CantStationPoint_LateralAcceleration" typeName="string" displayLabel="Non-compensating Lateral Acceleration" category="CantStationPoint_Cant_Station_Point" priority="299991" kindOfQuantity="cifu:ACCELERATION"/>
+        <ECProperty propertyName="CantStationPoint_AppliedRateOfChange" typeName="string" displayLabel="Applied Rate of Change" category="CantStationPoint_Cant_Station_Point" priority="299990" kindOfQuantity="cifu:VELOCITY_SLOW"/>
+        <ECProperty propertyName="CantStationPoint_DeficiencyRateOfChange" typeName="string" displayLabel="Deficiency Rate of Change" category="CantStationPoint_Cant_Station_Point" priority="299989" kindOfQuantity="cifu:VELOCITY_SLOW"/>
         <ECProperty propertyName="CantStationPoint_AppGrad" typeName="string" displayLabel="Applied Gradient" category="CantStationPoint_Cant_Station_Point" priority="299988"/>
-        <ECProperty propertyName="CantStationPoint_LeftRail" typeName="double" displayLabel="Left Rail" category="CantStationPoint_Cant_Station_Point" priority="299987" kindOfQuantity="cifu:LENGTH"/>
-        <ECProperty propertyName="CantStationPoint_RightRail" typeName="double" displayLabel="Right Rail" category="CantStationPoint_Cant_Station_Point" priority="299985" kindOfQuantity="cifu:LENGTH"/>
-        <ECProperty propertyName="CantStationPoint_Center" typeName="double" displayLabel="Center" category="CantStationPoint_Cant_Station_Point" priority="299986" kindOfQuantity="cifu:LENGTH"/>
+        <ECProperty propertyName="CantStationPoint_LeftRail" typeName="double" displayLabel="Left Rail" category="CantStationPoint_Cant_Station_Point" priority="299987" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="CantStationPoint_RightRail" typeName="double" displayLabel="Right Rail" category="CantStationPoint_Cant_Station_Point" priority="299985" kindOfQuantity="cifu:LENGTH_SHORT"/>
+        <ECProperty propertyName="CantStationPoint_Center" typeName="double" displayLabel="Center" category="CantStationPoint_Cant_Station_Point" priority="299986" kindOfQuantity="cifu:LENGTH_SHORT"/>
 	<ECProperty propertyName="CantStationPoint_Status" typeName="string" displayLabel="Fixed" category="CantStationPoint_Cant_Station_Point" priority="299984"/>
     </ECEntityClass>
     <ECEntityClass typeName="CantTableEntryAspect">

--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifUnits.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifUnits.ecschema.xml
@@ -37,6 +37,7 @@
     <Unit typeName="REACTION_PER_HR" phenomenon="u:FREQUENCY" unitSystem="u:INTERNATIONAL" definition="u:HR(-1)" displayLabel="/hr" />
     <Unit typeName="REACTION_PER_DAY" phenomenon="u:FREQUENCY" unitSystem="u:INTERNATIONAL" definition="u:DAY(-1)" displayLabel="/day" />
 
+    <KindOfQuantity typeName="ACCELERATION" displayLabel="Civil Designer Products Acceleration" persistenceUnit="u:M_PER_SEC_SQ" presentationUnits="f:DefaultRealU(2)[u:M_PER_SEC_SQ];f:DefaultRealU(2)[u:FT_PER_SEC_SQ]" relativeError="0.0001"/>
     <KindOfQuantity typeName="ANGLE" displayLabel="Civil Designer Products Angle" persistenceUnit="u:RAD" presentationUnits="f:DefaultRealU(2)[u:ARC_DEG];f:AngleDMS" relativeError="0.0001"/>
     <KindOfQuantity typeName="AREA" displayLabel="Civil Designer Products Area" persistenceUnit="u:SQ_M" presentationUnits="f:DefaultRealU(2)[u:SQ_M];f:DefaultRealU(2)[u:SQ_FT];f:DefaultRealU(2)[u:SQ_US_SURVEY_FT]" relativeError="0.0001"/>
 	<KindOfQuantity typeName="AREA_DRAINAGE" displayLabel="Civil Designer Products Area" persistenceUnit="u:SQ_M" presentationUnits="f:DefaultRealU(2)[u:SQ_M];f:DefaultRealU(2)[u:SQ_FT];f:DefaultRealU(2)[u:SQ_US_SURVEY_FT]" relativeError="0.0001"/>
@@ -97,6 +98,7 @@
     <KindOfQuantity typeName="TIME_FLOW" displayLabel="Civil Designer Products Time Flow" persistenceUnit="u:S" presentationUnits="f:DefaultRealU(2)[u:MIN]" relativeError="0.0001"/>
     <KindOfQuantity typeName="UNITLESS_PRICE" displayLabel="Civil Designer Products Unitless Price" persistenceUnit="u:COEFFICIENT" presentationUnits="f:DefaultReal(2)[u:COEFFICIENT]" relativeError="0.0001"/>
     <KindOfQuantity typeName="VELOCITY" displayLabel="Civil Designer Products Velocity" persistenceUnit="u:M_PER_SEC" presentationUnits="f:DefaultRealU(2)[u:KM_PER_HR];f:DefaultRealU(2)[u:MPH]" relativeError="0.0001"/>
+    <KindOfQuantity typeName="VELOCITY_SLOW" displayLabel="Civil Designer Products Velocity Short" persistenceUnit="u:M_PER_SEC" presentationUnits="f:DefaultRealU(2)[u:MM_PER_SEC];f:DefaultRealU(2)[u:IN_PER_SEC]" relativeError="0.0001"/>
     <KindOfQuantity typeName="VOLUME" displayLabel="Civil Designer Products Volume" persistenceUnit="u:CUB_M" presentationUnits="f:DefaultRealU(2)[u:CUB_M];f:DefaultRealU(2)[u:CUB_FT];f:DefaultRealU(2)[u:CUB_US_SURVEY_FT];f:DefaultRealU(2)[u:GALLON]" relativeError="0.0001"/>
     <KindOfQuantity typeName="VOLUME_LARGE" displayLabel="Civil Designer Products Volume Large" persistenceUnit="u:CUB_M" presentationUnits="f:DefaultRealU(2)[u:MILLION_LITRE];f:DefaultRealU(2)[u:MILLION_GALLON]" relativeError="0.0001"/>
     <KindOfQuantity typeName="WEIR_COEFFICIENT" displayLabel="Civil Designer Products Weir Coefficient" persistenceUnit="u:COEFFICIENT" presentationUnits="f:DefaultReal(2)[u:COEFFICIENT]" relativeError="0.0001"/>


### PR DESCRIPTION
To correctly show the Cant Station Points properties in iModel, modifications in CifUnits and CifRail schemas are added.