### PR TITLE
Add categories for ECClasses + various small fixes

### DIFF
--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -1642,7 +1642,7 @@
         <ECProperty propertyName="GapDown" typeName="double" displayLabel="Gap Down" category="IsmPipingVStopSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapUp" typeName="double" displayLabel="Gap Up" category="IsmPipingVStopSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapType" typeName="PipingVStopSupportGap" category="IsmPipingVStopSupport_category" displayLabel="Gap Type" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingVStopSupport_category" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingVStopSupport_category" kindOfQuantity="Coefficient3DP" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingSupportGapType" backingTypeName="int" isStrict="true" description="Piping Support Weight Gap.">
@@ -1707,7 +1707,7 @@
         <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" category="IsmPipingTieLinkSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" category="IsmPipingTieLinkSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingTieLinkSupport_category" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingTieLinkSupport_category" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingTieLinkSupport_category" kindOfQuantity="Coefficient3DP" />
     </ECEntityClass>
 
     <ECEnumeration typeName="AxialBehavior" backingTypeName="int" isStrict="true" description="Axial Behavior.">

--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -5,6 +5,8 @@
     <ECSchemaReference name="BisCore" version="01.00.14" alias="bis" />
     <ECSchemaReference name="Analytical" version="01.00.00" alias="anlyt" />
     <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU" />
+    <ECSchemaReference name="Units" version="01.00.04" alias="u" />
+    <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
 
     <PropertyCategory typeName="Calculated_category" displayLabel="Calculated" priority="0" />
 
@@ -523,15 +525,16 @@
         <BaseClass>IsmMaterial</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmNodeLink_category" displayLabel="Node Link Fixity" priority="190" />
     <ECEntityClass typeName="IsmNodeLink" displayLabel="Node Link" modifier="Sealed" >
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="RAxisTranslationFixity" typeName="boolean" displayLabel="R-Axis Translation Fixity" />
-        <ECProperty propertyName="SAxisTranslationFixity" typeName="boolean" displayLabel="S-Axis Translation Fixity" />
-        <ECProperty propertyName="TAxisTranslationFixity" typeName="boolean" displayLabel="T-Axis Translation Fixity" />
-        <ECProperty propertyName="RAxisRotationFixity" typeName="boolean" displayLabel="R-Axis Rotation Fixity" />
-        <ECProperty propertyName="SAxisRotationFixity" typeName="boolean" displayLabel="S-Axis Rotation Fixity" />
-        <ECProperty propertyName="TAxisRotationFixity" typeName="boolean" displayLabel="T-Axis Rotation Fixity" />
+        <ECProperty propertyName="RAxisTranslationFixity" typeName="boolean" displayLabel="R-Axis Translation Fixity" category="IsmNodeLink_category" />
+        <ECProperty propertyName="SAxisTranslationFixity" typeName="boolean" displayLabel="S-Axis Translation Fixity" category="IsmNodeLink_category" />
+        <ECProperty propertyName="TAxisTranslationFixity" typeName="boolean" displayLabel="T-Axis Translation Fixity" category="IsmNodeLink_category" />
+        <ECProperty propertyName="RAxisRotationFixity" typeName="boolean" displayLabel="R-Axis Rotation Fixity" category="IsmNodeLink_category" />
+        <ECProperty propertyName="SAxisRotationFixity" typeName="boolean" displayLabel="S-Axis Rotation Fixity" category="IsmNodeLink_category" />
+        <ECProperty propertyName="TAxisRotationFixity" typeName="boolean" displayLabel="T-Axis Rotation Fixity" category="IsmNodeLink_category" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmNodeLink_StartNode" strength="referencing" strengthDirection="forward" modifier="Sealed">
@@ -642,34 +645,37 @@
         <ECProperty propertyName="AutoGroupBarWeight" typeName="double" displayLabel="Group Bar Weight" category="Calculated_category" kindOfQuantity="AECU:WEIGHT" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmGrid_category" displayLabel="Grid" priority="190" />
     <ECEntityClass typeName="IsmGrid" modifier="Abstract" displayLabel="Grid" >
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="RAxis" typeName="Point3d" displayLabel="R Axis" />
-        <ECProperty propertyName="SAxis" typeName="Point3d" displayLabel="S Axis" />
-        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Origin" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="RAxis" typeName="Point3d" displayLabel="R Axis" category="IsmGrid_category" />
+        <ECProperty propertyName="SAxis" typeName="Point3d" displayLabel="S Axis" category="IsmGrid_category" />
+        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Origin" category="IsmGrid_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmCartesianGrid" modifier="Sealed" displayLabel="Cartesian Grid">
         <BaseClass>IsmGrid</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmGridLine_category" displayLabel="Grid Line" priority="190" />
     <ECEntityClass typeName="IsmGridLine" modifier="Abstract" displayLabel="Grid Line" >
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmSubObject</BaseClass>
-        <ECProperty propertyName="IsMajor" typeName="boolean" displayLabel="Is Major" />
-        <ECProperty propertyName="StartBubble" typeName="boolean" displayLabel="Start Bubble" />
-        <ECProperty propertyName="StartBubbleOffset" typeName="double" displayLabel="Start Bubble Offset" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="EndBubble" typeName="boolean" displayLabel="End Bubble" />
-        <ECProperty propertyName="EndBubbleOffset" typeName="double" displayLabel="End Bubble Offset" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="IsMajor" typeName="boolean" displayLabel="Is Major" category="IsmGridLine_category" />
+        <ECProperty propertyName="StartBubble" typeName="boolean" displayLabel="Start Bubble" category="IsmGridLine_category" />
+        <ECProperty propertyName="StartBubbleOffset" typeName="double" displayLabel="Start Bubble Offset" category="IsmGridLine_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="EndBubble" typeName="boolean" displayLabel="End Bubble" category="IsmGridLine_category" />
+        <ECProperty propertyName="EndBubbleOffset" typeName="double" displayLabel="End Bubble Offset" category="IsmGridLine_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmCartesianGridLine_category" displayLabel="Cartesian Grid Line" priority="180" />
     <ECEntityClass typeName="IsmCartesianGridLine" modifier="Sealed" displayLabel="Cartesian Grid Line">
         <BaseClass>IsmGridLine</BaseClass>
-        <ECProperty propertyName="Coordinate" typeName="double" displayLabel="Coordinate" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="GridLineKind" typeName="IsmCartesianGridLineKind" displayLabel="Grid Line Kind" />
-        <ECProperty propertyName="MaximumExtent" typeName="double" displayLabel="Maximum Extent" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="MinimumExtent" typeName="double" displayLabel="Minimum Extent" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Coordinate" typeName="double" displayLabel="Coordinate" category="IsmCartesianGridLine_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="GridLineKind" typeName="IsmCartesianGridLineKind" displayLabel="Grid Line Kind" category="IsmCartesianGridLine_category" />
+        <ECProperty propertyName="MaximumExtent" typeName="double" displayLabel="Maximum Extent" category="IsmCartesianGridLine_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="MinimumExtent" typeName="double" displayLabel="Minimum Extent" category="IsmCartesianGridLine_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
     <PropertyCategory typeName="IsmParallelRebar_category" displayLabel="Parallel Rebar" priority="180" />
@@ -713,11 +719,12 @@
         <ECProperty propertyName="Diameter" typeName="double" displayLabel="Diameter" category="IsmCircleTieRebar_category" kindOfQuantity="AECU:LENGTH_SHORT" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmCircularGridLine_category" displayLabel="Circular Grid Line" priority="180" />
     <ECEntityClass typeName="IsmCircularGridLine" modifier="None" displayLabel="Circular Grid Line">
         <BaseClass>IsmGridLine</BaseClass>
-        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="MinimumAngle" typeName="double" displayLabel="Minimum Angle" kindOfQuantity="AECU:ANGLE" />
-        <ECProperty propertyName="MaximumAngle" typeName="double" displayLabel="Maximum Angle" kindOfQuantity="AECU:ANGLE" />
+        <ECProperty propertyName="Radius" typeName="double" displayLabel="Radius" category="IsmCircularGridLine_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="MinimumAngle" typeName="double" displayLabel="Minimum Angle" category="IsmCircularGridLine_category" kindOfQuantity="AECU:ANGLE" />
+        <ECProperty propertyName="MaximumAngle" typeName="double" displayLabel="Maximum Angle" category="IsmCircularGridLine_category" kindOfQuantity="AECU:ANGLE" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmCompositeDeck" modifier="None" displayLabel="Composite Deck">
@@ -793,13 +800,14 @@
         <ECProperty propertyName="UseProjectedScale" typeName="boolean" displayLabel="Use Projected Scale" category="IsmForceMemberLoad_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmCurveForceMemberLoad_category" displayLabel="Curve Force Member Load" priority="170" />
     <ECEntityClass typeName="IsmCurveForceMemberLoad" modifier="Sealed" displayLabel="Curve Force Member Load">
-        <BaseClass>IsmLoad</BaseClass>
-        <ECProperty propertyName="Force0" typeName="Point3d" displayLabel="Force #0" kindOfQuantity="AECU:LINEAR_FORCE" />
-        <ECProperty propertyName="Force1" typeName="Point3d" displayLabel="Force #1" kindOfQuantity="AECU:LINEAR_FORCE" />
-        <ECProperty propertyName="Moment0" typeName="Point3d" displayLabel="Moment #0" kindOfQuantity="AECU:LINEAR_MOMENT" />
-        <ECProperty propertyName="Moment1" typeName="Point3d" displayLabel="Moment #1" kindOfQuantity="AECU:LINEAR_MOMENT" />
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
+        <BaseClass>IsmForceMemberLoad</BaseClass>
+        <ECProperty propertyName="Force0" typeName="Point3d" displayLabel="Force #0" category="IsmCurveForceMemberLoad_category" kindOfQuantity="AECU:LINEAR_FORCE" />
+        <ECProperty propertyName="Force1" typeName="Point3d" displayLabel="Force #1" category="IsmCurveForceMemberLoad_category" kindOfQuantity="AECU:LINEAR_FORCE" />
+        <ECProperty propertyName="Moment0" typeName="Point3d" displayLabel="Moment #0" category="IsmCurveForceMemberLoad_category" kindOfQuantity="AECU:LINEAR_MOMENT" />
+        <ECProperty propertyName="Moment1" typeName="Point3d" displayLabel="Moment #1" category="IsmCurveForceMemberLoad_category" kindOfQuantity="AECU:LINEAR_MOMENT" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmCurveForceMemberLoad_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="IsmCurveMemberPlacementPoint" backingTypeName="int" isStrict="true" description="Placement Point.">
@@ -885,18 +893,19 @@
         <ECEnumerator value="20" name="Ultimate" displayLabel="Ultimate" description="Ultimate." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmCurveMember_category" displayLabel="Curve Member" priority="180" />
     <ECEntityClass typeName="IsmCurveMember" displayLabel="Curve Member" modifier="Sealed">
         <BaseClass>IsmSpanningMember</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location (ICurve)" />
-        <ECProperty propertyName="AxialBehavior" typeName="AxialBehavior" displayLabel="Axial Behavior" />
-        <ECProperty propertyName="Camber" typeName="double" displayLabel="Camber" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="MirrorShapeAboutYAxis" typeName="boolean" displayLabel="Mirror Shape about Y-Axis" />
-        <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" />
-        <ECProperty propertyName="PlacementPoint" typeName="IsmCurveMemberPlacementPoint" displayLabel="Placement Point" />
-        <ECProperty propertyName="SystemKind" typeName="IsmCurveMemberSystemKind" displayLabel="System Kind" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location (ICurve)" category="IsmCurveMember_category" />
+        <ECProperty propertyName="AxialBehavior" typeName="AxialBehavior" displayLabel="Axial Behavior" category="IsmCurveMember_category" />
+        <ECProperty propertyName="Camber" typeName="double" displayLabel="Camber" kindOfQuantity="AECU:LENGTH_SHORT" category="IsmCurveMember_category" />
+        <ECProperty propertyName="MirrorShapeAboutYAxis" typeName="boolean" displayLabel="Mirror Shape about Y-Axis" category="IsmCurveMember_category" />
+        <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" category="IsmCurveMember_category" />
+        <ECProperty propertyName="PlacementPoint" typeName="IsmCurveMemberPlacementPoint" displayLabel="Placement Point" category="IsmCurveMember_category" />
+        <ECProperty propertyName="SystemKind" typeName="IsmCurveMemberSystemKind" displayLabel="System Kind" category="IsmCurveMember_category" />
         <ECArrayProperty propertyName="SteelConnectionTagAtStart" typeName="string" displayLabel="Steel Connection Tag at Start" />
         <ECArrayProperty propertyName="SteelConnectionTagAtEnd" typeName="string" displayLabel="Steel Connection Tag at End" />
-        <ECProperty propertyName="Use" typeName="IsmCurveMemberUse" displayLabel="Use" />
+        <ECProperty propertyName="Use" typeName="IsmCurveMemberUse" displayLabel="Use" category="IsmCurveMember_category" />
         <ECProperty propertyName="RAxisTranslationFixity1" typeName="boolean" displayLabel="R-Axis Translation Fixity #1" />
         <ECProperty propertyName="SAxisTranslationFixity1" typeName="boolean" displayLabel="S-Axis Translation Fixity #1" />
         <ECProperty propertyName="TAxisTranslationFixity1" typeName="boolean" displayLabel="T-Axis Translation Fixity #1" />
@@ -914,9 +923,9 @@
         <ECProperty propertyName="ReactionMomentAtStart" typeName="double" displayLabel="Reaction Moment at Start" kindOfQuantity="AECU:MOMENT" />
         <ECProperty propertyName="ReactionMomentAtEnd" typeName="double" displayLabel="Reaction Moment at End" kindOfQuantity="AECU:MOMENT" />
         <ECProperty propertyName="ReactionLimitState" typeName="ReactionLimitState" displayLabel="Reaction Limit State" />
-        <ECProperty propertyName="AutoLength" typeName="double" displayLabel="Length" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="AutoVolume" typeName="double" displayLabel="Volume" kindOfQuantity="AECU:VOLUME" />
-        <ECProperty propertyName="AutoWeight" typeName="double" displayLabel="Weight" kindOfQuantity="AECU:WEIGHT" />
+        <ECProperty propertyName="AutoLength" typeName="double" displayLabel="Length" category="Calculated_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="AutoVolume" typeName="double" displayLabel="Volume" category="Calculated_category" kindOfQuantity="AECU:VOLUME" />
+        <ECProperty propertyName="AutoWeight" typeName="double" displayLabel="Weight" category="Calculated_category" kindOfQuantity="AECU:WEIGHT" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmCurveMember_Material" strength="referencing" strengthDirection="forward" modifier="Sealed">
@@ -943,17 +952,18 @@
         <BaseClass>IsmMember</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmCurveSupport_category" displayLabel="Curve Support" priority="180" />
     <ECEntityClass typeName="IsmCurveSupport" displayLabel="Curve Support" modifier="Sealed">
         <BaseClass>IsmSupportMember</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="TAxis" typeName="Point3d" displayLabel="T-Axis" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="RAxisTranslationDirection" typeName="int" displayLabel="R-Axis Translation Direction" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="SAxisTranslationDirection" typeName="int" displayLabel="S-Axis Translation Direction" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="TAxisTranslationDirection" typeName="int" displayLabel="T-Axis Translation Direction" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmCurveSupport_category" />
+        <ECProperty propertyName="TAxis" typeName="Point3d" displayLabel="T-Axis" category="IsmCurveSupport_category" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:LINEAR_SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="R-Axis Translation Direction" category="IsmCurveSupport_category" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:LINEAR_SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="S-Axis Translation Direction" category="IsmCurveSupport_category" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:LINEAR_SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="T-Axis Translation Direction" category="IsmCurveSupport_category" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmCustomData" modifier="Sealed" displayLabel="Custom Data">
@@ -966,15 +976,17 @@
         <ECProperty propertyName="Data" typeName="string" displayLabel="Data" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmCustomGrid_category" displayLabel="Custom Grid" priority="180" />
     <ECEntityClass typeName="IsmCustomGrid" modifier="Sealed" displayLabel="Custom Grid">
         <BaseClass>IsmGrid</BaseClass>
-        <ECArrayProperty propertyName="AxisGroups" typeName="string" displayLabel="Axis Groups" />
+        <ECArrayProperty propertyName="AxisGroups" typeName="string" displayLabel="Axis Groups" category="IsmCustomGrid_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmCustomGridLine_category" displayLabel="Custom Grid Line" priority="180" />
     <ECEntityClass typeName="IsmCustomGridLine" modifier="Sealed" displayLabel="Custom Grid Line">
         <BaseClass>IsmGridLine</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="AxisGroup" typeName="string" displayLabel="Axis Group" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmCustomGridLine_category" />
+        <ECProperty propertyName="AxisGroup" typeName="string" displayLabel="Axis Group" category="IsmCustomGridLine_category" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmCustomParallelRebar" modifier="Sealed" displayLabel="Custom Parallel Rebar">
@@ -1263,12 +1275,13 @@
         <ECEnumerator value="10000" name="Other" displayLabel="Other" description="Other." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmLoadCase_category" displayLabel="Load Case" priority="190" />
     <ECEntityClass typeName="IsmLoadCase" modifier="Sealed" displayLabel="Load Case">
         <BaseClass>IsmLoadContainer</BaseClass>
-        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" />
-        <ECProperty propertyName="AnalysisKind" typeName="LoadAnalysisCase" displayLabel="Analysis Kind" />
-        <ECProperty propertyName="IncludesSelfWeightLoads" typeName="boolean" displayLabel="Includes Self Weight Loads" />
-        <ECProperty propertyName="LoadCause" typeName="LoadCause" displayLabel="Load Cause" />
+        <ECProperty propertyName="Description" typeName="string" displayLabel="Description" category="IsmLoadCase_category" />
+        <ECProperty propertyName="AnalysisKind" typeName="LoadAnalysisCase" displayLabel="Analysis Kind" category="IsmLoadCase_category" />
+        <ECProperty propertyName="IncludesSelfWeightLoads" typeName="boolean" displayLabel="Includes Self Weight Loads" category="IsmLoadCase_category" />
+        <ECProperty propertyName="LoadCause" typeName="LoadCause" displayLabel="Load Cause" category="IsmLoadCase_category" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmLoad_LoadCase" strength="referencing" strengthDirection="forward" modifier="Sealed">
@@ -1290,10 +1303,11 @@
         <BaseClass>IsmMaterial</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmStory_category" displayLabel="Story" priority="190" />
     <ECEntityClass typeName="IsmStory" modifier="Sealed" displayLabel="Story">
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="ReferenceElevation" typeName="double" displayLabel="Reference Elevation" />
+        <ECProperty propertyName="ReferenceElevation" typeName="double" displayLabel="Reference Elevation" category="IsmStory_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmMember_Story" strength="referencing" strengthDirection="forward" modifier="Sealed">
@@ -1316,26 +1330,34 @@
         </Target>
     </ECRelationshipClass>
 
+    <ECEnumeration typeName="IsmFixityDirection" backingTypeName="int" isStrict="true" description="Fixity Direction.">
+        <ECEnumerator value="1" name="CompressionOnly" displayLabel="Compression Only" description="Compression Only." />
+        <ECEnumerator value="2" name="TensionOnly" displayLabel="Tension Only" description="Tension Only." />
+        <ECEnumerator value="3" name="CompressionAndTension" displayLabel="Compression And Tension" description="Compression And Tension." />
+    </ECEnumeration>
+
+    <PropertyCategory typeName="IsmPointSupport_category" displayLabel="Point Support" priority="180" />
     <ECEntityClass typeName="IsmPointSupport" displayLabel="Point Support" modifier="Sealed">
         <BaseClass>IsmSupportMember</BaseClass>
-        <ECProperty propertyName="RAxis" typeName="Point3d" />
-        <ECProperty propertyName="SAxis" typeName="Point3d" />
-        <ECProperty propertyName="Location" typeName="Point3d" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
-        <ECProperty propertyName="RAxisTranslationDirection" typeName="int" displayLabel="R-Axis Translation Direction" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
-        <ECProperty propertyName="SAxisTranslationDirection" typeName="int" displayLabel="S-Axis Translation Direction" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
-        <ECProperty propertyName="TAxisTranslationDirection" typeName="int" displayLabel="T-Axis Translation Direction" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxis" typeName="Point3d" category="IsmPointSupport_category" />
+        <ECProperty propertyName="SAxis" typeName="Point3d" category="IsmPointSupport_category" />
+        <ECProperty propertyName="Location" typeName="Point3d" category="IsmPointSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="R-Axis Translation Direction" category="IsmPointSupport_category" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="S-Axis Translation Direction" category="IsmPointSupport_category" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="T-Axis Translation Direction" category="IsmPointSupport_category" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmNode_category" displayLabel="Node" priority="190" />
     <ECEntityClass typeName="IsmNode" displayLabel="Node" modifier="None" >
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" category="IsmNode_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmNode_Members" strength="referencing" strengthDirection="forward" modifier="Sealed">
@@ -1363,23 +1385,25 @@
         <BaseClass>IsmSteelDeck</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingLine_category" displayLabel="Piping Line" priority="190" />
     <ECEntityClass typeName="IsmPipingLine" modifier="Sealed" displayLabel="Piping Line">
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" />
+        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" category="IsmPipingLine_category" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmPipingMember" modifier="Abstract" displayLabel="Piping Member">
         <BaseClass>IsmMember</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingComponent_category" displayLabel="Piping Component" priority="180" />
     <ECEntityClass typeName="IsmPipingComponent" modifier="Abstract" displayLabel="Piping Component">
         <BaseClass>IsmPipingMember</BaseClass>
-        <ECProperty propertyName="IsRigid" typeName="boolean" displayLabel="Is Rigid" />
-        <ECProperty propertyName="Diameter" typeName="double" displayLabel="Diameter" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="NominalDiameter" typeName="double" displayLabel="Nominal Diameter" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="WallThickness" typeName="double" displayLabel="Wall Thickness" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" />
+        <ECProperty propertyName="IsRigid" typeName="boolean" displayLabel="Is Rigid" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="Diameter" typeName="double" displayLabel="Diameter" category="IsmPipingComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="NominalDiameter" typeName="double" displayLabel="Nominal Diameter" category="IsmPipingComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="WallThickness" typeName="double" displayLabel="Wall Thickness" category="IsmPipingComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" category="IsmPipingComponent_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingBranchingType" backingTypeName="int" isStrict="true" description="Piping Branching Type.">
@@ -1392,11 +1416,12 @@
         <ECEnumerator value="70" name="Other" displayLabel="Other" description="Other." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingRunComponent_category" displayLabel="Piping Run Component" priority="170" />
     <ECEntityClass typeName="IsmPipingRunComponent" modifier="Sealed" displayLabel="Piping Run Component">
         <BaseClass>IsmPipingComponent</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="StartBranchingType" typeName="PipingBranchingType" displayLabel="Start Branching Type" />
-        <ECProperty propertyName="EndBranchingType" typeName="PipingBranchingType" displayLabel="End Branching Type" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="StartBranchingType" typeName="PipingBranchingType" displayLabel="Start Branching Type" category="IsmPipingRunComponent_category" />
+        <ECProperty propertyName="EndBranchingType" typeName="PipingBranchingType" displayLabel="End Branching Type" category="IsmPipingRunComponent_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingFlangeType" backingTypeName="int" isStrict="true" description="Piping Flange Type.">
@@ -1439,22 +1464,23 @@
         <ECEnumerator value="220" name="HdpeButtFusion" displayLabel="Hdpe Butt Fusion" description="Hdpe Butt Fusion." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingFlangeComponent_category" displayLabel="Piping Flange Component" priority="170" />
     <ECEntityClass typeName="IsmPipingFlangeComponent" modifier="Sealed" displayLabel="Piping Flange Component">
         <BaseClass>IsmPipingComponent</BaseClass>
-        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" />
-        <ECProperty propertyName="BoltNutWeight" typeName="double" displayLabel="Bolt Nut Weight" kindOfQuantity="AECU:WEIGHT" />
-        <ECProperty propertyName="Weight" typeName="double" displayLabel="Weight" kindOfQuantity="AECU:WEIGHT" />
-        <ECProperty propertyName="FlangeType" typeName="PipingFlangeType" displayLabel="Flange Type" />
-        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" />
-        <ECProperty propertyName="PressureRating" typeName="string" displayLabel="Pressure Rating" />
-        <ECProperty propertyName="FlangePlacement" typeName="PipingFlangeComponentPlacement" displayLabel="Placement" />
-        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" />
-        <ECProperty propertyName="Series" typeName="string" displayLabel="Series" />
-        <ECProperty propertyName="OffsetJoint" typeName="double" displayLabel="Offset Joint" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="OffsetAverage" typeName="double" displayLabel="Offset Average" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="OffsetMaximum" typeName="double" displayLabel="Offset Maximum" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="JointStressIntensificationFactor" typeName="double" displayLabel="Joint Stress Intensification Factor" />
-        <ECProperty propertyName="JointType" typeName="PipingJoint" displayLabel="Joint Type" />
+        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="BoltNutWeight" typeName="double" displayLabel="Bolt Nut Weight" category="IsmPipingFlangeComponent_category" kindOfQuantity="AECU:WEIGHT" />
+        <ECProperty propertyName="Weight" typeName="double" displayLabel="Weight" category="IsmPipingFlangeComponent_category" kindOfQuantity="AECU:WEIGHT" />
+        <ECProperty propertyName="FlangeType" typeName="PipingFlangeType" displayLabel="Flange Type" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="PressureRating" typeName="string" displayLabel="Pressure Rating" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="FlangePlacement" typeName="PipingFlangeComponentPlacement" displayLabel="Placement" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="Series" typeName="string" displayLabel="Series" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="OffsetJoint" typeName="double" displayLabel="Offset Joint" category="IsmPipingFlangeComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="OffsetAverage" typeName="double" displayLabel="Offset Average" category="IsmPipingFlangeComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="OffsetMaximum" typeName="double" displayLabel="Offset Maximum" category="IsmPipingFlangeComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="JointStressIntensificationFactor" typeName="double" displayLabel="Joint Stress Intensification Factor" category="IsmPipingFlangeComponent_category" />
+        <ECProperty propertyName="JointType" typeName="PipingJoint" displayLabel="Joint End Type" category="IsmPipingFlangeComponent_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingBendComponentType" backingTypeName="int" isStrict="true" description="Piping Flange Component Joint.">
@@ -1463,22 +1489,24 @@
         <ECEnumerator value="30" name="Wide" displayLabel="Wide" description="Wide." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingBendComponent_category" displayLabel="Piping Bend Component" priority="170" />
     <ECEntityClass typeName="IsmPipingBendComponent" modifier="Sealed" displayLabel="Piping Bend Component">
         <BaseClass>IsmPipingComponent</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="BendType" typeName="PipingBendComponentType" displayLabel="Type" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="BendType" typeName="PipingBendComponentType" displayLabel="Type" category="IsmPipingBendComponent_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingNode_category" displayLabel="Piping Node" priority="170" />
     <ECEntityClass typeName="IsmPipingNode" modifier="Sealed" displayLabel="Piping Node">
         <BaseClass>IsmNode</BaseClass>
-        <ECProperty propertyName="JointType" typeName="PipingJoint" displayLabel="Type" />
-        <ECProperty propertyName="WeldSize" typeName="double" displayLabel="Weld Size" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="OffsetJoint" typeName="double" displayLabel="Offset Joint" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="OffsetAverage" typeName="double" displayLabel="Offset Average" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="OffsetMaximum" typeName="double" displayLabel="Offset Maximum" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="StressIntensificationFactor" typeName="double" displayLabel="Stress Intensification Factor" />
-        <ECProperty propertyName="InPlaneStressIntensificationFactor" typeName="double" displayLabel="In Plane Stress Intensification Factor" />
-        <ECProperty propertyName="OutPlaneStressOuttensificationFactor" typeName="double" displayLabel="Out Plane Stress Intensification Factor" />
+        <ECProperty propertyName="JointType" typeName="PipingJoint" displayLabel="Joint End Type" category="IsmPipingNode_category" />
+        <ECProperty propertyName="WeldSize" typeName="double" displayLabel="Weld Size" category="IsmPipingNode_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="OffsetJoint" typeName="double" displayLabel="Offset Joint" category="IsmPipingNode_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="OffsetAverage" typeName="double" displayLabel="Offset Average" category="IsmPipingNode_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="OffsetMaximum" typeName="double" displayLabel="Offset Maximum" category="IsmPipingNode_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="StressIntensificationFactor" typeName="double" displayLabel="Stress Intensification Factor" category="IsmPipingNode_category" />
+        <ECProperty propertyName="InPlaneStressIntensificationFactor" typeName="double" displayLabel="In Plane Stress Intensification Factor" category="IsmPipingNode_category" />
+        <ECProperty propertyName="OutPlaneStressIntensificationFactor" typeName="double" displayLabel="Out Plane Stress Intensification Factor" category="IsmPipingNode_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="ValveType" backingTypeName="int" isStrict="true" description="Valve Type.">
@@ -1494,27 +1522,29 @@
         <ECEnumerator value="2000" name="NonStandard" displayLabel="Non-Standard" description="Non-Standard." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingValveComponent_category" displayLabel="Piping Valve Component" priority="170" />
     <ECEntityClass typeName="IsmPipingValveComponent" modifier="Sealed" displayLabel="Piping Valve Component">
         <BaseClass>IsmPipingComponent</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" />
-        <ECProperty propertyName="ValveType" typeName="ValveType" displayLabel="Valve Type" />
-        <ECProperty propertyName="ValveWeight" typeName="double" displayLabel="Valve Weight" kindOfQuantity="AECU:WEIGHT" />
-        <ECProperty propertyName="HasActuator" typeName="boolean" displayLabel="Has Actuator" />
-        <ECProperty propertyName="ActuatorWeight" typeName="double" displayLabel="Actuator Weight" kindOfQuantity="AECU:WEIGHT" />
-        <ECProperty propertyName="ActuatorLength" typeName="double" displayLabel="Actuator Length" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="PressureRating" typeName="string" displayLabel="Pressure Rating" kindOfQuantity="AECU:PRESSURE" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" category="IsmPipingValveComponent_category" />
+        <ECProperty propertyName="ValveType" typeName="ValveType" displayLabel="Valve Type" category="IsmPipingValveComponent_category" />
+        <ECProperty propertyName="ValveWeight" typeName="double" displayLabel="Valve Weight" category="IsmPipingValveComponent_category" kindOfQuantity="AECU:WEIGHT" />
+        <ECProperty propertyName="HasActuator" typeName="boolean" displayLabel="Has Actuator" category="IsmPipingValveComponent_category" />
+        <ECProperty propertyName="ActuatorWeight" typeName="double" displayLabel="Actuator Weight" category="IsmPipingValveComponent_category" kindOfQuantity="AECU:WEIGHT" />
+        <ECProperty propertyName="ActuatorLength" typeName="double" displayLabel="Actuator Length" category="IsmPipingValveComponent_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="PressureRating" typeName="string" displayLabel="Pressure Rating" category="IsmPipingValveComponent_category" kindOfQuantity="AECU:PRESSURE" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingReducerComponent_category" displayLabel="Piping Reducer Component" priority="170" />
     <ECEntityClass typeName="IsmPipingReducerComponent" modifier="Sealed" displayLabel="Piping Reducer Component">
         <BaseClass>IsmPipingComponent</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="EndDiameter" typeName="double" displayLabel="End Diameter" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="EndNominalDiameter" typeName="double" displayLabel="End Nominal Diameter" kindOfQuantity="AECU:LENGTH" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="EndDiameter" typeName="double" displayLabel="End Diameter" category="IsmPipingReducerComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="EndNominalDiameter" typeName="double" displayLabel="End Nominal Diameter" category="IsmPipingReducerComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmPipingFlexibleJointComponent" modifier="Sealed" displayLabel="Piping Flexible Joint Component">
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmPipingComponent_category" />
         <BaseClass>IsmPipingComponent</BaseClass>
     </ECEntityClass>
 
@@ -1527,28 +1557,30 @@
         <ECEnumerator value="120" name="User" displayLabel="User" description="User." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingNozzleComponent_category" displayLabel="Piping Nozzle Component" priority="170" />
     <ECEntityClass typeName="IsmPipingNozzleComponent" modifier="Sealed" displayLabel="Piping Nozzle Component">
         <BaseClass>IsmPipingComponent</BaseClass>
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECProperty propertyName="VesselDiameter" typeName="double" displayLabel="Vessel Diameter" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="VesselDirection" typeName="Point3d" displayLabel="Vessel Direction" />
-        <ECProperty propertyName="FlexibilityMethod" typeName="FlexibilityMethod" displayLabel="Flexibility Method" />
-        <ECProperty propertyName="RadialStiffness" typeName="double" displayLabel="Radial Stiffness" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
-        <ECProperty propertyName="CircularStiffness" typeName="double" displayLabel="Circular Stiffness" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
-        <ECProperty propertyName="LongitudinalStiffness" typeName="double" displayLabel="Longitudinal Stiffness" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmPipingComponent_category" />
+        <ECProperty propertyName="VesselDiameter" typeName="double" displayLabel="Vessel Diameter" category="IsmPipingNozzleComponent_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="VesselDirection" typeName="Point3d" displayLabel="Vessel Direction" category="IsmPipingNozzleComponent_category" />
+        <ECProperty propertyName="FlexibilityMethod" typeName="FlexibilityMethod" displayLabel="Flexibility Method" category="IsmPipingNozzleComponent_category" />
+        <ECProperty propertyName="RadialStiffness" typeName="double" displayLabel="Radial Stiffness" category="IsmPipingNozzleComponent_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="CircularStiffness" typeName="double" displayLabel="Circular Stiffness" category="IsmPipingNozzleComponent_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="LongitudinalStiffness" typeName="double" displayLabel="Longitudinal Stiffness" category="IsmPipingNozzleComponent_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingSupport_category" displayLabel="Piping Support" priority="180" />
     <ECEntityClass typeName="IsmPipingSupport" modifier="Abstract" displayLabel="Piping Support">
         <BaseClass>IsmPipingMember</BaseClass>
-        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" />
-        <ECProperty propertyName="AttachmentId" typeName="string" displayLabel="Attachment Id" />
-        <ECProperty propertyName="ComponentWeight" typeName="double" displayLabel="Component Weight" kindOfQuantity="AECU:WEIGHT" />
-        <ECProperty propertyName="IsConnectedToGround" typeName="boolean" displayLabel="Is Connected To Ground" />
-        <ECProperty propertyName="StartPoint" typeName="Point3d" displayLabel="Start Point" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="EndPoint" typeName="Point3d" displayLabel="End Point" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="PipeDiameter" typeName="double" displayLabel="PipeDiameter" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="RAxis" typeName="Point3d" displayLabel="R Axis" />
-        <ECProperty propertyName="SAxis" typeName="Point3d" displayLabel="S Axis" />
+        <ECProperty propertyName="Tag" typeName="string" displayLabel="Tag" category="IsmPipingSupport_category" />
+        <ECProperty propertyName="AttachmentId" typeName="string" displayLabel="Attachment Id" category="IsmPipingSupport_category" />
+        <ECProperty propertyName="ComponentWeight" typeName="double" displayLabel="Component Weight" category="IsmPipingSupport_category" kindOfQuantity="AECU:WEIGHT" />
+        <ECProperty propertyName="IsConnectedToGround" typeName="boolean" displayLabel="Is Connected To Ground" category="IsmPipingSupport_category" />
+        <ECProperty propertyName="StartPoint" typeName="Point3d" displayLabel="Start Point" category="IsmPipingSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="EndPoint" typeName="Point3d" displayLabel="End Point" category="IsmPipingSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="PipeDiameter" typeName="double" displayLabel="PipeDiameter" category="IsmPipingSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="RAxis" typeName="Point3d" displayLabel="R Axis" category="IsmPipingSupport_category" />
+        <ECProperty propertyName="SAxis" typeName="Point3d" displayLabel="S Axis" category="IsmPipingSupport_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingSupportDesignMethod" backingTypeName="int" isStrict="true" description="Piping Spring Support Design Method.">
@@ -1561,32 +1593,34 @@
         <ECEnumerator value="20" name="Can" displayLabel="Can" description="Can." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingSpringSupport_category" displayLabel="Piping Spring Support" priority="170" />
     <ECEntityClass typeName="IsmPipingSpringSupport" modifier="Sealed" displayLabel="Piping Spring Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="DesignMethod" typeName="PipingSupportDesignMethod" displayLabel="Design Method" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="MaximumVerticalTravelRange" typeName="double" displayLabel="Maximum Vertical Travel Range" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="MovementDistance" typeName="double" displayLabel="Movement Distance" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="Load" typeName="double" displayLabel="Load" kindOfQuantity="AECU:FORCE" />
-        <ECProperty propertyName="LoadVariationRatio" typeName="double" displayLabel="Load Variation Ratio" />
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="CatalogName" typeName="string" displayLabel="Catalog Name" />
-        <ECProperty propertyName="SpringType" typeName="PipingSpringType" displayLabel="Spring Type" />
-        <ECProperty propertyName="IsDesigned" typeName="boolean" displayLabel="Is Designed" />
-        <ECProperty propertyName="HangerCount" typeName="int" displayLabel="Hanger Count" />
-        <ECProperty propertyName="SpringSize" typeName="string" displayLabel="Spring Size" />
-        <ECProperty propertyName="SpringFigure" typeName="string" displayLabel="Spring Figure" />
+        <ECProperty propertyName="DesignMethod" typeName="PipingSupportDesignMethod" displayLabel="Design Method" category="IsmPipingSpringSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="MaximumVerticalTravelRange" typeName="double" displayLabel="Maximum Vertical Travel Range" category="IsmPipingSpringSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="MovementDistance" typeName="double" displayLabel="Movement Distance" category="IsmPipingSpringSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Load" typeName="double" displayLabel="Load" category="IsmPipingSpringSupport_category" kindOfQuantity="AECU:FORCE" />
+        <ECProperty propertyName="LoadVariationRatio" typeName="double" displayLabel="Load Variation Ratio" category="IsmPipingSpringSupport_category" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingSpringSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="CatalogName" typeName="string" displayLabel="Catalog Name" category="IsmPipingSpringSupport_category" />
+        <ECProperty propertyName="SpringType" typeName="PipingSpringType" displayLabel="Spring Type" category="IsmPipingSpringSupport_category" />
+        <ECProperty propertyName="IsDesigned" typeName="boolean" displayLabel="Is Designed" category="IsmPipingSpringSupport_category" />
+        <ECProperty propertyName="HangerCount" typeName="int" displayLabel="Hanger Count" category="IsmPipingSpringSupport_category" />
+        <ECProperty propertyName="SpringSize" typeName="string" displayLabel="Spring Size" category="IsmPipingSpringSupport_category" />
+        <ECProperty propertyName="SpringFigure" typeName="string" displayLabel="Spring Figure" category="IsmPipingSpringSupport_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingConstantSupport_category" displayLabel="Piping Constant Support" priority="170" />
     <ECEntityClass typeName="IsmPipingConstantSupport" modifier="Sealed" displayLabel="Piping Constant Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="DesignMethod" typeName="PipingSupportDesignMethod" displayLabel="Design Method" />
-        <ECProperty propertyName="MaximumVerticalTravelRange" typeName="double" displayLabel="Maximum Vertical Travel Range" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="MovementDistance" typeName="double" displayLabel="Movement Distance" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="Load" typeName="double" displayLabel="Load" kindOfQuantity="AECU:FORCE" />
-        <ECProperty propertyName="CatalogName" typeName="string" displayLabel="Catalog Name" />
-        <ECProperty propertyName="SpringType" typeName="PipingSpringType" displayLabel="Spring Type" />
-        <ECProperty propertyName="IsDesigned" typeName="boolean" displayLabel="Is Designed" />
-        <ECProperty propertyName="HangerCount" typeName="int" displayLabel="Hanger Count" />
+        <ECProperty propertyName="DesignMethod" typeName="PipingSupportDesignMethod" displayLabel="Design Method" category="IsmPipingConstantSupport_category" />
+        <ECProperty propertyName="MaximumVerticalTravelRange" typeName="double" displayLabel="Maximum Vertical Travel Range" category="IsmPipingConstantSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="MovementDistance" typeName="double" displayLabel="Movement Distance" category="IsmPipingConstantSupport_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Load" typeName="double" displayLabel="Load" category="IsmPipingConstantSupport_category" kindOfQuantity="AECU:FORCE" />
+        <ECProperty propertyName="CatalogName" typeName="string" displayLabel="Catalog Name" category="IsmPipingConstantSupport_category" />
+        <ECProperty propertyName="SpringType" typeName="PipingSpringType" displayLabel="Spring Type" category="IsmPipingConstantSupport_category" />
+        <ECProperty propertyName="IsDesigned" typeName="boolean" displayLabel="Is Designed" category="IsmPipingConstantSupport_category" />
+        <ECProperty propertyName="HangerCount" typeName="int" displayLabel="Hanger Count" category="IsmPipingConstantSupport_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingVStopSupportType" backingTypeName="int" isStrict="true" description="V-Stop Type.">
@@ -1601,13 +1635,14 @@
         <ECEnumerator value="30" name="Shoe" displayLabel="Shoe" description="Shoe." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingVStopSupport_category" displayLabel="Piping V-Stop Support" priority="170" />
     <ECEntityClass typeName="IsmPipingVStopSupport" modifier="Sealed" displayLabel="Piping V-Stop Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="VStopType" typeName="PipingVStopSupportType" displayLabel="V-Stop Type" />
-        <ECProperty propertyName="GapDown" typeName="double" displayLabel="Gap Down" />
-        <ECProperty propertyName="GapUp" typeName="double" displayLabel="Gap Up" />
-        <ECProperty propertyName="GapType" typeName="PipingVStopSupportGap" displayLabel="Gap Type" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" />
+        <ECProperty propertyName="VStopType" typeName="PipingVStopSupportType" displayLabel="V-Stop Type" category="IsmPipingVStopSupport_category" />
+        <ECProperty propertyName="GapDown" typeName="double" displayLabel="Gap Down" category="IsmPipingVStopSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapUp" typeName="double" displayLabel="Gap Up" category="IsmPipingVStopSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapType" typeName="PipingVStopSupportGap" category="IsmPipingVStopSupport_category" displayLabel="Gap Type" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingVStopSupport_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="PipingSupportGapType" backingTypeName="int" isStrict="true" description="Piping Support Weight Gap.">
@@ -1615,54 +1650,64 @@
         <ECEnumerator value="20" name="AsBuilt" displayLabel="As Built" description="As Built." />
     </ECEnumeration>
 
+    <KindOfQuantity typeName='Real3DP' description='Real number 3DP'
+        displayLabel='Real number 3DP' persistenceUnit='u:COEFFICIENT' relativeError='.0005'
+        presentationUnits='f:DefaultRealU(3)[u:COEFFICIENT|]' />
+
+    <PropertyCategory typeName="IsmPipingInclineSupport_category" displayLabel="Piping Incline Support" priority="170" />
     <ECEntityClass typeName="IsmPipingInclineSupport" modifier="Sealed" displayLabel="Piping Incline Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" />
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" />
+        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" category="IsmPipingInclineSupport_category" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingInclineSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" category="IsmPipingInclineSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" category="IsmPipingInclineSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingInclineSupport_category" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingInclineSupport_category" kindOfQuantity="Real3DP" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingLineStopSupport_category" displayLabel="Piping Line Stop Support" priority="170" />
     <ECEntityClass typeName="IsmPipingLineStopSupport" modifier="Sealed" displayLabel="Piping Line Stop Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingLineStopSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" category="IsmPipingLineStopSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" category="IsmPipingLineStopSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingLineStopSupport_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingGuideSupport_category" displayLabel="Piping Guide Support" priority="170" />
     <ECEntityClass typeName="IsmPipingGuideSupport" modifier="Sealed" displayLabel="Piping Guide Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="GapDown" typeName="double" displayLabel="Gap Down" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapUp" typeName="double" displayLabel="Gap Up" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapLeft" typeName="double" displayLabel="Gap Left" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapRight" typeName="double" displayLabel="Gap Right" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" />
-        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="GapDown" typeName="double" displayLabel="Gap Down" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapUp" typeName="double" displayLabel="Gap Up" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapLeft" typeName="double" displayLabel="Gap Left" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapRight" typeName="double" displayLabel="Gap Right" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingGuideSupport_category" kindOfQuantity="Real3DP" />
+        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingGuideSupport_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingRotationSupport_category" displayLabel="Piping Rotation Support" priority="170" />
     <ECEntityClass typeName="IsmPipingRotationSupport" modifier="Sealed" displayLabel="Piping Rotation Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" />
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" category="IsmPipingRotationSupport_category" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingRotationSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmPipingDamperSupport_category" displayLabel="Piping Damper Support" priority="170" />
     <ECEntityClass typeName="IsmPipingDamperSupport" modifier="Sealed" displayLabel="Piping Damper Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" />
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" category="IsmPipingDamperSupport_category" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingDamperSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
     </ECEntityClass>
 
-    <ECEntityClass typeName="IsmPipingTieLinkSupport" modifier="Sealed" displayLabel="Piping Tie Link Support">
+    <PropertyCategory typeName="IsmPipingTieLinkSupport_category" displayLabel="Piping Tie/Link Support" priority="170" />
+    <ECEntityClass typeName="IsmPipingTieLinkSupport" modifier="Sealed" displayLabel="Piping Tie/Link Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" />
+        <ECProperty propertyName="Stiffness" typeName="double" displayLabel="Stiffness" category="IsmPipingTieLinkSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" category="IsmPipingTieLinkSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" category="IsmPipingTieLinkSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingTieLinkSupport_category" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingTieLinkSupport_category" />
     </ECEntityClass>
 
     <ECEnumeration typeName="AxialBehavior" backingTypeName="int" isStrict="true" description="Axial Behavior.">
@@ -1671,17 +1716,18 @@
         <ECEnumerator value="3" name="CompressionAndTension" displayLabel="Compression And Tension" description="Compression And Tension." />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPipingAnchorSupport_category" displayLabel="Piping Anchor Support" priority="170" />
     <ECEntityClass typeName="IsmPipingAnchorSupport" modifier="Sealed" displayLabel="Piping Anchor Support">
         <BaseClass>IsmPipingSupport</BaseClass>
-        <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" />
-        <ECProperty propertyName="RAxisTranslationDirection" typeName="AxialBehavior" displayLabel="R-Axis Translation Direction" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" />
-        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" />
-        <ECProperty propertyName="SAxisTranslationDirection" typeName="AxialBehavior" displayLabel="S-Axis Translation Direction" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" />
-        <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" />
-        <ECProperty propertyName="TAxisTranslationDirection" typeName="AxialBehavior" displayLabel="T-Axis Translation Direction" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" />
+        <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisTranslationDirection" typeName="AxialBehavior" displayLabel="R-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisTranslationDirection" typeName="AxialBehavior" displayLabel="S-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisTranslationDirection" typeName="AxialBehavior" displayLabel="T-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmPipingMember_PipingLine" modifier="None" strength="referencing" strengthDirection="forward">
@@ -1765,10 +1811,11 @@
         </Target>
     </ECRelationshipClass>
 
+    <PropertyCategory typeName="IsmTendonNode_category" displayLabel="Tendon Node" priority="190" />
     <ECEntityClass typeName="IsmTendonNode" modifier="None" displayLabel="Tendon Node">
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmSubObject</BaseClass>
-        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" category="IsmTendonNode_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmTendonSet_Nodes" modifier="None" strength="referencing" strengthDirection="forward">
@@ -1781,10 +1828,11 @@
         </Target>
     </ECRelationshipClass>
 
+    <PropertyCategory typeName="IsmTendon_category" displayLabel="Tendon" priority="190" />
     <ECEntityClass typeName="IsmTendon" modifier="None" displayLabel="Tendon">
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmSubObject</BaseClass>
-        <ECProperty propertyName="StrandCount" typeName="double" displayLabel="Strand Count" />
+        <ECProperty propertyName="StrandCount" typeName="double" displayLabel="Strand Count" category="IsmTendon_category" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmTendonSet_Tendon" modifier="None" strength="referencing" strengthDirection="forward">
@@ -1848,10 +1896,11 @@
         </Target>
     </ECRelationshipClass>
 
+    <PropertyCategory typeName="IsmTendonPart_category" displayLabel="Tendon Part" priority="190" />
     <ECEntityClass typeName="IsmTendonPart" modifier="Abstract" displayLabel="Tendon Part">
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmSubObject</BaseClass>
-        <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" />
+        <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" category="IsmTendonPart_category" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmTendon_TendonPart" modifier="None" strength="referencing" strengthDirection="forward">
@@ -1864,14 +1913,15 @@
         </Target>
     </ECRelationshipClass>
 
+    <PropertyCategory typeName="IsmTendonSegment_category" displayLabel="Tendon Segment" priority="180" />
     <ECEntityClass typeName="IsmTendonSegment" modifier="None" displayLabel="Tendon Segment">
         <BaseClass>IsmTendonPart</BaseClass>
-        <ECProperty propertyName="Harped" typeName="boolean" displayLabel="Harped" />
-        <ECProperty propertyName="InflectionRatio" typeName="double" displayLabel="Inflection Ratio" />
-        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" />
-        <ECStructProperty propertyName="DuctLocation" typeName="IsmPrimitiveGeometry" displayLabel="Duct Location" />
-        <ECProperty propertyName="StartStress" typeName="double" displayLabel="Start Stress" kindOfQuantity="AECU:PRESSURE" />
-        <ECProperty propertyName="EndStress" typeName="double" displayLabel="End Stress" kindOfQuantity="AECU:PRESSURE" />
+        <ECProperty propertyName="Harped" typeName="boolean" displayLabel="Harped" category="IsmTendonSegment_category" />
+        <ECProperty propertyName="InflectionRatio" typeName="double" displayLabel="Inflection Ratio" category="IsmTendonSegment_category" />
+        <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmTendonSegment_category" />
+        <ECStructProperty propertyName="DuctLocation" typeName="IsmPrimitiveGeometry" displayLabel="Duct Location" category="IsmTendonSegment_category" />
+        <ECProperty propertyName="StartStress" typeName="double" displayLabel="Start Stress" category="IsmTendonSegment_category" kindOfQuantity="AECU:AREA_FORCE_LARGE" />
+        <ECProperty propertyName="EndStress" typeName="double" displayLabel="End Stress" category="IsmTendonSegment_category" kindOfQuantity="AECU:AREA_FORCE_LARGE" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmTendonSegment_StartNode" modifier="None" strength="referencing" strengthDirection="forward">
@@ -1894,11 +1944,12 @@
         </Target>
     </ECRelationshipClass>
 
+    <PropertyCategory typeName="IsmTendonAnchor_category" displayLabel="Tendon Anchor" priority="180" />
     <ECEntityClass typeName="IsmTendonAnchor" modifier="Abstract" displayLabel="Tendon Anchor">
         <BaseClass>IsmTendonPart</BaseClass>
-        <ECProperty propertyName="AnchorFriction" typeName="double" displayLabel="Anchor Friction" />
-        <ECProperty propertyName="AnchorType" typeName="AnchorType" displayLabel="Anchor Type" />
-        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" />
+        <ECProperty propertyName="AnchorFriction" typeName="double" displayLabel="Anchor Friction" category="IsmTendonAnchor_category" />
+        <ECProperty propertyName="AnchorType" typeName="AnchorType" displayLabel="Anchor Type" category="IsmTendonAnchor_category" />
+        <ECProperty propertyName="Direction" typeName="Point3d" displayLabel="Direction" category="IsmTendonAnchor_category" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmTendonAnchor_Node" modifier="None" strength="referencing" strengthDirection="forward">
@@ -1911,11 +1962,12 @@
         </Target>
     </ECRelationshipClass>
 
+    <PropertyCategory typeName="IsmTendonTensioningEndAnchor_category" displayLabel="Tendon Tensioning End Anchor" priority="170" />
     <ECEntityClass typeName="IsmTendonTensioningEndAnchor" modifier="None" displayLabel="Tendon Tensioning-End Anchor">
         <BaseClass>IsmTendonAnchor</BaseClass>
-        <ECProperty propertyName="JackStress" typeName="double" displayLabel="Jack Stress" kindOfQuantity="AECU:PRESSURE" />
-        <ECProperty propertyName="SeatingDistance" typeName="double" displayLabel="Seating Distance" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="Elongation" typeName="double" displayLabel="Elongation" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="JackStress" typeName="double" displayLabel="Jack Stress" category="IsmTendonTensioningEndAnchor_category" kindOfQuantity="AECU:AREA_FORCE_LARGE" />
+        <ECProperty propertyName="SeatingDistance" typeName="double" displayLabel="Seating Distance" category="IsmTendonTensioningEndAnchor_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Elongation" typeName="double" displayLabel="Elongation" category="IsmTendonTensioningEndAnchor_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmTendonFixedEndAnchor" modifier="None" displayLabel="Tendon Fixed-End Anchor">
@@ -1969,30 +2021,33 @@
         <ECEnumerator value="1300" name="Other" displayLabel="Other" />
     </ECEnumeration>
 
+    <PropertyCategory typeName="IsmPointForceMemberLoad_category" displayLabel="Point Force Member Load" priority="180" />
     <ECEntityClass typeName="IsmPointForceMemberLoad" modifier="None" displayLabel="Point Force Member Load">
         <BaseClass>IsmForceMemberLoad</BaseClass>
-        <ECProperty propertyName="Force" typeName="Point3d" displayLabel="Force" kindOfQuantity="AECU:FORCE" />
-        <ECProperty propertyName="Moment" typeName="Point3d" displayLabel="Moment" kindOfQuantity="AECU:MOMENT" />
-        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="IsNodalLoad" typeName="boolean" displayLabel="Is Nodal Load" />
+        <ECProperty propertyName="Force" typeName="Point3d" displayLabel="Force" category="IsmPointForceMemberLoad_category" kindOfQuantity="AECU:FORCE" />
+        <ECProperty propertyName="Moment" typeName="Point3d" displayLabel="Moment" category="IsmPointForceMemberLoad_category" kindOfQuantity="AECU:MOMENT" />
+        <ECProperty propertyName="Location" typeName="Point3d" displayLabel="Location" category="IsmPointForceMemberLoad_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="IsNodalLoad" typeName="boolean" displayLabel="Is Nodal Load" category="IsmPointForceMemberLoad_category" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmProxy_category" displayLabel="Proxy" priority="190" />
     <ECEntityClass typeName="IsmProxy" modifier="None" displayLabel="Proxy">
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="Location" typeName="binary" displayLabel="Location" kindOfQuantity="AECU:LENGTH" />
-        <ECProperty propertyName="ProxyType" typeName="string" displayLabel="Proxy Type" />
+        <ECProperty propertyName="Location" typeName="binary" displayLabel="Location" category="IsmProxy_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="ProxyType" typeName="string" displayLabel="Proxy Type" category="IsmProxy_category" />
     </ECEntityClass>
 
     <ECEntityClass typeName="IsmRadialGrid" modifier="None" displayLabel="Radial Grid">
         <BaseClass>IsmGrid</BaseClass>
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmRadialGridLine_category" displayLabel="Radial Grid Line" priority="180" />
     <ECEntityClass typeName="IsmRadialGridLine" modifier="None" displayLabel="Radial Grid Line">
         <BaseClass>IsmGridLine</BaseClass>
-        <ECProperty propertyName="Angle" typeName="double" displayLabel="Angle" kindOfQuantity="AECU:ANGLE" />
-        <ECProperty propertyName="MinimumRadius" typeName="double" displayLabel="Minimum Radius" kindOfQuantity="AECU:ANGLE" />
-        <ECProperty propertyName="MaximumRadius" typeName="double" displayLabel="Maximum Radius" kindOfQuantity="AECU:ANGLE" />
+        <ECProperty propertyName="Angle" typeName="double" displayLabel="Angle" category="IsmRadialGridLine_category" kindOfQuantity="AECU:ANGLE" />
+        <ECProperty propertyName="MinimumRadius" typeName="double" displayLabel="Minimum Radius" category="IsmRadialGridLine_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="MaximumRadius" typeName="double" displayLabel="Maximum Radius" category="IsmRadialGridLine_category" kindOfQuantity="AECU:LENGTH" />
     </ECEntityClass>
 
 
@@ -2089,15 +2144,16 @@
         <ECProperty propertyName="Width" typeName="double" displayLabel="Width" category="IsmRectangleTieRebar_category" kindOfQuantity="AECU:LENGTH_SHORT" />
     </ECEntityClass>
 
+    <PropertyCategory typeName="IsmShearStudZone_category" displayLabel="Rectangle Tie Rebar" priority="190" />
     <ECEntityClass typeName="IsmShearStudZone" modifier="None" displayLabel="Shear Stud Zone" >
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmSubObject</BaseClass>
-        <ECProperty propertyName="ZoneLength" typeName="double" displayLabel="Zone Length" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="Index" typeName="int" displayLabel="Index" />
-        <ECProperty propertyName="StudCount" typeName="int" displayLabel="Stud Count" />
-        <ECProperty propertyName="StudDiameter" typeName="double" displayLabel="Stud Diameter" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="StudLength" typeName="double" displayLabel="Stud Length" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="StudTensileStrength" typeName="double" displayLabel="Stud Tensile Length" kindOfQuantity="AECU:PRESSURE" />
+        <ECProperty propertyName="ZoneLength" typeName="double" displayLabel="Zone Length" category="IsmShearStudZone_category" kindOfQuantity="AECU:LENGTH" />
+        <ECProperty propertyName="Index" typeName="int" displayLabel="Index" category="IsmShearStudZone_category" />
+        <ECProperty propertyName="StudCount" typeName="int" displayLabel="Stud Count" category="IsmShearStudZone_category" />
+        <ECProperty propertyName="StudDiameter" typeName="double" displayLabel="Stud Diameter" category="IsmShearStudZone_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="StudLength" typeName="double" displayLabel="Stud Length" category="IsmShearStudZone_category" kindOfQuantity="AECU:LENGTH_SHORT" />
+        <ECProperty propertyName="StudTensileStrength" typeName="double" displayLabel="Stud Tensile Length" category="IsmShearStudZone_category" kindOfQuantity="AECU:AREA_FORCE_LARGE" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmShearStudZone_Member" modifier="None" strength="referencing" strengthDirection="forward">

--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -1650,8 +1650,8 @@
         <ECEnumerator value="20" name="AsBuilt" displayLabel="As Built" description="As Built." />
     </ECEnumeration>
 
-    <KindOfQuantity typeName='Real3DP' description='Real number 3DP'
-        displayLabel='Real number 3DP' persistenceUnit='u:COEFFICIENT' relativeError='.0005'
+    <KindOfQuantity typeName='Coefficient3DP' description='Coefficient 3DP'
+        displayLabel='Coefficient 3DP' persistenceUnit='u:COEFFICIENT' relativeError='.0005'
         presentationUnits='f:DefaultRealU(3)[u:COEFFICIENT|]' />
 
     <PropertyCategory typeName="IsmPipingInclineSupport_category" displayLabel="Piping Incline Support" priority="170" />
@@ -1662,7 +1662,7 @@
         <ECProperty propertyName="GapForward" typeName="double" displayLabel="Gap Forward" category="IsmPipingInclineSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapBackward" typeName="double" displayLabel="Gap Backward" category="IsmPipingInclineSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingInclineSupport_category" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingInclineSupport_category" kindOfQuantity="Real3DP" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingInclineSupport_category" kindOfQuantity="Coefficient3DP" />
     </ECEntityClass>
 
     <PropertyCategory typeName="IsmPipingLineStopSupport_category" displayLabel="Piping Line Stop Support" priority="170" />
@@ -1682,7 +1682,7 @@
         <ECProperty propertyName="GapUp" typeName="double" displayLabel="Gap Up" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapLeft" typeName="double" displayLabel="Gap Left" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
         <ECProperty propertyName="GapRight" typeName="double" displayLabel="Gap Right" category="IsmPipingGuideSupport_category" kindOfQuantity="AECU:LENGTH_SHORT" />
-        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingGuideSupport_category" kindOfQuantity="Real3DP" />
+        <ECProperty propertyName="FrictionCoefficient" typeName="double" displayLabel="Friction Coefficient" category="IsmPipingGuideSupport_category" kindOfQuantity="Coefficient3DP" />
         <ECProperty propertyName="GapType" typeName="PipingSupportGapType" displayLabel="Gap Type" category="IsmPipingGuideSupport_category" />
     </ECEntityClass>
 

--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -894,6 +894,7 @@
     </ECEnumeration>
 
     <PropertyCategory typeName="IsmCurveMember_category" displayLabel="Curve Member" priority="180" />
+    <PropertyCategory typeName="IsmCurveMember_Reactions_category" displayLabel="Curve Member Reactions" priority="150" />
     <ECEntityClass typeName="IsmCurveMember" displayLabel="Curve Member" modifier="Sealed">
         <BaseClass>IsmSpanningMember</BaseClass>
         <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location (ICurve)" category="IsmCurveMember_category" />
@@ -903,8 +904,8 @@
         <ECProperty propertyName="Orientation" typeName="Point3d" displayLabel="Orientation" category="IsmCurveMember_category" />
         <ECProperty propertyName="PlacementPoint" typeName="IsmCurveMemberPlacementPoint" displayLabel="Placement Point" category="IsmCurveMember_category" />
         <ECProperty propertyName="SystemKind" typeName="IsmCurveMemberSystemKind" displayLabel="System Kind" category="IsmCurveMember_category" />
-        <ECArrayProperty propertyName="SteelConnectionTagAtStart" typeName="string" displayLabel="Steel Connection Tag at Start" />
-        <ECArrayProperty propertyName="SteelConnectionTagAtEnd" typeName="string" displayLabel="Steel Connection Tag at End" />
+        <ECArrayProperty propertyName="SteelConnectionTagAtStart" typeName="string" displayLabel="Steel Connection Tag at Start" category="IsmCurveMember_category" />
+        <ECArrayProperty propertyName="SteelConnectionTagAtEnd" typeName="string" displayLabel="Steel Connection Tag at End" category="IsmCurveMember_category" />
         <ECProperty propertyName="Use" typeName="IsmCurveMemberUse" displayLabel="Use" category="IsmCurveMember_category" />
         <ECProperty propertyName="RAxisTranslationFixity1" typeName="boolean" displayLabel="R-Axis Translation Fixity #1" />
         <ECProperty propertyName="SAxisTranslationFixity1" typeName="boolean" displayLabel="S-Axis Translation Fixity #1" />
@@ -918,11 +919,11 @@
         <ECProperty propertyName="RAxisRotationFixity2" typeName="boolean" displayLabel="R-Axis Rotation Fixity #2" />
         <ECProperty propertyName="SAxisRotationFixity2" typeName="boolean" displayLabel="S-Axis Rotation Fixity #2" />
         <ECProperty propertyName="TAxisRotationFixity2" typeName="boolean" displayLabel="T-Axis Rotation Fixity #2" />
-        <ECProperty propertyName="ReactionForceAtStart" typeName="double" displayLabel="Reaction Force at Start" kindOfQuantity="AECU:FORCE" />
-        <ECProperty propertyName="ReactionForceAtEnd" typeName="double" displayLabel="Reaction Force at End" kindOfQuantity="AECU:FORCE" />
-        <ECProperty propertyName="ReactionMomentAtStart" typeName="double" displayLabel="Reaction Moment at Start" kindOfQuantity="AECU:MOMENT" />
-        <ECProperty propertyName="ReactionMomentAtEnd" typeName="double" displayLabel="Reaction Moment at End" kindOfQuantity="AECU:MOMENT" />
-        <ECProperty propertyName="ReactionLimitState" typeName="ReactionLimitState" displayLabel="Reaction Limit State" />
+        <ECProperty propertyName="ReactionForceAtStart" typeName="double" displayLabel="Reaction Force at Start" category="IsmCurveMember_Reactions_category" kindOfQuantity="AECU:FORCE" />
+        <ECProperty propertyName="ReactionForceAtEnd" typeName="double" displayLabel="Reaction Force at End" category="IsmCurveMember_Reactions_category" kindOfQuantity="AECU:FORCE" />
+        <ECProperty propertyName="ReactionMomentAtStart" typeName="double" displayLabel="Reaction Moment at Start" category="IsmCurveMember_Reactions_category" kindOfQuantity="AECU:MOMENT" />
+        <ECProperty propertyName="ReactionMomentAtEnd" typeName="double" displayLabel="Reaction Moment at End" category="IsmCurveMember_Reactions_category" kindOfQuantity="AECU:MOMENT" />
+        <ECProperty propertyName="ReactionLimitState" typeName="ReactionLimitState" displayLabel="Reaction Limit State" category="IsmCurveMember_Reactions_category" />
         <ECProperty propertyName="AutoLength" typeName="double" displayLabel="Length" category="Calculated_category" kindOfQuantity="AECU:LENGTH" />
         <ECProperty propertyName="AutoVolume" typeName="double" displayLabel="Volume" category="Calculated_category" kindOfQuantity="AECU:VOLUME" />
         <ECProperty propertyName="AutoWeight" typeName="double" displayLabel="Weight" category="Calculated_category" kindOfQuantity="AECU:WEIGHT" />


### PR DESCRIPTION
Updated ISM IntegratedStructuralModel schema:
- Added PropertyCategories for a lot of ECEntityClasses
- Added references to Units and Formats schemas
- Updated kindOfQuantity for multiple ECProperties
- Updated displayLabels for multiple ECProperties
- Updated BaseClass of IsmCurveForceMemberLoad ECEntityClass
- Added IsmFixityDirection ECEnumeration
- Fixed incorrect ECProperty name: OutPlaneStressOuttensificationFactor -> OutPlaneStressIntensificationFactor
- Changed precision for FrictionCoefficient ECProperties on PipingSupports: 2DP -> 3DP