### PR TITLE
Use rru:LENGTH_SHORT KoQ in OpenSite properties

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
@@ -259,7 +259,7 @@
         <ECProperty propertyName="MinDriveSlope" typeName="double" kindOfQuantity="rru:SLOPE" category="CenterlinePathEdge_Grading" displayLabel="Min. Slope" description="Minimum path slope for design." />
         <ECProperty propertyName="MaxDriveSlope" typeName="double" kindOfQuantity="rru:SLOPE" category="CenterlinePathEdge_Grading" displayLabel="Max. Slope" description="Maximum path slope for design." />
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="CenterlinePathEdge_Grading" displayLabel="Surface Type" description="Surface material type for path." />
-        <ECProperty propertyName="SurfaceDepth" typeName="double" kindOfQuantity="rru:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Surface Depth" description="Surface material depth for path." />
+        <ECProperty propertyName="SurfaceDepth" typeName="double" kindOfQuantity="rru:LENGTH_SHORT" category="CenterlinePathEdge_Grading" displayLabel="Surface Depth" description="Surface material depth for path." />
         <ECProperty propertyName="MinZ" typeName="double" kindOfQuantity="rru:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Min. Elevation" description="Minimum design elevation for path." />
         <ECProperty propertyName="MaxZ" typeName="double" kindOfQuantity="rru:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Max. Elevation" description="Maximum design elevation for path." />
 
@@ -480,9 +480,9 @@
 
         <ECProperty propertyName="DoGrade" typeName="boolean" category="ShapedArea_Optimizer" displayLabel="Grading" description="Add area grading data to grading optimizer." />
 
-        <ECProperty propertyName="Topsoil" typeName="double" category="ShapedArea_Surface" displayLabel="Topsoil" description="Depth of topsoil." />
+        <ECProperty propertyName="Topsoil" typeName="double" category="ShapedArea_Surface" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Topsoil" description="Depth of topsoil." />
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="ShapedArea_Surface" displayLabel="Surface Type" description="Type definition of area." />
-        <ECProperty propertyName="SurfaceDepth" typeName="double" category="ShapedArea_Surface" kindOfQuantity="rru:LENGTH" displayLabel="Surface Depth" description="Material depth of area." />
+        <ECProperty propertyName="SurfaceDepth" typeName="double" category="ShapedArea_Surface" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Surface Depth" description="Material depth of area." />
         <ECProperty propertyName="RunoffCoefficient" typeName="double" category="ShapedArea_Surface" displayLabel="Runoff Coefficient" description="Runoff coefficient for area." />
 
         <ECProperty propertyName="MinSlope" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="rru:SLOPE" displayLabel="Min. Slope" description="Minimum design slope for area." />
@@ -556,9 +556,9 @@
         <ECProperty propertyName="MinSlopeParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="rru:SLOPE" displayLabel="Min. Design Slope" description="Minimum design slope for parking lot." />
         <ECProperty propertyName="MaxSlopeParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="rru:SLOPE" displayLabel="Max. Design Slope" description="Maximum design slope for parking lot." />
         <ECProperty propertyName="SurfaceTypeParkingLot" typeName="SurfaceType" category="LayoutParkingArea_ParkingGrading" displayLabel="Surface Type" description="Surface type or material for parking lot." />
-        <ECProperty propertyName="SurfaceDepthParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="rru:LENGTH" displayLabel="Surface Depth" description="Surface or material depth." />
+        <ECProperty propertyName="SurfaceDepthParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth." />
         <ECProperty propertyName="SurfaceTypeParkingSpaces" typeName="SurfaceType" category="LayoutParkingArea_ParkingGrading" displayLabel="Space Surface Type" description="Surface type or material for specific parking spaces." />
-        <ECProperty propertyName="SurfaceDepthParkingSpaces" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="rru:LENGTH" displayLabel="Space Surface Depth" description="Surface or material depth for specific parking spaces." />
+        <ECProperty propertyName="SurfaceDepthParkingSpaces" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Space Surface Depth" description="Surface or material depth for specific parking spaces." />
     </ECEntityClass>
 
     <ECEntityClass typeName="LayoutPondArea" modifier="Sealed" displayLabel="Pond Area" description="Layout pond area.">
@@ -573,9 +573,9 @@
 
         <ECProperty propertyName="DoGrade" typeName="boolean" category="GradingArea_Optimizer" displayLabel="Grading" />
 
-        <ECProperty propertyName="Topsoil" typeName="double" category="GradingArea_Surface" kindOfQuantity="rru:LENGTH" displayLabel="Topsoil" description="Topsoil depth for grading area." />
+        <ECProperty propertyName="Topsoil" typeName="double" category="GradingArea_Surface" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Topsoil" description="Topsoil depth for grading area." />
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="GradingArea_Surface" displayLabel="Surface Type" description="Surface type or material for grading area." />
-        <ECProperty propertyName="SurfaceDepth" typeName="double" category="GradingArea_Surface" kindOfQuantity="rru:LENGTH" displayLabel="Surface Depth" description="Surface or material depth for grading area." />
+        <ECProperty propertyName="SurfaceDepth" typeName="double" category="GradingArea_Surface" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth for grading area." />
 
         <ECProperty propertyName="MinSlope" typeName="double" category="GradingArea_Constraints" kindOfQuantity="rru:SLOPE" displayLabel="Min. Slope" description="Minimum slope constraint on grading area." />
         <ECProperty propertyName="MaxSlope" typeName="double" category="GradingArea_Constraints" kindOfQuantity="rru:SLOPE" displayLabel="Max. Slope" description="Maximum slope constraint on grading area." />
@@ -724,7 +724,7 @@
         <ECProperty propertyName="OnSideIslandCurbRadius" typeName="double" kindOfQuantity="rru:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Curb Radius" description="Onside parking island curb radius for this side of driveway." />
 
         <ECProperty propertyName="OnSideParkingSurfaceType" typeName="SurfaceType" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Type" description="Onside parking surface type for this side of driveway." />
-        <ECProperty propertyName="OnSideParkingSurfaceDepth" typeName="double" kindOfQuantity="rru:LENGTH" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Depth" description="Onside parking material depth for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingSurfaceDepth" typeName="double" kindOfQuantity="rru:LENGTH_SHORT" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Depth" description="Onside parking material depth for this side of driveway." />
         <ECProperty propertyName="OnSideParkingMinSlope" typeName="double" kindOfQuantity="rru:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Min. Slope" description="Onside parking minimum design slope for this side of driveway." />
         <ECProperty propertyName="OnSideParkingMaxSlope" typeName="double" kindOfQuantity="rru:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Max. Slope" description="Onside parking maximum design slope for this side of driveway." />
     </ECEntityClass>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -5173,7 +5173,7 @@
       "date": "Unknown",
       "dynamic": "No"
     }
-  ],  
+  ],
   "SewerHydraulicAnalysis": [
     {
       "name": "SewerHydraulicAnalysis",
@@ -5307,7 +5307,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.00",
+      "version": "01.00.01",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",


### PR DESCRIPTION
Changes following properties from using KoQ `rru:LENGTH` to `rru:LENGTH_SHORT`:
  - CenterlinePathEdge.SurfaceDepth
  - ShapedArea.SurfaceDepth
  - GradingArea.SurfaceDepth
  - LayoutParkingArea.SurfaceDepthParkingLot
  - LayoutParkingArea.SurfaceDepthParkingSpaces
  - EdgeOnSideParkingAspect.OnSideParkingSurfaceDepth
  - GradingArea.Topsoil
  - ShapedArea.Topsoil
