### PR TITLE
Changing multiplicity of TextAnnotationUsesTextStyleByDefault

### DIFF
--- a/Domains/0-Core/BisCore.ecschema.xml
+++ b/Domains/0-Core/BisCore.ecschema.xml
@@ -1608,8 +1608,7 @@
         <Source multiplicity="(0..*)" roleLabel="is styled by" polymorphic="true">
             <Class class="ITextAnnotation"/>
         </Source>
-        <Target multiplicity="(1..1)" roleLabel="styles" polymorphic="false">
-
+        <Target multiplicity="(0..1)" roleLabel="styles" polymorphic="false">
             <Class class="AnnotationTextStyle"/>
         </Target>
     </ECRelationshipClass>


### PR DESCRIPTION
Changing multiplicity of `TextAnnotationUsesTextStyleByDefault` in response to https://github.com/iTwin/itwinjs-core/pull/8469#issuecomment-3276402136