### PR TITLE
OpenSite+ Additions: SpatialLocationExtractedFromPhysicalElement Relationship, CachedLinear Element

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -641,6 +641,12 @@
         <BaseClass>GradingPath</BaseClass>
     </ECEntityClass>
 
+    <ECEntityClass typeName="CachedLinear" modifier="Sealed" displayLabel="Cached Linear" description="Cached 3D Linear geometry.">
+        <BaseClass>bis:SpatialLocationElement</BaseClass>
+
+        <ECProperty propertyName="geometry" typeName="Bentley.Geometry.Common.IGeometry" displayLabel="Linear Geometry" />
+    </ECEntityClass>
+
     <ECEntityClass typeName="ContourLinesAspect" modifier="Sealed" displayLabel="Contour Lines" description="Terrain contour lines" >
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
@@ -966,6 +972,16 @@
         </Source>
         <Target multiplicity="(0..*)" roleLabel="is driven by" polymorphic="true">
             <Class class="stmswrphys:DistributionStructure"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="SpatialLocationExtractedFromPhysicalElement" modifier="None" strength="referencing" strengthDirection="forward" description="A relationship that describes how a bis:SpatialLocationElement can be extracted from a bis:PhysicalElement">
+        <BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="extracts" polymorphic="true">
+            <Class class="bis:SpatialLocationElement"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is extracted from" polymorphic="true">
+            <Class class="bis:PhysicalElement"/>
         </Target>
     </ECRelationshipClass>
 </ECSchema>


### PR DESCRIPTION
This PR makes the following changes to OpenSite+ Application Schema:

- Adds ```SpatialLocationExtractedFromPhysicalElement``` relationship
  - This will be eventually used by spatial Curb elements that have been extracted from their physical counterparts
  - This will also be used by the new ```CachedLinear``` class, which are also extracted from physical elements (curbs, courses)
-  Adds ```CachedLinear``` class
   - Surface control requires the 3D boundary of various meshes in OpenSite+
   - With the recent change of making plan model elements contain 2D geometry only, the 3D boundary information was lost
   - This class will allow for persistence of various 3D linestrings, such as Back of Curb, Flow Line, and Edge of Gutter