### PR TITLE
Release CifCommon schema to support various derived classes of Mesh

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifCommon.01.00.13.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/Released/CifCommon.01.00.13.ecschema.xml
@@ -3,14 +3,14 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CifCommon" alias="cifcmn" version="01.00.14" description="iModel Connector schema containing aspect classes with common properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CifCommon" alias="cifcmn" version="01.00.13" description="iModel Connector schema containing aspect classes with common properties from Civil Infrastructure Framework (CIF) applications." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
-    <ECSchemaReference name="CifUnits" version="01.00.08" alias="cifu"/>
+    <ECSchemaReference name="CifUnits" version="01.00.07" alias="cifu"/>
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA"/>
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.04">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>Production</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -3415,7 +3415,7 @@
       "name": "CifCommon",
       "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\CifCommon.ecschema.xml",
       "released": false,
-      "version": "01.00.13",
+      "version": "01.00.14",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Diego.Diaz",
@@ -3602,6 +3602,20 @@
       "verified": "Yes",
       "author": "Monmohan.Bordoloi",
       "date": "4/1/2025",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "CifCommon",
+      "path": "Domains\\4-Application\\Connectors\\CivilInfrastructureFramework\\Released\\CifCommon.01.00.13.ecschema.xml",
+      "released": true,
+      "version": "01.00.13",
+      "comment": "Added derived classes for MeshSurfaceEntityBaseAspect",
+      "verifier": "Colin.Kerr",
+      "sha1": "3931b54db020c6339f9a07811ffc59034e85719e",
+      "verified": "Yes",
+      "author": "Sachin.Bhosale",
+      "date": "5/21/2025",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
Added derived classes for MeshSurfaceEntityBaseAspect, which is a copy of MeshSurfaceEntityAspect, but it will give us the flexibility of showing and hiding properties as per the requirement of the element