### PR TITLE
Use latest released AecUnits Schema in AecValueDefinitions and PipeworkPhysical

### DIFF
--- a/Domains/1-Common/AecValueDefinitions/AecValueDefinitions.ecschema.xml
+++ b/Domains/1-Common/AecValueDefinitions/AecValueDefinitions.ecschema.xml
@@ -6,7 +6,7 @@
 <ECSchema schemaName="AecValueDefinitions" alias="aecvdef" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="Design Modeling Value Definitions" description="Schema declaring single logical value definitions used across AEC schemas.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
-    <ECSchemaReference name="AecUnits" version="01.00.04" alias="AECU"/>
+    <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU"/>
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">

--- a/Domains/2-DisciplinePhysical/Piping/PipeworkPhysical.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/Piping/PipeworkPhysical.ecschema.xml
@@ -7,7 +7,7 @@
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
-    <ECSchemaReference name="AecUnits" version="01.00.04" alias="AECU"/>
+    <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU"/>
     <ECSchemaReference name="AecValueDefinitions" version="01.00.00" alias="aecvdef"/>
     <ECSchemaReference name="DistributionSystems" version="01.00.02" alias="dsys"/>
 
@@ -49,7 +49,7 @@
             <IsMixin xmlns="CoreCustomAttributes.01.00.03">
                 <AppliesToEntityClass>bis:PhysicalType</AppliesToEntityClass>
             </IsMixin>
-        </ECCustomAttributes>        
+        </ECCustomAttributes>
     </ECEntityClass>
 
     <ECEntityClass typeName="PipeElement" modifier="Abstract" displayLabel="Pipe Element" description="A bis:PhysicalElement that models a tube used to typically join two sections of a piping network.">


### PR DESCRIPTION
`AecValueDefinitions` and `PipeworkPhysical` do not use anything new in working version (1.0.4) of `AecUnits`. `PipeworkPhysical` will release is soon - no need to force `AecUnits` release.