### PR TITLE
adding schema for design pipe sizes

### DIFF
--- a/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
+++ b/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
@@ -369,4 +369,35 @@
     <ECProperty propertyName="MeasureCoverTo" typeName="MeasureCoverTo" displayLabel="Measure Cover To" category="HydraulicData"/>
 		<ECProperty propertyName="IsPartFullDesign" typeName="boolean" displayLabel="Is Part Full Design" category="HydraulicData"/>
 	</ECEntityClass>
+
+	  <ECEntityClass typeName="PipeSet" modifier="Sealed" displayLabel="Pipe Set">
+    <BaseClass>bis:DefinitionElement</BaseClass>
+    <ECProperty propertyName="Shape" typeName="PipeShape" displayLabel="Shape"  category="HydraulicData"/>
+    <ECProperty propertyName="Material" typeName="string" displayLabel="Material"  category="HydraulicData"/>
+  </ECEntityClass>
+  
+  <ECRelationshipClass typeName="PipeSetOwnsPipeSetItem" strength="embedding" modifier="Sealed">
+    <BaseClass>bis:ElementOwnsChildElements</BaseClass>
+    <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+      <Class class="PipeSet"/>
+    </Source>
+    <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
+      <Class class="PipeSetItem"/>
+    </Target>
+  </ECRelationshipClass>
+  
+  <ECEntityClass typeName="PipeSetItem" modifier="Sealed" displayLabel="Pipe Item">
+    <BaseClass>bis:DefinitionElement</BaseClass>
+    <ECProperty propertyName="Manningsn" typeName="double" displayLabel="Manning's n" category="HydraulicData"/>
+  </ECEntityClass>
+  
+  <ECRelationshipClass typeName="PipeSetItemOwnsPipeShapeAspect" strength="embedding" modifier="Sealed">
+    <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+    <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+      <Class class="PipeSetItem"/>
+    </Source>
+    <Target multiplicity="(1..1)" roleLabel="owned by" polymorphic="true">
+      <Class class="PipeShapeAspect"/>
+    </Target>
+  </ECRelationshipClass>
 </ECSchema>

--- a/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
+++ b/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
@@ -370,7 +370,7 @@
 		<ECProperty propertyName="IsPartFullDesign" typeName="boolean" displayLabel="Is Part Full Design" category="HydraulicData"/>
 	</ECEntityClass>
 
-	  <ECEntityClass typeName="PipeSet" modifier="Sealed" displayLabel="Pipe Set">
+	  <ECEntityClass typeName="PipeSizeSet" modifier="Sealed" displayLabel="Pipe Sizes">
     <BaseClass>bis:DefinitionElement</BaseClass>
     <ECProperty propertyName="Shape" typeName="PipeShape" displayLabel="Shape"  category="HydraulicData"/>
     <ECProperty propertyName="Material" typeName="string" displayLabel="Material"  category="HydraulicData"/>
@@ -379,14 +379,14 @@
   <ECRelationshipClass typeName="PipeSetOwnsPipeSetItem" strength="embedding" modifier="Sealed">
     <BaseClass>bis:ElementOwnsChildElements</BaseClass>
     <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
-      <Class class="PipeSet"/>
+      <Class class="PipeSizeSet"/>
     </Source>
     <Target multiplicity="(0..*)" roleLabel="owned by" polymorphic="false">
-      <Class class="PipeSetItem"/>
+      <Class class="PipeSize"/>
     </Target>
   </ECRelationshipClass>
   
-  <ECEntityClass typeName="PipeSetItem" modifier="Sealed" displayLabel="Pipe Item">
+  <ECEntityClass typeName="PipeSize" modifier="Sealed" displayLabel="Pipe Item">
     <BaseClass>bis:DefinitionElement</BaseClass>
     <ECProperty propertyName="Manningsn" typeName="double" displayLabel="Manning's n" category="HydraulicData"/>
   </ECEntityClass>
@@ -394,7 +394,7 @@
   <ECRelationshipClass typeName="PipeSetItemOwnsPipeShapeAspect" strength="embedding" modifier="Sealed">
     <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
     <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
-      <Class class="PipeSetItem"/>
+      <Class class="PipeSize"/>
     </Source>
     <Target multiplicity="(1..1)" roleLabel="owned by" polymorphic="true">
       <Class class="PipeShapeAspect"/>


### PR DESCRIPTION
Adding two new Definition elements to allow users to define which shapes and materials to use in the automated design.

- Pipe Size Set - A set of pipe sizes with the same shape and material.... and owns a set of Pipe Sizes
- Pipe Size - gives a selectable unique id for each pipe size along with an initial roughness value...
-  Each pipe size points to a PipeShapeAspect which already exists