### PR TITLE
Use Node 22.x for iTwinjsCore build

### DIFF
--- a/tools/SchemaValidation/iModelEvolutionTests.yaml
+++ b/tools/SchemaValidation/iModelEvolutionTests.yaml
@@ -10,6 +10,7 @@ pr:
     include:
       - Domains/
       - System/
+      - tools/SchemaValidation/iModelEvolutionTests.yaml
       - SchemaInventory.json
 
 jobs:

--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -10,6 +10,7 @@ pr:
     include:
       - Domains/
       - System/
+      - tools/SchemaValidation/imodel-native-tests.yaml
       - SchemaInventory.json
 
 resources:

--- a/tools/SchemaValidation/imodel-native-tests.yaml
+++ b/tools/SchemaValidation/imodel-native-tests.yaml
@@ -229,7 +229,7 @@ stages:
     #should validate the imodeljs-win32-x64
     - template: common/config/azure-pipelines/templates/core-build.yaml@itwinjs-core
       parameters:
-        nodeVersion: 18.12.x
+        nodeVersion: 22.x
         runRushAudit: false
         rushBuildCacheEnabled: 0
         currentBranch: master


### PR DESCRIPTION
With respect to the following changes on core side: https://github.com/iTwin/itwinjs-core/pull/7379 updating the node version.

Additionally, we have fixed some path filters for the build execution.