### PR TITLE
[OpenSite] Add DrivewayTransitions; deprecate old transition properties on DrivewayMidVertex

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -482,7 +482,7 @@
         </Target>
     </ECRelationshipClass>
 
-    <ECRelationshipClass typeName="DrivewayMidVertexOwnsTransition" strength="embedding" strengthDirection="Forward" modifier="Sealed">
+    <ECRelationshipClass typeName="DrivewayMidVertexOwnsTransitions" strength="embedding" strengthDirection="Forward" modifier="Sealed">
         <BaseClass>bis:ElementOwnsChildElements</BaseClass>
         <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
             <Class class="DrivewayMidVertex" />

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -144,9 +144,30 @@
     <ECEntityClass typeName="DrivewayMidVertex" modifier="Sealed" displayLabel="Driveway Mid Vertex" description="Vertex of a DrivewayPath that is attached to two DrivewayPathEdge instances.">
         <BaseClass>PathMidVertex</BaseClass>
 
-        <ECProperty propertyName="SideTransitionOffset" typeName="double" kindOfQuantity="rru:LENGTH" category="DrivewayMidVertex_Transition" displayLabel="Transition Offset" description="The transition offset distance." />
-        <ECProperty propertyName="SideTransitionRadius1" typeName="double" kindOfQuantity="rru:LENGTH" category="DrivewayMidVertex_Transition" displayLabel="Transition Inner Radius" description="The inner radius of the transition." />
-        <ECProperty propertyName="SideTransitionRadius2" typeName="double" kindOfQuantity="rru:LENGTH" category="DrivewayMidVertex_Transition" displayLabel="Transition Outer Radius" description="The outer radius of the transition." />
+        <ECProperty propertyName="SideTransitionOffset" typeName="double" kindOfQuantity="rru:LENGTH" category="DrivewayMidVertex_Transition" displayLabel="Transition Offset" description="The transition offset distance." >
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Transition data to be stored in DrivewayTransitions instead. </Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SideTransitionRadius1" typeName="double" kindOfQuantity="rru:LENGTH" category="DrivewayMidVertex_Transition" displayLabel="Transition Inner Radius" description="The inner radius of the transition." >
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Transition data to be stored in DrivewayTransitions instead. </Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
+        <ECProperty propertyName="SideTransitionRadius2" typeName="double" kindOfQuantity="rru:LENGTH" category="DrivewayMidVertex_Transition" displayLabel="Transition Outer Radius" description="The outer radius of the transition." >
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
+                <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                    <Description>Transition data to be stored in DrivewayTransitions instead. </Description>
+                </Deprecated>
+            </ECCustomAttributes>
+        </ECProperty>
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingVertex" modifier="Abstract" displayLabel="Parking Vertex">
@@ -316,6 +337,20 @@
         <ECProperty propertyName="DitchSlope" typeName="double" kindOfQuantity="rru:SLOPE" category="DrivewayPathFin_Shoulder" displayLabel="Ditch Slope" description="Ditch slope for this side of driveway." />
     </ECEntityClass>
 
+    <ECEntityClass typeName="DrivewayTransition" modifier="Sealed" displayLabel="Transition">
+        <BaseClass>bis:SpatialLocationElement</BaseClass>
+
+        <ECProperty propertyName="IsPrimary" typeName="boolean">
+            <ECCustomAttributes>
+                <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
+            </ECCustomAttributes>
+        </ECProperty>
+
+        <ECProperty propertyName="sideTransitionOffset" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Transition Offset"/>
+        <ECProperty propertyName="sideTransitionRadius1" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Transition Inner Radius"/>
+        <ECProperty propertyName="sideTransitionRadius2" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Transition Outer Radius"/>
+    </ECEntityClass>
+
     <ECEntityClass typeName="SidewalkPathEdge" modifier="Sealed" displayLabel="Sidewalk Edge" description="Sidewalk path edge.">
         <BaseClass>CenterlinePathEdge</BaseClass>
     </ECEntityClass>
@@ -444,6 +479,16 @@
         </Source>
         <Target multiplicity="(2..2)" roleLabel="is owned by" polymorphic="false">
             <Class class="DrivewayPathFin" />
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="DrivewayMidVertexOwnsTransition" strength="embedding" strengthDirection="Forward" modifier="Sealed">
+        <BaseClass>bis:ElementOwnsChildElements</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="DrivewayMidVertex" />
+        </Source>
+        <Target multiplicity="(2..2)" roleLabel="is owned by" polymorphic="false">
+            <Class class="DrivewayTransition" />
         </Target>
     </ECRelationshipClass>
 


### PR DESCRIPTION
Adds the DrivewayTransition entity class (owned by the DrivewayMidVertex) with offset and radius properties. These properties on the DrivewayMidVertex have been marked as deprecated.