### PR TITLE
[OpenSite] Add LineSegment to the OpenSiteDraft schema

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSiteDraft.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSiteDraft.ecschema.xml
@@ -22,6 +22,12 @@
         <BaseClass>bis:GraphicalElement3d</BaseClass>
     </ECEntityClass>
 
+    <ECEntityClass typeName="LineSegment" displayLabel="Line Segment">
+        <BaseClass>Draft</BaseClass>
+        <ECProperty propertyName="Length" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Length" />
+        <ECProperty propertyName="Bearing" typeName="double" kindOfQuantity="rru:BEARING" displayLabel="Bearing" />
+    </ECEntityClass>
+
     <ECEntityClass typeName="Path" displayLabel="Path">
         <BaseClass>Draft</BaseClass>
     </ECEntityClass>


### PR DESCRIPTION
Add a line segment object to our draft, when a path is a single line we want to show and edit both bearing (direction) and length