### PR TITLE
Change IsmPipingNode class property name

### DIFF
--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -1416,7 +1416,7 @@
 
     <ECEntityClass typeName="IsmPipingNode" modifier="Sealed" displayLabel="Piping Node">
         <BaseClass>IsmNode</BaseClass>
-        <ECProperty propertyName="Type" typeName="PipingJoint" displayLabel="Type" />
+        <ECProperty propertyName="JointType" typeName="PipingJoint" displayLabel="Type" />
         <ECProperty propertyName="WeldSize" typeName="double" displayLabel="Weld Size" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="OffsetJoint" typeName="double" displayLabel="Offset Joint" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="OffsetAverage" typeName="double" displayLabel="Offset Average" kindOfQuantity="AECU:LENGTH_SHORT" />


### PR DESCRIPTION
Changed IsmPipingNode class property name from incorrect `Type` to `JointType`.