### PR TITLE
Add Curbs to CivilSpatial Schema

### DIFF
--- a/Domains/2-DisciplinePhysical/Civil/SpatialComposition/CivilSpatial/CivilSpatial.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/Civil/SpatialComposition/CivilSpatial/CivilSpatial.ecschema.xml
@@ -143,7 +143,7 @@
     <ECEntityClass typeName="GenericAreaType" displayLabel="Generic Space Type" modifier="Sealed" description="Defines a shared set of properties whose values vary per-type of cvsp:GenericArea rather than per-instance.">
         <BaseClass>spcomp:SpaceType</BaseClass>
     </ECEntityClass>
-    
+
     <ECRelationshipClass typeName="GenericAreaIsOfType" strength="referencing" modifier="Sealed" description="A type-instance relation; one that indicates that the specific cvsp:GenericArea is an instance of the defined cvsp:GenericAreaType.">
         <BaseClass>spcomp:SpaceIsOfType</BaseClass>
         <Source multiplicity="(0..*)" roleLabel="is of" polymorphic="false">
@@ -151,6 +151,24 @@
         </Source>
         <Target multiplicity="(0..1)" roleLabel="is type of" polymorphic="false">
             <Class class="GenericAreaType"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECEntityClass typeName="Curb" modifier="None" displayLabel="Curb" description="A cvsp:Space modeling a curb.">
+        <BaseClass>Space</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="CurbType" modifier="None" displayLabel="Curb Type" description="Defines a shared set of properties whose values vary per-type of cvsp:Curb rather than per-instance.">
+        <BaseClass>spcomp:SpaceType</BaseClass>
+    </ECEntityClass>
+
+    <ECRelationshipClass typeName="CurbIsOfType" strength="referencing" modifier="None" description="A type-instance relation; one that indicates that the specific cvsp:Curb is an instance of the defined cvsp:CurbType.">
+        <BaseClass>spcomp:SpaceIsOfType</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="is of" polymorphic="true">
+            <Class class="Curb" />
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is type of" polymorphic="true">
+            <Class class="CurbType"/>
         </Target>
     </ECRelationshipClass>
 </ECSchema>


### PR DESCRIPTION
- This PR adds a Curb class to the CivilSpatial Schema
- Motivated by OpenSite+ to have an easy way to show the "outlines" of curbs for drawing production/plan view