### PR TITLE
Support the labeling of the Cant Station Points

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
@@ -9,6 +9,7 @@
     <ECSchemaReference name="CifCommon" version="01.00.10" alias="cifcmn"/>
     <ECSchemaReference name="CifUnits" version="01.00.08" alias="cifu"/>
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA"/>
+    <ECSchemaReference name="Bentley_Standard_CustomAttributes" version="01.00.14" alias="bsca"/>
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.04">
             <SupportedUse>NotForProduction</SupportedUse>
@@ -326,6 +327,11 @@
     </ECEntityClass>
     <ECEntityClass typeName="CantStationPointAspect" displayLabel="Cant Station Point">
         <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECCustomAttributes>
+            <InstanceLabelSpecification xmlns="Bentley_Standard_CustomAttributes.01.00.14">
+                <PropertyName>CantStationPoint_Station</PropertyName>
+            </InstanceLabelSpecification>
+        </ECCustomAttributes>
         <ECProperty propertyName="CantStationPoint_TransitionType" typeName="string" displayLabel="Object Type" category="CantStationPoint_Cant_Station_Point" priority="299999"/>
         <ECProperty propertyName="CantStationPoint_Station" typeName="double" displayLabel="Station" category="CantStationPoint_Cant_Station_Point" priority="299998" kindOfQuantity="cifu:STATION"/>
         <ECProperty propertyName="CantStationPoint_DesignSpeed" typeName="double" displayLabel="Design Speed" category="CantStationPoint_Cant_Station_Point" priority="299997" kindOfQuantity="cifu:VELOCITY"/>


### PR DESCRIPTION
Cant station points are shown with indices as labels, but now with this correction, they will be displayed with their station.