### PR TITLE
Add "AuthoringElementDrivesPlanElement" schema relationship

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -9,7 +9,7 @@
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
     <ECSchemaReference name="LinearReferencing" version="02.00.03" alias="lr" />
     <ECSchemaReference name="RoadRailUnits" version="01.00.02" alias="rru" />
-    <ECSchemaRefernce name= "CivilSpatial" version="01.00.00" alias="cvsp" />
+    <ECSchemaReference name="SpatialComposition" version="01.00.01" alias="spcomp" />
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -935,7 +935,7 @@
             <Class class="SpatialLocationElement"/>
         </Source>
         <Target multiplicity="(0..*)" roleLabel="is created by" polymorphic="true">
-            <Class class="cvsp:Space"/>
+            <Class class="spcomp:Space"/>
         </Target>
     </ECRelationshipClass>
 </ECSchema>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -929,7 +929,7 @@
         </Target>
     </ECRelationshipClass>
 
-    <ECRelationshipClass typeName="AuthoringElementDrivesPlanElement" modifier="None" strength="referencing">
+    <ECRelationshipClass typeName="AuthoringElementDrivesPlanElements" modifier="None" strength="referencing">
         <BaseClass>bis:ElementDrivesElement</BaseClass>
         <Source multiplicity="(1..1)" roleLabel="creates" polymorphic="true">
             <Class class="bis:SpatialLocationElement"/>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -101,7 +101,7 @@
     </ECEnumeration>
 
     <ECEntityClass typeName="Vertex" modifier="Abstract" displayLabel="Vertex">
-        <BaseClass>bis:SpatialLocationElement</BaseClass>
+        <BaseClass>bis:bis:</BaseClass>
 
         <ECProperty propertyName="Location" typeName="Point3d" />
     </ECEntityClass>
@@ -185,7 +185,7 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="Edge" modifier="Abstract">
-        <BaseClass>bis:SpatialLocationElement</BaseClass>
+        <BaseClass>bis:bis:</BaseClass>
 
         <ECProperty propertyName="Order" typeName="int">
             <ECCustomAttributes>
@@ -280,7 +280,7 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayPathFin" modifier="Sealed" displayLabel="Driveway Fin" description="One of two sides to a Driveway Path Edge.">
-        <BaseClass>bis:SpatialLocationElement</BaseClass>
+        <BaseClass>bis:bis:</BaseClass>
 
         <!--
             In SITEOPS, (almost) all the properties on this element are duplicated with the '-Other' post-fix and live on a single Side object.
@@ -328,7 +328,7 @@
     </ECRelationshipClass>
 
     <ECEntityClass typeName="Wire" modifier="Abstract">
-        <BaseClass>bis:SpatialLocationElement</BaseClass>
+        <BaseClass>bis:bis:</BaseClass>
         <BaseClass>bis:IParentElement</BaseClass>
     </ECEntityClass>
 
@@ -932,7 +932,7 @@
     <ECRelationshipClass typeName="AuthoringElementDrivesPlanElement" modifier="None" strength="referencing">
         <BaseClass>bis:ElementDrivesElement</BaseClass>
         <Source multiplicity="(1..1)" roleLabel="creates" polymorphic="true">
-            <Class class="SpatialLocationElement"/>
+            <Class class="bis:SpatialLocationElement"/>
         </Source>
         <Target multiplicity="(0..*)" roleLabel="is created by" polymorphic="true">
             <Class class="spcomp:Space"/>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -9,6 +9,7 @@
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
     <ECSchemaReference name="LinearReferencing" version="02.00.03" alias="lr" />
     <ECSchemaReference name="RoadRailUnits" version="01.00.02" alias="rru" />
+    <ECSchemaRefernce name= "CivilSpatial" version="01.00.00" alias="cvsp" />
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -928,4 +929,13 @@
         </Target>
     </ECRelationshipClass>
 
+    <ECRelationshipClass typeName="AuthoringElementDrivesPlanElement" modifier="None" strength="referencing">
+        <BaseClass>bis:ElementDrivesElement</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="creates" polymorphic="true">
+            <Class class="SpatialLocationElement"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is created by" polymorphic="true">
+            <Class class="cvsp:Space"/>
+        </Target>
+    </ECRelationshipClass>
 </ECSchema>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -101,7 +101,7 @@
     </ECEnumeration>
 
     <ECEntityClass typeName="Vertex" modifier="Abstract" displayLabel="Vertex">
-        <BaseClass>bis:bis:</BaseClass>
+        <BaseClass>bis:SpatialLocationElement</BaseClass>
 
         <ECProperty propertyName="Location" typeName="Point3d" />
     </ECEntityClass>
@@ -185,7 +185,7 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="Edge" modifier="Abstract">
-        <BaseClass>bis:bis:</BaseClass>
+        <BaseClass>bis:SpatialLocationElement</BaseClass>
 
         <ECProperty propertyName="Order" typeName="int">
             <ECCustomAttributes>
@@ -280,7 +280,7 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayPathFin" modifier="Sealed" displayLabel="Driveway Fin" description="One of two sides to a Driveway Path Edge.">
-        <BaseClass>bis:bis:</BaseClass>
+        <BaseClass>bis:SpatialLocationElement</BaseClass>
 
         <!--
             In SITEOPS, (almost) all the properties on this element are duplicated with the '-Other' post-fix and live on a single Side object.
@@ -328,7 +328,7 @@
     </ECRelationshipClass>
 
     <ECEntityClass typeName="Wire" modifier="Abstract">
-        <BaseClass>bis:bis:</BaseClass>
+        <BaseClass>bis:SpatialLocationElement</BaseClass>
         <BaseClass>bis:IParentElement</BaseClass>
     </ECEntityClass>
 


### PR DESCRIPTION
- In OpenSite+, we were planning to use the ElementDrivesElement relationship when creating Spatial areas (as outputs) from our Authoring elements (inputs) during site layout to link the related elements in different models:
![image](https://github.com/user-attachments/assets/89375532-17d1-4d69-815b-da1c4670f965)

- The ElementDrivesElement relationship will be used in other places in our application (ex. Drainage), so a sub-class would help clarify the nature of the relationship for each instance

- This PR adds a "AuthoringElementDrivesPlanElement" relationship to meet these needs