### PR TITLE
Bug#1515750 Adding the Component Layer and Civil Quantities for Sleeper

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifRail.ecschema.xml
@@ -158,6 +158,17 @@
         <ECEnumerator name="Absolute" value="0" displayLabel="Absolute"/>
         <ECEnumerator name="Relative_to_Centerline" value="1" displayLabel="Relative to Centerline"/>
     </ECEnumeration>
+    <ECEnumeration typeName="MeshSurfaceEntityAspect_VolumeOption_Enum" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Design" value="2" displayLabel="Design"/>
+        <ECEnumerator name="Existing" value="1" displayLabel="Existing"/>
+        <ECEnumerator name="None" value="0" displayLabel="None"/>
+        <ECEnumerator name="Subgrade" value="4" displayLabel="Subgrade"/>
+        <ECEnumerator name="Substrata" value="3" displayLabel="Substrata"/>
+        <ECEnumerator name="Cut" value="5" displayLabel="Cut"/>
+        <ECEnumerator name="Fill" value="6" displayLabel="Fill"/>
+        <ECEnumerator name="Unsuitable" value="7" displayLabel="Unsuitable"/>
+        <ECEnumerator name="Custom" value="8" displayLabel="Custom"/>
+    </ECEnumeration>
     <ECEnumeration typeName="PathwayRouteAspect_Direction_Enum" backingTypeName="int" isStrict="true">
         <ECEnumerator name="Up" value="0" displayLabel="Up"/>
         <ECEnumerator name="Down" value="1" displayLabel="Down"/>
@@ -557,6 +568,35 @@
         </ECProperty>
         <ECProperty propertyName="RemainderLengthOptionValue" typeName="DistanceKeeperComponentAspect_RemainderLengthOption_Enum" displayLabel="Remainder Length Option" category="DistanceKeepersProperties_Distance_Keepers" priority="299960"/>
     </ECEntityClass>
+    <ECEntityClass typeName="SleeperComponentLayerAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SleeperComponentLayer_Description" typeName="string" displayLabel="Description" category="Sleeper_Component_Layer" priority="299980"/>
+        <ECProperty propertyName="SleeperComponentLayer_VolumeOption" typeName="MeshSurfaceEntityAspect_VolumeOption_Enum" displayLabel="Volume Option" category="Sleeper_Component_Layer" priority="299925"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSleeperComponentLayerAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SleeperComponentLayerAspect"/>
+        </Target>
+    </ECRelationshipClass>
+    <ECEntityClass typeName="SleeperCivilQuantitiesAspect">
+        <BaseClass>cifcmn:CivilPresentation</BaseClass>
+        <ECProperty propertyName="SleeperCivilQuantities_SlopedArea" typeName="double" displayLabel="Top Sloped Area" category="Sleeper_Civil_Quantities" priority="299920" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SleeperCivilQuantities_PlanarArea" typeName="double" displayLabel="Planar Area" category="Sleeper_Civil_Quantities" priority="299910" kindOfQuantity="cifu:AREA"/>
+        <ECProperty propertyName="SleeperCivilQuantities_CivilVolume" typeName="double" displayLabel="Volume" category="Sleeper_Civil_Quantities" priority="299900" kindOfQuantity="cifu:VOLUME"/>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="ElementOwnsSleeperCivilQuantitiesAspect" modifier="None" strength="embedding">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:GeometricElement3d"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="SleeperCivilQuantitiesAspect"/>
+        </Target>
+    </ECRelationshipClass>
     <ECRelationshipClass typeName="ElementOwnsAlongGeometryTrenchPointRuleAspect" modifier="None" strength="embedding">
         <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
         <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
@@ -1586,6 +1626,8 @@
     <PropertyCategory typeName="Joint_Joint" description="Joint" displayLabel="Joint" priority="4294967286"/>
     <PropertyCategory typeName="JointGroup_Joint_Group" description="JointGroup" displayLabel="Joint Group" priority="4294967281"/>
     <PropertyCategory typeName="LocationProperties_Location" description="LocationProperties" displayLabel="Location" priority="4294967284"/>
+    <PropertyCategory typeName="Sleeper_Civil_Quantities" description="CivilQuantities" displayLabel="Civil Quantities" priority="401000"/>
+    <PropertyCategory typeName="Sleeper_Component_Layer" description="ComponentLayer" displayLabel="Component Layer" priority="401000"/>
     <PropertyCategory typeName="Miscellaneous_Along_Geometry_Trench_Point_Rule" description="Miscellaneous" displayLabel="Along Geometry Trench Point Rule" priority="401000"/>
     <PropertyCategory typeName="Miscellaneous_Base_Turnout_Branches_Feature" description="Miscellaneous" displayLabel="Base Turnout Branches Feature" priority="401000"/>
     <PropertyCategory typeName="Miscellaneous_Base_Turnout_Elements_Feature" description="Miscellaneous" displayLabel="Base Turnout Elements Feature" priority="401000"/>


### PR DESCRIPTION
A Component Layer and Civil Quantities exist in CifCommon, but they have generic properties that appear unnecessary for the Sleeper elements. I tried to hide or remove the unnecessary properties through code, schema and mappings, but it did not work for me. So now I am deleting the generic CifCommon MeshSurfaceEntityAspect instance from the sleeper element and adding the CifRail SleeperComponentLayerAspect and SleeperCivilQuantitiesAspect instance to the sleeper element.