### PR TITLE
Schema upgrade tests should consider same read version

### DIFF
--- a/ignoreSchemaList.json
+++ b/ignoreSchemaList.json
@@ -110,5 +110,20 @@
     "name": "RoadRailAlignment",
     "version": "02.00.01",
     "reason": "Reference schema ECDbMap is missing"
+  },
+  {
+    "name": "CifGeometricRules",
+    "version": "*",
+    "reason": "Temporarily adding WIP schema here as it fails while schema upgrade: Error | ECDb | ECSchema Upgrade failed. ECSchema CifGeometricRules.01.00.06: Enumeration CifGeometricRules:ArcBetweenElementArcRuleAspect_AheadTransitionDefinitionMethod_Enum: An enumerator was deleted from Enumeration which is not supported."
+  },
+  {
+    "name": "CifHydraulicAnalysis",
+    "version": "*",
+    "reason": "Temporarily adding WIP schema here as it fails while schema upgrade: Error | ECDb | ECSchema Upgrade failed. ECSchema CifHydraulicAnalysis.01.00.09: Enumeration CifHydraulicAnalysis:Conduit_PhysicalAspect_HeadwaterMaximumType_Enum: An enumerator was deleted from Enumeration which is not supported."
+  },
+  {
+    "name": "CifHydraulicResults",
+    "version": "*",
+    "reason": "Temporarily adding WIP schema here as it fails while schema upgrade: Error | ECDb | ECSchema Upgrade failed. ECSchema CifHydraulicResults.01.00.07: Enumeration CifHydraulicResults:DerivedPumpResultsAspect_PumpDefinitionType_Enum: An enumerator was deleted from Enumeration which is not supported."
   }
 ]

--- a/ignoreSchemaList.json
+++ b/ignoreSchemaList.json
@@ -113,17 +113,17 @@
   },
   {
     "name": "CifGeometricRules",
-    "version": "*",
+    "version": "wip",
     "reason": "Temporarily adding WIP schema here as it fails while schema upgrade: Error | ECDb | ECSchema Upgrade failed. ECSchema CifGeometricRules.01.00.06: Enumeration CifGeometricRules:ArcBetweenElementArcRuleAspect_AheadTransitionDefinitionMethod_Enum: An enumerator was deleted from Enumeration which is not supported."
   },
   {
     "name": "CifHydraulicAnalysis",
-    "version": "*",
+    "version": "wip",
     "reason": "Temporarily adding WIP schema here as it fails while schema upgrade: Error | ECDb | ECSchema Upgrade failed. ECSchema CifHydraulicAnalysis.01.00.09: Enumeration CifHydraulicAnalysis:Conduit_PhysicalAspect_HeadwaterMaximumType_Enum: An enumerator was deleted from Enumeration which is not supported."
   },
   {
     "name": "CifHydraulicResults",
-    "version": "*",
+    "version": "wip",
     "reason": "Temporarily adding WIP schema here as it fails while schema upgrade: Error | ECDb | ECSchema Upgrade failed. ECSchema CifHydraulicResults.01.00.07: Enumeration CifHydraulicResults:DerivedPumpResultsAspect_PumpDefinitionType_Enum: An enumerator was deleted from Enumeration which is not supported."
   }
 ]

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "validateSchemas": "node ./tools/SchemaValidation/SchemaValidationRunner.js",
     "compareSchemas": "node ./tools/SchemaDifference/compareSchemas.js",
     "validateJsonSchemas": "node ./tools/packages/schemaJsonValidationRunner.js",
-    "iModelSchemaValidation": "node ./tools/SchemaValidation/iModelSchemaValidationRunner.js",
+    "iModelSchemaValidation": "node ./tools/SchemaValidation/iModelSchemaValidation.js",
     "genInventory": "node ./tools/packages/generateInventory.js --BisRoot .",
     "genPackages": "node ./tools/packages/generatePackages.js --inventory ./SchemaInventory.json --skipList ./ignoreSchemaList.json --outDir ./packageOut --template ./tools/packages/package.json.template",
     "testPkgGen": "mocha tools/packages/test/**.test.js",
     "testInvGen": "mocha tools/SchemaInventory/test/**.test.js --timeout=50000",
     "testSchemaDifference": "mocha tools/SchemaDifference/test/**.test.js --timeout=50000",
+    "testSchemaUpgrade": "mocha tools/SchemaValidation/test/schemaUpgrade.test.js --timeout=50000",
     "generateJsonSchemas": "node ./tools/packages/getSchemaJsons.js"
   },
   "dependencies": {

--- a/tools/SchemaValidation/iModelSchemaValidation.js
+++ b/tools/SchemaValidation/iModelSchemaValidation.js
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+// This tool is designed to validate all schemas in the bis-schema repository.
+
+"use strict";
+
+const validator = require('./iModelSchemaValidationRunner');
+
+validator.validateIModelSchemas().then()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tools/SchemaValidation/iModelSchemaValidationRunner.js
+++ b/tools/SchemaValidation/iModelSchemaValidationRunner.js
@@ -103,7 +103,6 @@ async function schemaUpgradeTest(ignoreList, output, checkAllVersions) {
     imodel = await importAndExportSchemaToIModel(schemaName, previousSchema, key.readVersion, previousReadVersion, releasedSchema, schemaDirs, imodel, output);
     console.log("-> ", chalk.default.green(`${schemaName}.${schemaVersion} successfully imported.`));
     writeLogsToFile(`-> ${schemaName}.${schemaVersion} successfully imported.\n\n`, output);
-    count++;
     previousSchema = schemaName;
     previousReadVersion = key.readVersion;
   }

--- a/tools/SchemaValidation/iModelSchemaValidationRunner.js
+++ b/tools/SchemaValidation/iModelSchemaValidationRunner.js
@@ -455,7 +455,7 @@ function checkIfWipSchemaRequired(previousSchema, latestReleasedVersion, wipSche
  * @param checkAllVersions Check to limit the test to read compatible versions or not
  * @returns List of shortlisted schemas that will be tested for schema upgrade.
  */
-function getShortListedVersions(releasedSchemas, wipSchemas, output, checkAllVersions) {
+function getShortListedVersions(releasedSchemas, wipSchemas, output) {
   let check = true;
   let latestReleasedVersion;
   let previousSchema;
@@ -485,7 +485,7 @@ function getShortListedVersions(releasedSchemas, wipSchemas, output, checkAllVer
     previousVersion = schemaVersion;
     previousReadVersion = schemaInfo.readVersion;
   }
-  return shortListedVersions.sort();
+  return sortSchemas(shortListedVersions);
 }
 
 /**
@@ -522,6 +522,14 @@ async function importAndExportSchemaToIModel(releasedSchema, schemaDirs, batchSt
     throw Error(err);
 
   return imodel;
+}
+
+function sortSchemas(schemaList) {
+  return schemaList.sort((a, b) => {
+    const schemaA = path.basename(a).toLowerCase();
+    const schemaB = path.basename(b).toLowerCase();
+    return schemaA.localeCompare(schemaB);
+  });
 }
 
 /**

--- a/tools/SchemaValidation/iModelSchemaValidationRunner.js
+++ b/tools/SchemaValidation/iModelSchemaValidationRunner.js
@@ -100,7 +100,7 @@ async function schemaUpgradeTest(ignoreList, output) {
     const schemaVersion = getVersionString(key.readVersion, key.writeVersion, key.minorVersion);
     const isWIP = wipSchemas.includes(schema);
 
-    if (excludeSchema(schemaName, schemaVersion, isWIP, ignoreList)) {
+    if (excludeSchema(schemaName, schemaVersion, ignoreList, isWIP)) {
       continue;
     }
 
@@ -252,7 +252,7 @@ function prepareOutputFile() {
  * @param excludeList List of schemas present in ignoreSchemaList.json
  * @returns Boolean based upon the decision
  */
-function excludeSchema(schemaName, schemaVersion, isWIP=undefined, excludeList) {
+function excludeSchema(schemaName, schemaVersion, excludeList, isWIP=undefined) {
   if (!excludeList)
     return false;
 

--- a/tools/SchemaValidation/iModelSchemaValidationRunner.js
+++ b/tools/SchemaValidation/iModelSchemaValidationRunner.js
@@ -483,7 +483,6 @@ async function importAndExportSchemaToIModel(schemaName, previousSchema, schemaR
   const schemaPaths = orderedSchemas.map((s) => s.schemaKey.fileName);
 
   if ((schemaName !== previousSchema) || (schemaName === previousSchema && schemaReadVersion !== previousReadVersion)) {
-    console.log(chalk.default.yellow("-> *** It is the new schema or major version ***"));
     if (imodel) {
       imodel.close();
       await IModelHost.shutdown();

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaA.01.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaA.01.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaA" alias="a" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema A.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaA.01.00.01.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaA.01.00.01.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaA" alias="a" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema A.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaA.01.00.02.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaA.01.00.02.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaA" alias="a" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema A.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaA.02.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaA.02.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaA" alias="a" version="02.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema A.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaA.02.00.01.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaA.02.00.01.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaA" alias="a" version="02.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema A.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaA.02.00.02.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaA.02.00.02.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaA" alias="a" version="02.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema A.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaB.01.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaB.01.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaB" alias="b" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema B.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaB.02.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaB.02.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaB" alias="b" version="02.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema B.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaB.02.01.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaB.02.01.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaB" alias="b" version="02.01.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema B.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/Released/SchemaB.03.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/Released/SchemaB.03.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaB" alias="b" version="03.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema B.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/1/SchemaB.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/1/SchemaB.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaB" alias="b" version="03.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema B.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/2/Released/SchemaC.01.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/2/Released/SchemaC.01.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaC" alias="c" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema C.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/2/Released/SchemaD.01.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/2/Released/SchemaD.01.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaD" alias="d" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema D.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/2/Released/SchemaD.01.01.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/2/Released/SchemaD.01.01.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaD" alias="d" version="01.01.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema D.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/2/Released/SchemaD.02.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/2/Released/SchemaD.02.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaD" alias="d" version="02.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema D.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/2/Released/SchemaE.01.00.00.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/2/Released/SchemaE.01.00.00.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaE" alias="e" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema D.">
+</ECSchema>

--- a/tools/SchemaValidation/test/assets/2/SchemaD.ecschema.xml
+++ b/tools/SchemaValidation/test/assets/2/SchemaD.ecschema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SchemaD" alias="d" version="02.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="SchemaA" description="This is a test Schema D.">
+</ECSchema>

--- a/tools/SchemaValidation/test/schemaUpgrade.test.js
+++ b/tools/SchemaValidation/test/schemaUpgrade.test.js
@@ -1,0 +1,129 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+const chai = require('chai');
+const fs = require("fs-extra");
+const path = require("path");
+const { schemaUpgradeTest } = require('../../SchemaValidation/iModelSchemaValidationRunner.js');
+chai.use(require('chai-as-promised'))
+
+describe('Schema Upgrade Tests', function() {
+  const outDir = path.normalize(__dirname + "/../../../testOut");
+  const assetsDir = path.join(__dirname, "assets");
+
+  before(() => {
+    if (!fs.existsSync(outDir)) {
+      fs.mkdirSync(outDir, {recursive: false});
+    }
+  });
+
+  it("More than one read compatible sets present in each schema family, Schema Upgrade testing is performed in respective batches.", async function () {
+    process.env.BisSchemaRepo = path.join(assetsDir, "1");
+    const results = await schemaUpgradeTest(undefined,outDir);
+
+    // SchemaA first batch
+    chai.expect(results["SchemaA"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaA"][0].batch).to.equal(1);
+    chai.expect(results["SchemaA"][0].version).to.equal("01.00.00");
+    chai.expect(results["SchemaA"][1].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][1].batch).to.equal(1);
+    chai.expect(results["SchemaA"][1].version).to.equal("01.00.01");
+    chai.expect(results["SchemaA"][2].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][2].batch).to.equal(1);
+    chai.expect(results["SchemaA"][2].version).to.equal("01.00.02");
+
+    // SchemaA second batch
+    chai.expect(results["SchemaA"][3].batchStarted).to.be.true;
+    chai.expect(results["SchemaA"][3].batch).to.equal(2);
+    chai.expect(results["SchemaA"][3].version).to.equal("02.00.00");
+    chai.expect(results["SchemaA"][4].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][4].batch).to.equal(2);
+    chai.expect(results["SchemaA"][4].version).to.equal("02.00.01");
+    chai.expect(results["SchemaA"][5].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][5].batch).to.equal(2);
+    chai.expect(results["SchemaA"][5].version).to.equal("02.00.02");
+
+    // SchemaB first batch
+    chai.expect(results["SchemaB"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaB"][0].batch).to.equal(1);
+    chai.expect(results["SchemaB"][0].version).to.equal("01.00.00");
+
+    // SchemaB second batch
+    chai.expect(results["SchemaB"][1].batchStarted).to.be.true;
+    chai.expect(results["SchemaB"][1].batch).to.equal(2);
+    chai.expect(results["SchemaB"][1].version).to.equal("02.00.00");
+    chai.expect(results["SchemaB"][2].batchStarted).to.be.false;
+    chai.expect(results["SchemaB"][2].batch).to.equal(2);
+    chai.expect(results["SchemaB"][2].version).to.equal("02.01.00");
+
+    // SchemaB third batch
+    chai.expect(results["SchemaB"][3].batchStarted).to.be.true;
+    chai.expect(results["SchemaB"][3].batch).to.equal(3);
+    chai.expect(results["SchemaB"][3].version).to.equal("03.00.00");
+  });
+
+  it("One or more read compatible sets present in each schema family, Schema Upgrade testing is performed in respective batches.", async function () {
+    process.env.BisSchemaRepo = path.join(assetsDir);
+    const results = await schemaUpgradeTest(undefined,outDir);
+
+    // SchemaA first batch
+    chai.expect(results["SchemaA"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaA"][0].batch).to.equal(1);
+    chai.expect(results["SchemaA"][0].version).to.equal("01.00.00");
+    chai.expect(results["SchemaA"][1].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][1].batch).to.equal(1);
+    chai.expect(results["SchemaA"][1].version).to.equal("01.00.01");
+    chai.expect(results["SchemaA"][2].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][2].batch).to.equal(1);
+    chai.expect(results["SchemaA"][2].version).to.equal("01.00.02");
+    // SchemaA second batch
+    chai.expect(results["SchemaA"][3].batchStarted).to.be.true;
+    chai.expect(results["SchemaA"][3].batch).to.equal(2);
+    chai.expect(results["SchemaA"][3].version).to.equal("02.00.00");
+    chai.expect(results["SchemaA"][4].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][4].batch).to.equal(2);
+    chai.expect(results["SchemaA"][4].version).to.equal("02.00.01");
+    chai.expect(results["SchemaA"][5].batchStarted).to.be.false;
+    chai.expect(results["SchemaA"][5].batch).to.equal(2);
+    chai.expect(results["SchemaA"][5].version).to.equal("02.00.02");
+
+    // SchemaB first batch
+    chai.expect(results["SchemaB"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaB"][0].batch).to.equal(1);
+    chai.expect(results["SchemaB"][0].version).to.equal("01.00.00");
+    // SchemaB second batch
+    chai.expect(results["SchemaB"][1].batchStarted).to.be.true;
+    chai.expect(results["SchemaB"][1].batch).to.equal(2);
+    chai.expect(results["SchemaB"][1].version).to.equal("02.00.00");
+    chai.expect(results["SchemaB"][2].batchStarted).to.be.false;
+    chai.expect(results["SchemaB"][2].batch).to.equal(2);
+    chai.expect(results["SchemaB"][2].version).to.equal("02.01.00");
+    // SchemaB third batch
+    chai.expect(results["SchemaB"][3].batchStarted).to.be.true;
+    chai.expect(results["SchemaB"][3].batch).to.equal(3);
+    chai.expect(results["SchemaB"][3].version).to.equal("03.00.00");
+
+    // SchemaC first batch
+    chai.expect(results["SchemaC"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaC"][0].batch).to.equal(1);
+    chai.expect(results["SchemaC"][0].version).to.equal("01.00.00");
+
+    // SchemaD first batch
+    chai.expect(results["SchemaD"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaD"][0].batch).to.equal(1);
+    chai.expect(results["SchemaD"][0].version).to.equal("01.00.00");
+    chai.expect(results["SchemaD"][1].batchStarted).to.be.false;
+    chai.expect(results["SchemaD"][1].batch).to.equal(1);
+    chai.expect(results["SchemaD"][1].version).to.equal("01.01.00");
+    // SchemaD second batch
+    chai.expect(results["SchemaD"][2].batchStarted).to.be.true;
+    chai.expect(results["SchemaD"][2].batch).to.equal(2);
+    chai.expect(results["SchemaD"][2].version).to.equal("02.00.00");
+
+    // SchemaE first batch
+    chai.expect(results["SchemaE"][0].batchStarted).to.be.true;
+    chai.expect(results["SchemaE"][0].batch).to.equal(1);
+    chai.expect(results["SchemaE"][0].version).to.equal("01.00.00");
+  });
+});

--- a/tools/SchemaValidation/test/schemaUpgrade.test.js
+++ b/tools/SchemaValidation/test/schemaUpgrade.test.js
@@ -61,6 +61,9 @@ describe('Schema Upgrade Tests', function() {
     chai.expect(results["SchemaB"][3].batchStarted).to.be.true;
     chai.expect(results["SchemaB"][3].batch).to.equal(3);
     chai.expect(results["SchemaB"][3].version).to.equal("03.00.00");
+    chai.expect(results["SchemaB"][4].batchStarted).to.be.false;
+    chai.expect(results["SchemaB"][4].batch).to.equal(3);
+    chai.expect(results["SchemaB"][4].version).to.equal("03.00.01");
   });
 
   it("One or more read compatible sets present in each schema family, Schema Upgrade testing is performed in respective batches.", async function () {
@@ -120,6 +123,9 @@ describe('Schema Upgrade Tests', function() {
     chai.expect(results["SchemaD"][2].batchStarted).to.be.true;
     chai.expect(results["SchemaD"][2].batch).to.equal(2);
     chai.expect(results["SchemaD"][2].version).to.equal("02.00.00");
+    chai.expect(results["SchemaD"][3].batchStarted).to.be.false;
+    chai.expect(results["SchemaD"][3].batch).to.equal(2);
+    chai.expect(results["SchemaD"][3].version).to.equal("02.00.01");
 
     // SchemaE first batch
     chai.expect(results["SchemaE"][0].batchStarted).to.be.true;

--- a/tools/testRunner.yaml
+++ b/tools/testRunner.yaml
@@ -58,3 +58,9 @@ steps:
   inputs:
     command: custom
     customCommand: run testSchemaDifference
+
+- task: Npm@1
+  displayName: 'Schema Upgrade Tests'
+  inputs:
+    command: custom
+    customCommand: run testSchemaUpgrade


### PR DESCRIPTION
The schema upgrade testing should be performed for the same read versions of a schema.