### PR TITLE
Reflect decisions from 2/7/2025 BWG meeting.

### DIFF
--- a/Domains/0-Core/BisCore.ecschema.xml
+++ b/Domains/0-Core/BisCore.ecschema.xml
@@ -2200,7 +2200,7 @@
         </ECProperty>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" description="Settings of the style">
             <ECCustomAttributes>
-                <HiddenProperty xmlns="BisCore.01.00.16"/>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
             </ECCustomAttributes>
         </ECProperty>
         <ECProperty propertyName="Data" typeName="binary" description="Encoded style properties">

--- a/Domains/0-Core/BisCore.ecschema.xml
+++ b/Domains/0-Core/BisCore.ecschema.xml
@@ -1524,7 +1524,7 @@
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.01.00.00"/>
             <Deprecated xmlns="CoreCustomAttributes.01.00.03">
-                <Description>Settings are now stored in the `JsonProperties` attribute of TextAnnotation2d and TextAnnotation3d classes.</Description>
+                <Description>`TextAnnotationData` is deprecated and replaced by the `TextAnnotationData` property of TextAnnotation2d and TextAnnotation3d classes.</Description>
             </Deprecated>
         </ECCustomAttributes>
         <ECProperty propertyName="TextAnnotation" typeName="binary" displayLabel="Text Annotation" description="Text in Annotations.fb.h flat buffer format">
@@ -1539,6 +1539,11 @@
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.01.00.00"/>
         </ECCustomAttributes>
+        <ECProperty propertyName="TextAnnotationData" typeName="string" extendedTypeName="Json" description="Data used to generate the visual representation of a TextAnnotation2d element.">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
     </ECEntityClass>
     <ECRelationshipClass typeName="TextAnnotation2dOwnsTextAnnotationData" strength="embedding" modifier="None">
         <BaseClass>ElementOwnsUniqueAspect</BaseClass>
@@ -1560,6 +1565,11 @@
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.01.00.00"/>
         </ECCustomAttributes>
+        <ECProperty propertyName="TextAnnotationData" typeName="string" extendedTypeName="Json" description="Data used to generate the visual representation of a TextAnnotation3d element.">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+            </ECCustomAttributes>
+        </ECProperty>
     </ECEntityClass>
     <ECRelationshipClass typeName="TextAnnotation3dOwnsTextAnnotationData" strength="embedding" modifier="None">
         <BaseClass>ElementOwnsUniqueAspect</BaseClass>
@@ -2182,19 +2192,24 @@
         <BaseClass>DefinitionElement</BaseClass>
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.01.00.00"/>
-            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
-                <Description>Not modeled with BIS anymore.</Description>
-            </Deprecated>
         </ECCustomAttributes>
         <ECProperty propertyName="Description" typeName="string" description="Description of the style">
             <ECCustomAttributes>
                 <CustomHandledProperty xmlns="BisCore.01.00.16"/>
             </ECCustomAttributes>
         </ECProperty>
+        <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" description="Settings of the style">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="BisCore.01.00.16"/>
+            </ECCustomAttributes>
+        </ECProperty>
         <ECProperty propertyName="Data" typeName="binary" description="Encoded style properties">
             <ECCustomAttributes>
                 <CustomHandledProperty xmlns="BisCore.01.00.16"/>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03"/>
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>The `Data` property is deprecated and replaced by the `Settings` property.</Description>
+                </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
     </ECEntityClass>


### PR DESCRIPTION
- AnnotationTextStyle not deprecated.
- Deprecate AnnotationTextStyle.Data.
- New AnnotationTextStyle.Settings property (Json-based).
- New TextAnnotationData properties (Json-based) on TextAnnotation2d and 3d.

Captured both the tweaks to deprecations as well as the new properties into a single PR rather than two as originally mentioned in the BWG meeting, in order to link them via deprecation descriptions.

These changes are meant to be included in the upcoming release of BisCore (01.00.17), which is planned to be deployed by iTwin.js-core 5.