### PR TITLE
Removed IsmNodeLink fixities category

### DIFF
--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -525,16 +525,15 @@
         <BaseClass>IsmMaterial</BaseClass>
     </ECEntityClass>
 
-    <PropertyCategory typeName="IsmNodeLink_category" displayLabel="Node Link Fixity" priority="190" />
     <ECEntityClass typeName="IsmNodeLink" displayLabel="Node Link" modifier="Sealed" >
         <BaseClass>anlyt:AnalyticalElement</BaseClass>
         <BaseClass>IIsmObject</BaseClass>
-        <ECProperty propertyName="RAxisTranslationFixity" typeName="boolean" displayLabel="R-Axis Translation Fixity" category="IsmNodeLink_category" />
-        <ECProperty propertyName="SAxisTranslationFixity" typeName="boolean" displayLabel="S-Axis Translation Fixity" category="IsmNodeLink_category" />
-        <ECProperty propertyName="TAxisTranslationFixity" typeName="boolean" displayLabel="T-Axis Translation Fixity" category="IsmNodeLink_category" />
-        <ECProperty propertyName="RAxisRotationFixity" typeName="boolean" displayLabel="R-Axis Rotation Fixity" category="IsmNodeLink_category" />
-        <ECProperty propertyName="SAxisRotationFixity" typeName="boolean" displayLabel="S-Axis Rotation Fixity" category="IsmNodeLink_category" />
-        <ECProperty propertyName="TAxisRotationFixity" typeName="boolean" displayLabel="T-Axis Rotation Fixity" category="IsmNodeLink_category" />
+        <ECProperty propertyName="RAxisTranslationFixity" typeName="boolean" displayLabel="R-Axis Translation Fixity" />
+        <ECProperty propertyName="SAxisTranslationFixity" typeName="boolean" displayLabel="S-Axis Translation Fixity" />
+        <ECProperty propertyName="TAxisTranslationFixity" typeName="boolean" displayLabel="T-Axis Translation Fixity" />
+        <ECProperty propertyName="RAxisRotationFixity" typeName="boolean" displayLabel="R-Axis Rotation Fixity" />
+        <ECProperty propertyName="SAxisRotationFixity" typeName="boolean" displayLabel="S-Axis Rotation Fixity" />
+        <ECProperty propertyName="TAxisRotationFixity" typeName="boolean" displayLabel="T-Axis Rotation Fixity" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmNodeLink_StartNode" strength="referencing" strengthDirection="forward" modifier="Sealed">


### PR DESCRIPTION
- Removed IsmNodeLink fixities category
- This is because fixity values need calculatedProperties. Category will be created inside of the ruleset because of that