### PR TITLE
Adding description to few properties to avoid confusion

### DIFF
--- a/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
+++ b/Domains/4-Application/Connectors/CivilInfrastructureFramework/CifCommon.ecschema.xml
@@ -910,8 +910,8 @@
     </ECRelationshipClass>
     <ECEntityClass typeName="PlanNamedBoundaryAspect">
         <BaseClass>NamedBoundaryAspect</BaseClass>
-        <ECProperty propertyName="ParentElement" typeName="string" displayLabel="Parent Alignment" category="NamedBoundary_Category" priority="299990"/>
-        <ECProperty propertyName="GroupName" typeName="string" displayLabel="Group" category="NamedBoundary_Category" priority="299980"/>
+        <ECProperty propertyName="ParentElement" typeName="string" displayLabel="Parent Alignment" category="NamedBoundary_Category" priority="299990" description="Name of the alignment associated with the named boundary" />
+        <ECProperty propertyName="GroupName" typeName="string" displayLabel="Group" category="NamedBoundary_Category" priority="299980" description="Name of the named boundary group" />
         <ECProperty propertyName="StartLocation" typeName="point3d" displayLabel="Start Location" category="NamedBoundary_CivilProperties_Category" priority="299980"/>
         <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Station" category="NamedBoundary_CivilProperties_Category" priority="299970" kindOfQuantity="cifu:STATION"/>
         <ECProperty propertyName="StopLocation" typeName="point3d" displayLabel="Stop Location" category="NamedBoundary_CivilProperties_Category" priority="299960"/>
@@ -934,8 +934,8 @@
     </ECRelationshipClass>
     <ECEntityClass typeName="ProfileNamedBoundaryAspect">
         <BaseClass>NamedBoundaryAspect</BaseClass>
-        <ECProperty propertyName="ParentElement" typeName="string" displayLabel="Parent Alignment" category="NamedBoundary_Category" priority="299990"/>
-        <ECProperty propertyName="GroupName" typeName="string" displayLabel="Group" category="NamedBoundary_Category" priority="299980"/>
+        <ECProperty propertyName="ParentElement" typeName="string" displayLabel="Parent Alignment" category="NamedBoundary_Category" priority="299990" description="Name of the alignment associated with the named boundary" />
+        <ECProperty propertyName="GroupName" typeName="string" displayLabel="Group" category="NamedBoundary_Category" priority="299980" description="Name of the named boundary group" />
         <ECProperty propertyName="StartDistance" typeName="double" displayLabel="Start Station" category="NamedBoundary_CivilProperties_Category" priority="299990" kindOfQuantity="cifu:STATION"/>
         <ECProperty propertyName="StopDistance" typeName="double" displayLabel="Stop Station" category="NamedBoundary_CivilProperties_Category" priority="299980" kindOfQuantity="cifu:STATION"/>
         <ECProperty propertyName="Length" typeName="double" displayLabel="Length" category="NamedBoundary_CivilProperties_Category" priority="299970" kindOfQuantity="cifu:LENGTH"/>
@@ -962,8 +962,8 @@
     </ECRelationshipClass>
     <ECEntityClass typeName="XSectionNamedBoundaryAspect">
         <BaseClass>NamedBoundaryAspect</BaseClass>
-        <ECProperty propertyName="ParentElement" typeName="string" displayLabel="Parent Alignment" category="NamedBoundary_Category" priority="299990"/>
-        <ECProperty propertyName="GroupName" typeName="string" displayLabel="Group" category="NamedBoundary_Category" priority="299980"/>
+        <ECProperty propertyName="ParentElement" typeName="string" displayLabel="Parent Alignment" category="NamedBoundary_Category" priority="299990" description="Name of the alignment associated with the named boundary" />
+        <ECProperty propertyName="GroupName" typeName="string" displayLabel="Group" category="NamedBoundary_Category" priority="299980" description="Name of the named boundary group" />
         <ECProperty propertyName="Station" typeName="double" displayLabel="Station" category="NamedBoundary_CivilProperties_Category" priority="299990" kindOfQuantity="cifu:STATION"/>
         <ECProperty propertyName="LeftOffset" typeName="double" displayLabel="Left Offset" category="NamedBoundary_CivilProperties_Category" priority="299980" kindOfQuantity="cifu:LENGTH"/>
         <ECProperty propertyName="RightOffset" typeName="double" displayLabel="Right Offset" category="NamedBoundary_CivilProperties_Category" priority="299970" kindOfQuantity="cifu:LENGTH"/>


### PR DESCRIPTION
Adding description to following properties to avoid confusion
1. Name of the parent alignment associated with named boundary and 
2. Name of the named boundary group