### PR TITLE
Use a different unit system for linear springs

### DIFF
--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -951,18 +951,22 @@
     <ECEntityClass typeName="IsmSupportMember" modifier="Abstract">
         <BaseClass>IsmMember</BaseClass>
     </ECEntityClass>
-
+    <KindOfQuantity typeName="LINEAR_SPRING_CONSTANT_KN_DEFAULT"
+                  displayLabel="Linear Spring Constant (kN/m² default)"
+                  persistenceUnit="u:LINEAR_SPRING_CONSTANT_N_PER_SQ_M"
+                  relativeError="0.001"
+                  presentationUnits="f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_KN_PER_SQ_M];f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_N_PER_SQ_M];f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_KPF_PER_SQ_FT]"/>
     <PropertyCategory typeName="IsmCurveSupport_category" displayLabel="Curve Support" priority="180" />
     <ECEntityClass typeName="IsmCurveSupport" displayLabel="Curve Support" modifier="Sealed">
         <BaseClass>IsmSupportMember</BaseClass>
         <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmCurveSupport_category" />
         <ECProperty propertyName="TAxis" typeName="Point3d" displayLabel="T-Axis" category="IsmCurveSupport_category" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:LINEAR_SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
         <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="RAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="R-Axis Translation Direction" category="IsmCurveSupport_category" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:LINEAR_SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
         <ECProperty propertyName="SAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="S-Axis Translation Direction" category="IsmCurveSupport_category" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:LINEAR_SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
         <ECProperty propertyName="TAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="T-Axis Translation Direction" category="IsmCurveSupport_category" />
     </ECEntityClass>
 
@@ -1350,13 +1354,13 @@
         <ECProperty propertyName="Location" typeName="Point3d" category="IsmPointSupport_category" kindOfQuantity="AECU:LENGTH" />
         <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="RAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="R-Axis Translation Direction" category="IsmPointSupport_category" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
-        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
         <ECProperty propertyName="SAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="S-Axis Translation Direction" category="IsmPointSupport_category" />
         <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
         <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="TAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="T-Axis Translation Direction" category="IsmPointSupport_category" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
     </ECEntityClass>
 
     <PropertyCategory typeName="IsmNode_category" displayLabel="Node" priority="190" />
@@ -1727,13 +1731,13 @@
         <BaseClass>IsmPipingSupport</BaseClass>
         <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="RAxisTranslationDirection" typeName="AxialBehavior" displayLabel="R-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
         <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="SAxisTranslationDirection" typeName="AxialBehavior" displayLabel="S-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
         <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="TAxisTranslationDirection" typeName="AxialBehavior" displayLabel="T-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmPipingMember_PipingLine" modifier="None" strength="referencing" strengthDirection="forward">

--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -953,7 +953,7 @@
     </ECEntityClass>
 
     <KindOfQuantity typeName="LINEAR_SPRING_CONSTANT_KN"
-                  displayLabel="Linear Spring Constant (kN/m² default)"
+                  displayLabel="Linear Spring Constant (kN/m²)"
                   persistenceUnit="u:LINEAR_SPRING_CONSTANT_N_PER_SQ_M"
                   relativeError="0.001"
                   presentationUnits="f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_KN_PER_SQ_M];f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_N_PER_SQ_M];f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_KPF_PER_SQ_FT]"/>

--- a/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
+++ b/Domains/4-Application/ISM/IntegratedStructuralModel.ecschema.xml
@@ -951,22 +951,24 @@
     <ECEntityClass typeName="IsmSupportMember" modifier="Abstract">
         <BaseClass>IsmMember</BaseClass>
     </ECEntityClass>
-    <KindOfQuantity typeName="LINEAR_SPRING_CONSTANT_KN_DEFAULT"
+
+    <KindOfQuantity typeName="LINEAR_SPRING_CONSTANT_KN"
                   displayLabel="Linear Spring Constant (kN/m² default)"
                   persistenceUnit="u:LINEAR_SPRING_CONSTANT_N_PER_SQ_M"
                   relativeError="0.001"
                   presentationUnits="f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_KN_PER_SQ_M];f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_N_PER_SQ_M];f:DefaultRealU(4)[u:LINEAR_SPRING_CONSTANT_KPF_PER_SQ_FT]"/>
+
     <PropertyCategory typeName="IsmCurveSupport_category" displayLabel="Curve Support" priority="180" />
     <ECEntityClass typeName="IsmCurveSupport" displayLabel="Curve Support" modifier="Sealed">
         <BaseClass>IsmSupportMember</BaseClass>
         <ECStructProperty propertyName="Location" typeName="IsmPrimitiveGeometry" displayLabel="Location" category="IsmCurveSupport_category" />
         <ECProperty propertyName="TAxis" typeName="Point3d" displayLabel="T-Axis" category="IsmCurveSupport_category" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
         <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="RAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="R-Axis Translation Direction" category="IsmCurveSupport_category" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
         <ECProperty propertyName="SAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="S-Axis Translation Direction" category="IsmCurveSupport_category" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmCurveSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
         <ECProperty propertyName="TAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="T-Axis Translation Direction" category="IsmCurveSupport_category" />
     </ECEntityClass>
 
@@ -1354,13 +1356,13 @@
         <ECProperty propertyName="Location" typeName="Point3d" category="IsmPointSupport_category" kindOfQuantity="AECU:LENGTH" />
         <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="RAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="R-Axis Translation Direction" category="IsmPointSupport_category" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
-        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
+        <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
         <ECProperty propertyName="SAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="S-Axis Translation Direction" category="IsmPointSupport_category" />
         <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:SPRING_CONSTANT" />
         <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" category="IsmPointSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="TAxisTranslationDirection" typeName="IsmFixityDirection" displayLabel="T-Axis Translation Direction" category="IsmPointSupport_category" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPointSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
     </ECEntityClass>
 
     <PropertyCategory typeName="IsmNode_category" displayLabel="Node" priority="190" />
@@ -1731,13 +1733,13 @@
         <BaseClass>IsmPipingSupport</BaseClass>
         <ECProperty propertyName="RAxisRotationStiffness" typeName="double" displayLabel="R-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="RAxisTranslationDirection" typeName="AxialBehavior" displayLabel="R-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
-        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="RAxisTranslationStiffness" typeName="double" displayLabel="R-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
         <ECProperty propertyName="SAxisRotationStiffness" typeName="double" displayLabel="S-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="SAxisTranslationDirection" typeName="AxialBehavior" displayLabel="S-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
-        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="SAxisTranslationStiffness" typeName="double" displayLabel="S-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
         <ECProperty propertyName="TAxisRotationStiffness" typeName="double" displayLabel="T-Axis Rotation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="AECU:ROTATIONAL_SPRING_CONSTANT" />
         <ECProperty propertyName="TAxisTranslationDirection" typeName="AxialBehavior" displayLabel="T-Axis Translation Direction" category="IsmPipingAnchorSupport_category" />
-        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN_DEFAULT" />
+        <ECProperty propertyName="TAxisTranslationStiffness" typeName="double" displayLabel="T-Axis Translation Stiffness" category="IsmPipingAnchorSupport_category" kindOfQuantity="LINEAR_SPRING_CONSTANT_KN" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="IsmPipingMember_PipingLine" modifier="None" strength="referencing" strengthDirection="forward">


### PR DESCRIPTION
Changed from using default N/m^2 to kN/m^2 unit.