### PR TITLE
Add CategorySymbolizesClassification to OpenSite schema

### DIFF
--- a/Domains/2-DisciplinePhysical/Civil/CivilPhysical/CivilPhysical.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/Civil/CivilPhysical/CivilPhysical.ecschema.xml
@@ -48,6 +48,22 @@
             <Class class="CurbType"/>
         </Target>
     </ECRelationshipClass>
+    <ECEntityClass typeName="RetainingWall" displayLabel="Retaining Wall" description="A lr:LinearPhysicalElement modeling a structure built to hold back soil or other materials, supporting them laterally, preventing them from sliding or eroding away.">
+
+        <BaseClass>lr:LinearPhysicalElement</BaseClass>
+    </ECEntityClass>
+    <ECEntityClass typeName="RetainingWallType" displayLabel="Retaining Wall Type" description="Defines a shared set of properties whose values vary per-type of RetainingWall rather than per-instance.">
+        <BaseClass>bis:PhysicalType</BaseClass>
+    </ECEntityClass>
+    <ECRelationshipClass typeName="RetainingWallIsOfType" strength="referencing" modifier="None" description="A type-instance relation; one that indicates that the specific cp:RetainingWall is an instance of the defined cp:RetainingWallType.">
+        <BaseClass>bis:PhysicalElementIsOfType</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="is of" polymorphic="true">
+            <Class class="RetainingWall" />
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is type of" polymorphic="true">
+            <Class class="RetainingWallType"/>
+        </Target>
+    </ECRelationshipClass>
     <ECEntityClass typeName="SurfaceMarking" displayLabel="Surface Marking" description="A bis:PhysicalElement modeling markings on a surface.">
         <BaseClass>bis:PhysicalElement</BaseClass>
     </ECEntityClass>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -12,7 +12,7 @@
     <ECSchemaReference name="SpatialComposition" version="01.00.01" alias="spcomp" />
     <ECSchemaReference name="StormSewerPhysical" version="01.00.00" alias="stmswrphys" />
     <ECSchemaReference name="CivilPhysical" version="01.00.01" alias="cvphys" />
-    <ECSchemaReference name="ClassificationSystems" version="01.00.03" alias="clsf" />
+    <ECSchemaReference name="ClassificationSystems" version="01.00.04" alias="clsf" />
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -1456,8 +1456,18 @@
         </Target>
     </ECRelationshipClass>
 
-    <ECRelationshipClass typeName="CategorySymbolizesClassification" strength="referencing" modifier="Sealed">
+    <ECRelationshipClass typeName="CategorySymbolizesClassification" strength="referencing" modifier="Abstract">
 		<BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(1..*)" roleLabel="symbolizes" polymorphic="true">
+            <Class class="bis:Category" />
+        </Source>
+        <Target multiplicity="(1..1)" roleLabel="is symbolized by" polymorphic="true">
+            <Class class="clsf:Classification" />
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="GenericCategorySymbolizesClassification" strength="referencing" modifier="Sealed">
+		<BaseClass>CategorySymbolizesClassification</BaseClass>
         <Source multiplicity="(1..*)" roleLabel="symbolizes" polymorphic="true">
             <Class class="bis:Category" />
         </Source>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -1468,7 +1468,7 @@
 
     <ECRelationshipClass typeName="GenericCategorySymbolizesClassification" strength="referencing" modifier="Sealed">
 		<BaseClass>CategorySymbolizesClassification</BaseClass>
-        <Source multiplicity="(1..*)" roleLabel="symbolizes" polymorphic="true">
+        <Source multiplicity="(1..1)" roleLabel="symbolizes" polymorphic="true">
             <Class class="bis:Category" />
         </Source>
         <Target multiplicity="(1..1)" roleLabel="is symbolized by" polymorphic="true">

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -457,6 +457,15 @@
         </Target>
     </ECRelationshipClass>
 
+    <ECRelationshipClass typeName="RetainingWallAreaUsesRetainingWallType" strength="referencing" modifier="Sealed">
+        <Source multiplicity="(0..*)" roleLabel="uses" polymorphic="false">
+            <Class class="RetainingWallArea" />
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is used by" polymorphic="true">
+            <Class class="RetainingWallType" />
+        </Target>
+    </ECRelationshipClass>
+
     <ECRelationshipClass typeName="EdgeStartsAtVertex" strength="referencing" modifier="Sealed">
         <Source multiplicity="(0..2)" roleLabel="starts at" polymorphic="true">
             <Class class="Edge" />
@@ -642,6 +651,12 @@
 
     <ECEntityClass typeName="Area" modifier="Abstract" displayLabel="Area" description="Area">
         <BaseClass>Wire</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="RetainingWallArea" displayLabel="Retaining Wall" description="Retaining Wall">
+        <BaseClass>Area</BaseClass>
+		<ECProperty propertyName="Width" typeName="double" kindOfQuantity="rru:LENGTH_SHORT" displayLabel="Width" description="Width of the retaining wall." />
+        <ECNavigationProperty propertyName="RetainingWallType" relationshipName="RetainingWallAreaUsesRetainingWallType" direction="Forward" displayLabel="Retaining Wall Type" />
     </ECEntityClass>
 
     <ECEntityClass typeName="ShapedArea" modifier="Abstract" displayLabel="Shaped Area" description="Shaped area">
@@ -852,6 +867,20 @@
 
         <ECProperty propertyName="MinorStep" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Minor Step" description="Minor steps interval size" />
         <ECProperty propertyName="MajorStepMultiple" typeName="int" displayLabel="Major Step Interval" description="Number of minor intervals between two major steps" />
+    </ECEntityClass>
+
+    <ECEntityClass typeName="RetainingWallType" displayLabel="Retaining Wall Type" description="Defines a shared set of properties whose values vary per-type of RetainingWall rather than per-instance.">
+        <BaseClass>cvphys:RetainingWallType</BaseClass>
+
+        <ECProperty propertyName="FrontWallSetback" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Front Wall Setback" description="Width of front wall setback." />
+        <ECProperty propertyName="BackWallSetback" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Back Wall Setback" description="Width of back wall setback." />
+        <ECProperty propertyName="ExposedWallHeight" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Exposed Wall Height" description="Height of exposed wall." />
+        <ECProperty propertyName="CoverDepth" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Cover Depth" description="Depth of cover." />
+        <ECProperty propertyName="ToeWidth" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Toe Width" description="Width of toe." />
+        <ECProperty propertyName="HeelWidth" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Heel Width" description="Width of heel." />
+        <ECProperty propertyName="FootingThickness" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Footing Thickness" description="Thickness of footing." />
+        <ECProperty propertyName="KeyWidth" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Key Width" description="Width of key." />
+        <ECProperty propertyName="KeyHeight" typeName="double" kindOfQuantity="rru:LENGTH" displayLabel="Key Height" description="Height of key." />
     </ECEntityClass>
 
     <ECEntityClass typeName="CurbType" displayLabel="Curb Type" description="Defines a shared set of properties whose values vary per-type of Curb rather than per-instance.">

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -1458,10 +1458,10 @@
 
     <ECRelationshipClass typeName="CategorySymbolizesClassification" strength="referencing" modifier="Sealed">
 		<BaseClass>bis:ElementRefersToElements</BaseClass>
-        <Source multiplicity="(1..*)" roleLabel="is symbolized by" polymorphic="true">
+        <Source multiplicity="(1..*)" roleLabel="symbolizes" polymorphic="true">
             <Class class="bis:Category" />
         </Source>
-        <Target multiplicity="(1..1)" roleLabel="symbolize" polymorphic="true">
+        <Target multiplicity="(1..1)" roleLabel="is symbolized by" polymorphic="true">
             <Class class="clsf:Classification" />
         </Target>
     </ECRelationshipClass>

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -12,6 +12,7 @@
     <ECSchemaReference name="SpatialComposition" version="01.00.01" alias="spcomp" />
     <ECSchemaReference name="StormSewerPhysical" version="01.00.00" alias="stmswrphys" />
     <ECSchemaReference name="CivilPhysical" version="01.00.01" alias="cvphys" />
+    <ECSchemaReference name="ClassificationSystems" version="01.00.03" alias="clsf" />
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -1452,6 +1453,16 @@
         </Source>
         <Target multiplicity="(1..*)" roleLabel="is owned by" polymorphic="false">
             <Class class="ControlLineEdge" />
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="CategorySymbolizesClassification" strength="referencing" modifier="Sealed">
+		<BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(1..*)" roleLabel="is symbolized by" polymorphic="true">
+            <Class class="bis:Category" />
+        </Source>
+        <Target multiplicity="(1..1)" roleLabel="symbolize" polymorphic="true">
+            <Class class="clsf:Classification" />
         </Target>
     </ECRelationshipClass>
 </ECSchema>


### PR DESCRIPTION
This relationship will be used to control the hierarchy shown in classification tree.
We are testing it in OpenSite+, but it is intended to be common later.