### PR TITLE
Added needed Design properties to the Outfall element

### DIFF
--- a/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
+++ b/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
@@ -825,6 +825,8 @@
     <ECEntityClass typeName="Outfall" modifier="Sealed" displayLabel="Outfall">
         <BaseClass>BaseStructure</BaseClass>
         <ECProperty propertyName="BoundaryConditionType" typeName="BoundaryConditionType" displayLabel="Boundary Condition Type" category="HydraulicData" description="Select method to establish bounding tailwater for the network."/>
+        <ECProperty propertyName="DesignStructure" typeName="boolean" displayLabel="Design Structure" category="DesignData" description="If true the subsurface structure will be designed to meet the active pipe matching constraints."/>
+        <ECProperty propertyName="OverrideGlobalPipeMatchingConstraints" typeName="boolean" displayLabel="Override Global Pipe Matching Constraints" category="DesignData" />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="OutfallOwnsNodeDesignConstraintsAspect" strength="embedding" modifier="Sealed">


### PR DESCRIPTION
Took the two design fields that GravityStructure has and also created them on the Outfall. This is needed because both GravityStructure and Outfall support the NodeDesignConstraintsAspect.