### PR TITLE
Temporary OpenSite+ workaround for RoadRailUnits SLOPE KoQ display fo…

### DIFF
--- a/Domains/2-DisciplinePhysical/Civil/RoadRailUnits/RoadRailUnits.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/Civil/RoadRailUnits/RoadRailUnits.ecschema.xml
@@ -25,8 +25,18 @@
     <KindOfQuantity typeName="FLOW" displayLabel="Road &amp; Rail Flow" persistenceUnit="u:CUB_M_PER_SEC" presentationUnits="f:DefaultRealU(2)[u:CUB_M_PER_SEC];f:DefaultRealU(2)[u:CUB_FT_PER_SEC]" relativeError="0.0001"/>
     <KindOfQuantity typeName="LENGTH" displayLabel="Road &amp; Rail Length" persistenceUnit="u:M" presentationUnits="f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>
     <KindOfQuantity typeName="LENGTH_SHORT" displayLabel="Road &amp; Rail Short Length" persistenceUnit="u:M" presentationUnits="f:DefaultRealU(3)[u:M];f:AmerFI" relativeError="0.0001"/>
-    <KindOfQuantity typeName="SLOPE" displayLabel="Road &amp; Rail Slope" persistenceUnit="u:M_PER_M" presentationUnits="f:DefaultRealU(2)[u:M_PER_M];f:DefaultRealU(2)[u:FT_PER_FT]" relativeError="0.0001" />
-    <KindOfQuantity typeName="STATION" displayLabel="Road &amp; Rail Station" persistenceUnit="u:M" presentationUnits="f:StationZ_1000_3[u:M];f:StationZ_100_2[u:FT];f:StationZ_100_2[u:US_SURVEY_FT];f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>    
+    <!--
+    TEMPORARY / WIP:
+        OpenSite+ iModels wants to use PERCENT_SLOPE presentation format for rru:SLOPE properties. Adding another presentation unit to existing ones doesn't work as there is currently no
+        way to configure unit formats in application by end users (platform is working on it). PERCENT_SLOPE could be added as the very first entry in 'presentationUnits' to be considered the default one,
+        but Presentation layer doesn't pick it as default due to it being in the INTERNATIONAL unit system. As a temporary workaround for OpenSite+ iModels - force PERCENT_SLOPE as the only presentation unit.
+
+        Before releasing this Schema, uncomment the following line, delete the next one after and adjust ordering of 'presentationUnits' if necessary.
+        By the time this is Schema is released, platform should have support for unit formatting configuration in iTwin.js / iTwin Studio based applications.
+    -->
+    <!-- <KindOfQuantity typeName="SLOPE" displayLabel="Road &amp; Rail Slope" persistenceUnit="u:M_PER_M" presentationUnits="f:DefaultRealU(2)[u:PERCENT_SLOPE];f:DefaultRealU(2)[u:M_PER_M];f:DefaultRealU(2)[u:FT_PER_FT]" relativeError="0.0001" /> -->
+    <KindOfQuantity typeName="SLOPE" displayLabel="Road &amp; Rail Slope" persistenceUnit="u:M_PER_M" presentationUnits="f:DefaultRealU(2)[u:PERCENT_SLOPE]" relativeError="0.0001" />
+    <KindOfQuantity typeName="STATION" displayLabel="Road &amp; Rail Station" persistenceUnit="u:M" presentationUnits="f:StationZ_1000_3[u:M];f:StationZ_100_2[u:FT];f:StationZ_100_2[u:US_SURVEY_FT];f:DefaultRealU(2)[u:M];f:DefaultRealU(2)[u:FT];f:DefaultRealU(2)[u:US_SURVEY_FT]" relativeError="0.0001"/>
     <KindOfQuantity typeName="VELOCITY" displayLabel="Road &amp; Rail Velocity" persistenceUnit="u:M_PER_SEC" presentationUnits="f:DefaultRealU(2)[u:KM_PER_HR];f:DefaultRealU(2)[u:MPH]" relativeError="0.0001"/>
     <KindOfQuantity typeName="VOLUME" displayLabel="Road &amp; Rail Volume" persistenceUnit="u:CUB_M" presentationUnits="f:DefaultRealU(2)[u:CUB_M];f:DefaultRealU(2)[u:CUB_FT]" relativeError="0.0001"/>
     <KindOfQuantity typeName="PERCENTAGE" displayLabel="Road &amp; Rail Percentage" persistenceUnit="u:DECIMAL_PERCENT" presentationUnits="f:DefaultRealU(2)[u:PERCENT];f:DefaultRealU(4)[u:DECIMAL_PERCENT]" relativeError="0.0001"/>


### PR DESCRIPTION
OpenSite+ iModels want to use `PERCENT_SLOPE` presentation format for `RoadRailUnits:SLOPE` KindOfQuantity properties. This is currently hard to achieve because Platform doesn't support end user configuration of unit formatting, so simply adding another display format doesn't work.

As a **TEMPORARY WORKAROUND** - comment out existing `rru:SLOPE` KoQ definition and replace it with one that has `PERCENT_SLOPE` as the only display unit.

This change should be reverted before new Schema release, assuming that by that time platform will support unit format configuration and `PERCENT_SLOPE` will be added as additional `rru:SLOPE` presentation unit.