### PR TITLE
Add ElementDrivesElement subclasses for cases where an dependent element is defined along a linear source element

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -960,7 +960,7 @@
     </ECRelationshipClass>
 
     <ECRelationshipClass typeName="ElementDrivesDistributionStructuresLinearly" modifier="None" strength="referencing" strengthDirection="forward" description="">
-        <BaseClass>ElementDrivesElementLinearly</BaseClass>
+        <BaseClass>ElementDrivesElementsLinearly</BaseClass>
         <Source multiplicity="(0..1)" roleLabel="drives" polymorphic="true">
             <Class class="bis:GeometricElement3d"/>
         </Source>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -3,13 +3,14 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.04" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.05" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
     <ECSchemaReference name="LinearReferencing" version="02.00.03" alias="lr" />
     <ECSchemaReference name="RoadRailUnits" version="01.00.02" alias="rru" />
     <ECSchemaReference name="SpatialComposition" version="01.00.01" alias="spcomp" />
+    <ECSchemaReference name="StormSewerPhysical" version="01.00.01" alias="ssphys" />
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -936,6 +937,35 @@
         </Source>
         <Target multiplicity="(0..*)" roleLabel="is created by" polymorphic="true">
             <Class class="spcomp:Space"/>
+        </Target>
+    </ECRelationshipClass>
+	
+	<ECStructClass typeName="DistanceAlongLinearPath" description="Describes a distance along a linear path, as either an absolute distance or a percent along" modifier="Sealed">
+        <ECProperty propertyName="AbsoluteAlong" typeName="double" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Applicable when IsDistanceAbsolute is true. It is the distance along the linear path in meters"/>
+        <ECProperty propertyName="PercentAlong" typeName="double" kindOfQuantity="rru:PERCENTAGE" displayLabel="Applicable when IsDistanceAbsolute is false. It is the percent along the linear path"/>
+        <ECProperty propertyName="IsDistanceAbsolute" typeName="boolean" displayLabel="True if DistanceAlong property should be used, false if PercentAlong describes the distance. Undefined implies an absolute distance"/>
+    </ECStructClass>
+
+	<ECRelationshipClass typeName="ElementDrivesElementLinearly" modifier="Abstract" strength="referencing" strengthDirection="forward" description="">
+        <BaseClass>bis:ElementDrivesElement</BaseClass>
+        <Source multiplicity="(0..1)" roleLabel="drives" polymorphic="true">
+            <Class class="bis:GeometricElement"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is driven by" polymorphic="true">
+            <Class class="bis:GeometricElement"/>
+        </Target>
+        <ECStructProperty propertyName="DistanceAlong" typeName="DistanceAlongLinearPath" displayLabel="Distance along linear, in meters or percent"/>
+        <ECProperty propertyName="Offset" typeName="double" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Perpendicular offset from linear. Positive is to the right, negative to the left, relative to the linear path direction"/>
+        <ECProperty propertyName="IsDistanceFromStart" typeName="boolean" displayLabel="True if distance is from the start of the linear path, false if it is from the end. Undefined implies it is from the start"/>
+    </ECRelationshipClass>
+
+	<ECRelationshipClass typeName="ElementDrivesDistributionStructureLinearly" modifier="None" strength="referencing" strengthDirection="forward" description="">
+        <BaseClass>ElementDrivesElementLinearly</BaseClass>
+        <Source multiplicity="(0..1)" roleLabel="drives" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is driven by" polymorphic="true">
+            <Class class="ssphys:DistributionStructure"/>
         </Target>
     </ECRelationshipClass>
 </ECSchema>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -10,7 +10,7 @@
     <ECSchemaReference name="LinearReferencing" version="02.00.03" alias="lr" />
     <ECSchemaReference name="RoadRailUnits" version="01.00.02" alias="rru" />
     <ECSchemaReference name="SpatialComposition" version="01.00.01" alias="spcomp" />
-    <ECSchemaReference name="StormSewerPhysical" version="01.00.01" alias="ssphys" />
+    <ECSchemaReference name="StormSewerPhysical" version="01.00.01" alias="stmswrphys" />
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -965,7 +965,7 @@
             <Class class="bis:GeometricElement3d"/>
         </Source>
         <Target multiplicity="(0..*)" roleLabel="is driven by" polymorphic="true">
-            <Class class="ssphys:DistributionStructure"/>
+            <Class class="stmswrphys:DistributionStructure"/>
         </Target>
     </ECRelationshipClass>
 </ECSchema>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.05" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.04" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
@@ -939,14 +939,14 @@
             <Class class="spcomp:Space"/>
         </Target>
     </ECRelationshipClass>
-	
-	<ECStructClass typeName="DistanceAlongLinearPath" description="Describes a distance along a linear path, as either an absolute distance or a percent along" modifier="Sealed">
+
+    <ECStructClass typeName="DistanceAlongLinearPath" description="Describes a distance along a linear path, as either an absolute distance or a percent along" modifier="Sealed">
         <ECProperty propertyName="AbsoluteAlong" typeName="double" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Applicable when IsDistanceAbsolute is true. It is the distance along the linear path in meters"/>
         <ECProperty propertyName="PercentAlong" typeName="double" kindOfQuantity="rru:PERCENTAGE" displayLabel="Applicable when IsDistanceAbsolute is false. It is the percent along the linear path"/>
         <ECProperty propertyName="IsDistanceAbsolute" typeName="boolean" displayLabel="True if DistanceAlong property should be used, false if PercentAlong describes the distance. Undefined implies an absolute distance"/>
     </ECStructClass>
 
-	<ECRelationshipClass typeName="ElementDrivesElementLinearly" modifier="Abstract" strength="referencing" strengthDirection="forward" description="">
+    <ECRelationshipClass typeName="ElementDrivesElementsLinearly" modifier="Abstract" strength="referencing" strengthDirection="forward" description="">
         <BaseClass>bis:ElementDrivesElement</BaseClass>
         <Source multiplicity="(0..1)" roleLabel="drives" polymorphic="true">
             <Class class="bis:GeometricElement"/>
@@ -959,7 +959,7 @@
         <ECProperty propertyName="IsDistanceFromStart" typeName="boolean" displayLabel="True if distance is from the start of the linear path, false if it is from the end. Undefined implies it is from the start"/>
     </ECRelationshipClass>
 
-	<ECRelationshipClass typeName="ElementDrivesDistributionStructureLinearly" modifier="None" strength="referencing" strengthDirection="forward" description="">
+    <ECRelationshipClass typeName="ElementDrivesDistributionStructuresLinearly" modifier="None" strength="referencing" strengthDirection="forward" description="">
         <BaseClass>ElementDrivesElementLinearly</BaseClass>
         <Source multiplicity="(0..1)" roleLabel="drives" polymorphic="true">
             <Class class="bis:GeometricElement3d"/>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -5489,7 +5489,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.04",
+      "version": "01.00.05",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -5489,7 +5489,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.05",
+      "version": "01.00.04",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",


### PR DESCRIPTION
Add ElementDrivesElement subclasses for cases where an dependent element is defined along a linear source element