### PR TITLE
Release CifBridge schema which will hide the Build Order fields in iModel for all OBM objects

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifBridge.01.00.13.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifBridge.01.00.13.ecschema.xml
@@ -3,16 +3,16 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifBridge" alias="cifbrg" version="01.00.14" description="iModel Connector schema containing aspect classes with properties from OpenBridge Modeler." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifBridge" alias="cifbrg" version="01.00.13" description="iModel Connector schema containing aspect classes with properties from OpenBridge Modeler." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
-    <ECSchemaReference name="CifCommon" version="01.00.10" alias="cifcmn"/>
-    <ECSchemaReference name="CifUnits" version="01.00.08" alias="cifu"/>
+    <ECSchemaReference name="CifCommon" version="01.00.09" alias="cifcmn"/>
+    <ECSchemaReference name="CifUnits" version="01.00.07" alias="cifu"/>
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA"/>
     <ECSchemaReference name="SchemaUpgradeCustomAttributes" version="01.00.00" alias="SchemaUpgradeCA"/>
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.04">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>Production</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -3081,7 +3081,7 @@
       "name": "CifBridge",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifBridge.ecschema.xml",
       "released": false,
-      "version": "01.00.13",
+      "version": "01.00.14",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3268,6 +3268,20 @@
       "verified": "Yes",
       "author": "Monmohan.Bordoloi",
       "date": "8/14/2024",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "CifBridge",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifBridge.01.00.13.ecschema.xml",
+      "released": true,
+      "version": "01.00.13",
+      "comment": "Hide the Build Order fields in iModel",
+      "verifier": "Colin.Kerr",
+      "sha1": "6b3f2682945ca16a7ec9dda542080d0294fe0a19",
+      "verified": "Yes",
+      "author": "Sachin.Bhosale",
+      "date": "9/18/2024",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
Release CifBridge schema which will hide the Build Order fields in iModel