### PR TITLE
Fixed bug in WIP schema validation and updated OpenSiteDraft schema name

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSiteDraft.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSiteDraft.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSiteDrafts" alias="OpenSiteDrafts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite Drafts" description="Drafts schema for drawing precise shapes in OpenSite+.">
+<ECSchema schemaName="OpenSiteDraft" alias="OpenSiteDrafts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite Drafts" description="Drafts schema for drawing precise shapes in OpenSite+.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />

--- a/tools/SchemaValidation/iModelSchemaValidationRunner.js
+++ b/tools/SchemaValidation/iModelSchemaValidationRunner.js
@@ -175,7 +175,7 @@ async function validateWipSchemas(ignoreList, singleSchemaName, output) {
   }
 
   if (results.length > 0)
-    throw new Error(chalk.default.red("\nWIP Schema validation failed.  Please see logs for more details"));
+    throw new Error("\nWIP Schema validation failed.  Please see logs for more details");
   else
     console.log(chalk.default.green("\nWIP Schema validation Succeeded"));
 }

--- a/tools/SchemaValidation/iModelSchemaValidationRunner.js
+++ b/tools/SchemaValidation/iModelSchemaValidationRunner.js
@@ -175,7 +175,7 @@ async function validateWipSchemas(ignoreList, singleSchemaName, output) {
   }
 
   if (results.length > 0)
-    console.log(chalk.default.red("\nWIP Schema validation failed.  Please see logs for more details"));
+    throw new Error(chalk.default.red("\nWIP Schema validation failed.  Please see logs for more details"));
   else
     console.log(chalk.default.green("\nWIP Schema validation Succeeded"));
 }


### PR DESCRIPTION
The OpenSiteDraft schema filename is **OpenSiteDraft**.ecschema.xml but the XML has `schemaName="OpenSiteDrafts"` that is causing the following issue:

```
An error occurred during validation: ENOENT: no such file or directory, lstat 'C:\Users\VSSADM~1\AppData\Local\Temp\SchemaValidation\Briefcases\validation\testimodel\exported\OpenSiteDraft.01.00.00.ecschema.xml'
```