### PR TITLE
Added SheetNumbering ECView to the SheetNumdering Schema

### DIFF
--- a/Domains/4-Application/DrawingProduction/SheetNumbering.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumbering.ecschema.xml
@@ -3,10 +3,10 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="SheetNumbering" alias="snum" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="Contains classes and relationships for sheet numbering.">
+<ECSchema schemaName="SheetNumbering" alias="snum" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="Contains classes and relationships for sheet numbering.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
-    <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>   
+    <ECSchemaReference name="BisCore" version="01.00.23" alias="bis"/>   
     <ECSchemaReference name="ECDbMap" version="02.00.04" alias="ecdbmap"/>
 
     <ECCustomAttributes>
@@ -54,4 +54,94 @@
             <Class class="SheetNumberAspect"/>
         </Target>
     </ECRelationshipClass>
+        <ECEntityClass typeName="SheetNumberingInfo" modifier="Abstract" displayLabel="Page and Group numbers" description="Calculates the Page and Group numbers for the SheetReferences in a SheetIndex">
+        <ECCustomAttributes>
+            <QueryView xmlns="ECDbMap.02.00.04">
+                <Query>
+                  SELECT 
+                        ECInstanceId,
+                        ECClassId,
+                        SheetNumber,
+                        PageNumber,
+                        PageCount,
+                        GroupNumber,
+                        GroupCount
+                    FROM (
+                  WITH
+                    -- General Notes:
+                    -- There are a number of times that column names are alised arbitrarily.
+                    --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
+
+                    -- Recursively traverses the tree from root to leaves, building hierarchical paths.
+                    -- Creates a global ordering based on depth-frist traversal with respect to EntryPriority.
+                    -- The SortPath ensures proper tree traversal order for sequential number assignment.
+                    -- AssemblyPath is included only for debubbing purposes 
+                    treeTraversal ([ECInstanceId], [ECClassId], [SheetNumber], [Priority], [DirectParentId], [AssemblyPath], [SortPath]) AS (
+                      -- Start with root nodes-SheetIndexes
+                      SELECT
+                        si.ECInstanceId,
+                        si.ECClassId,
+                        COALESCE([si].[CodeValue], [si].[UserLabel]) AS [SheetNumber],
+                        0 AS [Priority],
+                        NULL AS [DirectParentId],
+                        COALESCE([si].[CodeValue], [si].[UserLabel]) AS [AssemblyPath],
+                        -- Use string padding for consistent sorting - pad to 10 digits with leading zeros
+                        SUBSTR('0000000000' || CAST(0 AS TEXT), -10) AS [SortPath]
+                      FROM bis:SheetIndex si
+
+                      UNION ALL
+                      -- Recursively add children to parents, building hierarchical sort paths
+                      SELECT
+                        child.ECInstanceId,
+                        child.ECClassId,
+                        child.SheetNumber,
+                        child.NodePriority AS [Priority],
+                        child.NodeParentId AS [DirectParentId],
+                        parent.AssemblyPath || '->' || child.SheetNumber AS [AssemblyPath],
+                        parent.SortPath || '.' || SUBSTR('0000000000' || CAST(COALESCE(child.NodePriority, 0) AS TEXT), -10) AS [SortPath]
+                      FROM treeTraversal parent
+                      JOIN (
+                      -- A table of all possible children joined to their parents
+                          SELECT
+                              [sr].[ECInstanceId],
+                              ECClassId,
+                              COALESCE([sr].[CodeValue], [sr].[UserLabel]) AS [SheetNumber],
+                              [sr].[EntryPriority] AS [NodePriority],
+                              [sr].[Parent].[Id] AS [NodeParentId]
+                          FROM
+                              [bis].[SheetReference] [sr]
+
+                          UNION ALL
+
+                          SELECT
+                              [sif].[ECInstanceId],
+                              ECClassId,
+                              COALESCE([sif].[CodeValue], [sif].[UserLabel]) AS [SheetNumber],
+                              [sif].[EntryPriority] AS [NodePriority],
+                              [sif].[Parent].[Id] AS [NodeParentId]
+                          FROM
+                              [bis].[SheetIndexFolder] [sif]
+                      ) child ON child.NodeParentId = parent.ECInstanceId
+                    )
+                    -- Final result: Returns only SheetReference node due to inner join
+                    SELECT
+                        t.ECInstanceId AS ECInstanceId,
+                        ec_classid('SheetNumbering', 'SheetNumberingInfo') [ECClassId],
+                        t.SheetNumber AS SheetNumber,
+                        CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber,
+                        CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount,
+                        CAST(ROW_NUMBER() OVER (PARTITION BY [sr].[Parent].[Id] ORDER BY EntryPriority) AS INTEGER) AS [GroupNumber],
+                        CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
+                    FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
+                    ORDER BY t.SortPath
+                  )
+                </Query>
+            </QueryView>
+        </ECCustomAttributes>
+        <ECProperty propertyName="SheetNumber" typeName="string" description="The formatted sheet identifier of the sheet"/>
+        <ECProperty propertyName="GroupNumber" typeName="int" description="The sequential number of this sheet within its parent group, ordered by entry priority"/>
+        <ECProperty propertyName="GroupCount" typeName="int" description="The total number of sheets within the same parent group as this sheet"/>
+        <ECProperty propertyName="PageNumber" typeName="int" description="The global sequential page number of this sheet across the entire sheet index tree"/>
+        <ECProperty propertyName="PageCount" typeName="int" description="The total number of sheet references across the entire sheet index tree"/>
+    </ECEntityClass>
 </ECSchema>

--- a/Domains/4-Application/DrawingProduction/SheetNumbering.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumbering.ecschema.xml
@@ -3,10 +3,10 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="SheetNumbering" alias="snum" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="Contains classes and relationships for sheet numbering.">
+<ECSchema schemaName="SheetNumbering" alias="snum" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="Contains classes and relationships for sheet numbering.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
-    <ECSchemaReference name="BisCore" version="01.00.23" alias="bis"/>   
+    <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>   
     <ECSchemaReference name="ECDbMap" version="02.00.04" alias="ecdbmap"/>
 
     <ECCustomAttributes>
@@ -54,94 +54,4 @@
             <Class class="SheetNumberAspect"/>
         </Target>
     </ECRelationshipClass>
-        <ECEntityClass typeName="SheetNumberingInfo" modifier="Abstract" displayLabel="Page and Group numbers" description="Calculates the Page and Group numbers for the SheetReferences in a SheetIndex">
-        <ECCustomAttributes>
-            <QueryView xmlns="ECDbMap.02.00.04">
-                <Query>
-                  SELECT 
-                        ECInstanceId,
-                        ECClassId,
-                        SheetNumber,
-                        PageNumber,
-                        PageCount,
-                        GroupNumber,
-                        GroupCount
-                    FROM (
-                  WITH
-                    -- General Notes:
-                    -- There are a number of times that column names are alised arbitrarily.
-                    --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
-
-                    -- Recursively traverses the tree from root to leaves, building hierarchical paths.
-                    -- Creates a global ordering based on depth-frist traversal with respect to EntryPriority.
-                    -- The SortPath ensures proper tree traversal order for sequential number assignment.
-                    -- AssemblyPath is included only for debubbing purposes 
-                    treeTraversal ([ECInstanceId], [ECClassId], [SheetNumber], [Priority], [DirectParentId], [AssemblyPath], [SortPath]) AS (
-                      -- Start with root nodes-SheetIndexes
-                      SELECT
-                        si.ECInstanceId,
-                        si.ECClassId,
-                        COALESCE([si].[CodeValue], [si].[UserLabel]) AS [SheetNumber],
-                        0 AS [Priority],
-                        NULL AS [DirectParentId],
-                        COALESCE([si].[CodeValue], [si].[UserLabel]) AS [AssemblyPath],
-                        -- Use string padding for consistent sorting - pad to 10 digits with leading zeros
-                        SUBSTR('0000000000' || CAST(0 AS TEXT), -10) AS [SortPath]
-                      FROM bis:SheetIndex si
-
-                      UNION ALL
-                      -- Recursively add children to parents, building hierarchical sort paths
-                      SELECT
-                        child.ECInstanceId,
-                        child.ECClassId,
-                        child.SheetNumber,
-                        child.NodePriority AS [Priority],
-                        child.NodeParentId AS [DirectParentId],
-                        parent.AssemblyPath || '->' || child.SheetNumber AS [AssemblyPath],
-                        parent.SortPath || '.' || SUBSTR('0000000000' || CAST(COALESCE(child.NodePriority, 0) AS TEXT), -10) AS [SortPath]
-                      FROM treeTraversal parent
-                      JOIN (
-                      -- A table of all possible children joined to their parents
-                          SELECT
-                              [sr].[ECInstanceId],
-                              ECClassId,
-                              COALESCE([sr].[CodeValue], [sr].[UserLabel]) AS [SheetNumber],
-                              [sr].[EntryPriority] AS [NodePriority],
-                              [sr].[Parent].[Id] AS [NodeParentId]
-                          FROM
-                              [bis].[SheetReference] [sr]
-
-                          UNION ALL
-
-                          SELECT
-                              [sif].[ECInstanceId],
-                              ECClassId,
-                              COALESCE([sif].[CodeValue], [sif].[UserLabel]) AS [SheetNumber],
-                              [sif].[EntryPriority] AS [NodePriority],
-                              [sif].[Parent].[Id] AS [NodeParentId]
-                          FROM
-                              [bis].[SheetIndexFolder] [sif]
-                      ) child ON child.NodeParentId = parent.ECInstanceId
-                    )
-                    -- Final result: Returns only SheetReference node due to inner join
-                    SELECT
-                        t.ECInstanceId AS ECInstanceId,
-                        ec_classid('SheetNumbering', 'SheetNumberingInfo') [ECClassId],
-                        t.SheetNumber AS SheetNumber,
-                        CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber,
-                        CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount,
-                        CAST(ROW_NUMBER() OVER (PARTITION BY [sr].[Parent].[Id] ORDER BY EntryPriority) AS INTEGER) AS [GroupNumber],
-                        CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
-                    FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
-                    ORDER BY t.SortPath
-                  )
-                </Query>
-            </QueryView>
-        </ECCustomAttributes>
-        <ECProperty propertyName="SheetNumber" typeName="string" description="The formatted sheet identifier of the sheet"/>
-        <ECProperty propertyName="GroupNumber" typeName="int" description="The sequential number of this sheet within its parent group, ordered by entry priority"/>
-        <ECProperty propertyName="GroupCount" typeName="int" description="The total number of sheets within the same parent group as this sheet"/>
-        <ECProperty propertyName="PageNumber" typeName="int" description="The global sequential page number of this sheet across the entire sheet index tree"/>
-        <ECProperty propertyName="PageCount" typeName="int" description="The total number of sheet references across the entire sheet index tree"/>
-    </ECEntityClass>
 </ECSchema>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -18,165 +18,167 @@
         </SchemaLayerInfo>
     </ECCustomAttributes>
 
-    <ECEntityClass typeName="SheetIndexFolderView" modifier="Abstract" displayLabel="Group numbers" description="Group numbers for a sheet it's in a SheetIndex">
+    <ECEntityClass typeName="SheetIndexFolderView" modifier="Abstract" displayLabel="SheetIndex Folder View" description="View that returns the number of children in folder (This can include the number of children under the SheetIndex)">
         <ECCustomAttributes>
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>
-                  SELECT
-                    [sr].ECInstanceId AS ECInstanceId,
-                    ec_classid('SheetNumbering', 'SheetIndexFolderView') [ECClassId],
-                    -- An assigned a Row Number for rows that share a parent and are ordered by their EntryPriority 
-                    --   and cast to an integer because it's a long otherwise for some reason
-                    CAST(ROW_NUMBER() OVER (PARTITION BY [sr].[Parent].[Id] ORDER BY EntryPriority) AS INTEGER) AS [GroupNumber],
-                    -- The number of SheetReferences that share a parent, again, cast to an integer
-                    CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
-                  FROM bis.SheetReference [sr]
+                    SELECT
+                        [sr].Parent.id AS ECInstanceId,
+                        ec_classid('SheetNumbering', 'SheetIndexFolderView') [ECClassId],
+                        -- The number of SheetReferences that share a parent, again, cast to an integer
+                        CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
+                    FROM bis.SheetReference [sr]
                 </Query>
             </QueryView>
         </ECCustomAttributes>
-        <ECProperty propertyName="GroupNumber" typeName="int" description="The sequential number of this sheet within its parent group, ordered by entry priority"/>
         <ECProperty propertyName="GroupCount" typeName="int" description="The total number of sheets within the same parent group as this sheet"/>
     </ECEntityClass>
-    <ECEntityClass typeName="SheetIndexView" modifier="Abstract" displayLabel="Group numbers" description="Group numbers for a sheet it's in a SheetIndex">
+    <ECEntityClass typeName="SheetIndex View" modifier="Abstract" displayLabel="SheetIndex View" description="View that returns the total number of sheets in a sheet index">
         <ECCustomAttributes>
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>
-                  SELECT 
-                    ECInstanceId,
-                    ECClassId,
-                    PageCount
-                  FROM (
+                    SELECT 
+                        ECInstanceId,
+                        ECClassId,
+                        PageCount
+                    FROM (
+                        WITH
+                        -- General Notes:
+                        -- There are a number of times that column names are aliased arbitrarily.
+                        --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
+
+                        -- Recursively traverses the tree from root to leaves, building hierarchical paths.
+                        treeTraversal ([ECInstanceId], [ECClassId], [DirectParentId]) AS (
+                        -- Start with root nodes-SheetIndexes
+                        SELECT
+                            si.ECInstanceId,
+                            si.ECClassId,
+                            NULL AS [DirectParentId]
+                        FROM bis:SheetIndex si
+
+                        UNION ALL
+                            -- Recursively add children to parents, building hierarchical sort paths
+                            SELECT
+                            child.ECInstanceId,
+                            child.ECClassId,
+                            child.NodeParentId AS [DirectParentId]
+                            FROM treeTraversal parent
+                        JOIN (
+                        -- A table of all possible children joined to their parents
+                                SELECT
+                                    [sr].[ECInstanceId],
+                                    ECClassId,
+                                    [sr].[Parent].[Id] AS [NodeParentId]
+                                FROM
+                                    [bis].[SheetReference] [sr]
+
+                                UNION ALL
+
+                                SELECT
+                                    [sif].[ECInstanceId],
+                                    ECClassId,
+                                    [sif].[Parent].[Id] AS [NodeParentId]
+                                FROM
+                                    [bis].[SheetIndexFolder] [sif]
+                            ) child ON child.NodeParentId = parent.ECInstanceId
+                        )
+                        -- Final result: Returns only SheetReference node due to inner join
+                        SELECT
+                            sr.ECInstanceId AS [ECInstanceId],
+                            ec_classid('SheetNumbering', 'SheetIndexView') [ECClassId],
+                            CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount
+                        FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
+                    )
+                </Query>
+            </QueryView>
+        </ECCustomAttributes>
+        <ECProperty propertyName="PageCount" typeName="int" description="The total number of sheet references across the entire sheet index tree"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="SheetReferenceView" modifier="Abstract" displayLabel="SheetReference View" description="Views the calculated properties of a SheetReference">
+        <ECCustomAttributes>
+            <QueryView xmlns="ECDbMap.02.00.04">
+                <Query>
+                    SELECT 
+                        ECInstanceId,
+                        ECClassId,
+                        SheetNumber,
+                        GroupNumber,
+                        PageNumber
+                    FROM (
                     WITH
                     -- General Notes:
                     -- There are a number of times that column names are aliased arbitrarily.
                     --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
 
                     -- Recursively traverses the tree from root to leaves, building hierarchical paths.
-                    treeTraversal ([ECInstanceId], [ECClassId], [DirectParentId]) AS (
-                      -- Start with root nodes-SheetIndexes
-                      SELECT
-                      si.ECInstanceId,
-                      si.ECClassId,
-                      NULL AS [DirectParentId]
-                      FROM bis:SheetIndex si
-
-                      UNION ALL
-                      -- Recursively add children to parents, building hierarchical sort paths
-                      SELECT
-                      child.ECInstanceId,
-                      child.ECClassId,
-                      child.NodeParentId AS [DirectParentId]
-                      FROM treeTraversal parent
-                      JOIN (
-                      -- A table of all possible children joined to their parents
+                    -- Creates a global ordering based on depth-frist traversal with respect to EntryPriority.
+                    -- The SortPath ensures proper tree traversal order for sequential number assignment.
+                    -- AssemblyPath is included only for debugging purposes 
+                    treeTraversal ([ECInstanceId], [ECClassId], [SheetNumber], [Priority], [DirectParentId], [AssemblyPath], [SortPath]) AS (
+                        -- Start with root nodes-SheetIndexes
                         SELECT
-                          [sr].[ECInstanceId],
-                          ECClassId,
-                          [sr].[Parent].[Id] AS [NodeParentId]
-                        FROM
-                          [bis].[SheetReference] [sr]
+                        si.ECInstanceId,
+                        si.ECClassId,
+                        COALESCE([si].[CodeValue], [si].[UserLabel]) AS [SheetNumber],
+                        0 AS [Priority],
+                        NULL AS [DirectParentId],
+                        COALESCE([si].[CodeValue], [si].[UserLabel]) AS [AssemblyPath],
+                        -- Use string padding for consistent sorting - pad to 10 digits with leading zeros
+                        SUBSTR('0000000000' || CAST(0 AS TEXT), -10) AS [SortPath]
+                        FROM bis:SheetIndex si
 
                         UNION ALL
-
+                        -- Recursively add children to parents, building hierarchical sort paths
                         SELECT
-                          [sif].[ECInstanceId],
-                          ECClassId,
-                          [sif].[Parent].[Id] AS [NodeParentId]
-                        FROM
-                          [bis].[SheetIndexFolder] [sif]
-                      ) child ON child.NodeParentId = parent.ECInstanceId
+                        child.ECInstanceId,
+                        child.ECClassId,
+                        child.SheetNumber,
+                        child.NodePriority AS [Priority],
+                        child.NodeParentId AS [DirectParentId],
+                        parent.AssemblyPath || '->' || child.SheetNumber AS [AssemblyPath],
+                        parent.SortPath || '.' || SUBSTR('0000000000' || CAST(COALESCE(child.NodePriority, 0) AS TEXT), -10) AS [SortPath]
+                        FROM treeTraversal parent
+                        JOIN (
+                        -- A table of all possible children joined to their parents
+                            SELECT
+                                [sr].[ECInstanceId],
+                                ECClassId,
+                                COALESCE([sr].[CodeValue], [sr].[UserLabel]) AS [SheetNumber],
+                                [sr].[EntryPriority] AS [NodePriority],
+                                [sr].[Parent].[Id] AS [NodeParentId]
+                            FROM
+                                [bis].[SheetReference] [sr]
+
+                            UNION ALL
+
+                            SELECT
+                                [sif].[ECInstanceId],
+                                ECClassId,
+                                COALESCE([sif].[CodeValue], [sif].[UserLabel]) AS [SheetNumber],
+                                [sif].[EntryPriority] AS [NodePriority],
+                                [sif].[Parent].[Id] AS [NodeParentId]
+                            FROM
+                                [bis].[SheetIndexFolder] [sif]
+                        ) child ON child.NodeParentId = parent.ECInstanceId
                     )
                     -- Final result: Returns only SheetReference node due to inner join
                     SELECT
-                      sr.ECInstanceId AS [ECInstanceId],
-                      ec_classid('SheetNumbering', 'SheetIndexView') [ECClassId],
-                      CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount
+                        sr.ECInstanceId AS [ECInstanceId],
+                        ec_classid('SheetNumbering', 'SheetReferenceView') [ECClassId],
+                        t.SheetNumber AS SheetNumber,
+                        -- Partitioning by class to filter by SheetReferences
+                        CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber,
+                        -- An assigned a Row Number for rows that share a parent and are ordered by their EntryPriority 
+                        --   and cast to an integer because it's a long otherwise for some reason
+                        CAST(ROW_NUMBER() OVER (PARTITION BY [sr].[Parent].[Id] ORDER BY EntryPriority) AS INTEGER) AS [GroupNumber]
                     FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
-                  )
-                </Query>
-            </QueryView>
-        </ECCustomAttributes>
-        <ECProperty propertyName="PageCount" typeName="int" description="The total number of sheet references across the entire sheet index tree"/>
-    </ECEntityClass>
-    <ECEntityClass typeName="SheetReferenceView" modifier="Abstract" displayLabel="Page and Group numbers" description="Calculates the Page and Group numbers for the SheetReferences in a SheetIndex">
-        <ECCustomAttributes>
-            <QueryView xmlns="ECDbMap.02.00.04">
-                <Query>
-                  SELECT 
-                      ECInstanceId,
-                      ECClassId,
-                      SheetNumber,
-                      PageNumber
-                  FROM (
-                  WITH
-                  -- General Notes:
-                  -- There are a number of times that column names are aliased arbitrarily.
-                  --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
-
-                  -- Recursively traverses the tree from root to leaves, building hierarchical paths.
-                  -- Creates a global ordering based on depth-frist traversal with respect to EntryPriority.
-                  -- The SortPath ensures proper tree traversal order for sequential number assignment.
-                  -- AssemblyPath is included only for debugging purposes 
-                  treeTraversal ([ECInstanceId], [ECClassId], [SheetNumber], [Priority], [DirectParentId], [AssemblyPath], [SortPath]) AS (
-                      -- Start with root nodes-SheetIndexes
-                      SELECT
-                      si.ECInstanceId,
-                      si.ECClassId,
-                      COALESCE([si].[CodeValue], [si].[UserLabel]) AS [SheetNumber],
-                      0 AS [Priority],
-                      NULL AS [DirectParentId],
-                      COALESCE([si].[CodeValue], [si].[UserLabel]) AS [AssemblyPath],
-                      -- Use string padding for consistent sorting - pad to 10 digits with leading zeros
-                      SUBSTR('0000000000' || CAST(0 AS TEXT), -10) AS [SortPath]
-                      FROM bis:SheetIndex si
-
-                      UNION ALL
-                      -- Recursively add children to parents, building hierarchical sort paths
-                      SELECT
-                      child.ECInstanceId,
-                      child.ECClassId,
-                      child.SheetNumber,
-                      child.NodePriority AS [Priority],
-                      child.NodeParentId AS [DirectParentId],
-                      parent.AssemblyPath || '->' || child.SheetNumber AS [AssemblyPath],
-                      parent.SortPath || '.' || SUBSTR('0000000000' || CAST(COALESCE(child.NodePriority, 0) AS TEXT), -10) AS [SortPath]
-                      FROM treeTraversal parent
-                      JOIN (
-                      -- A table of all possible children joined to their parents
-                          SELECT
-                              [sr].[ECInstanceId],
-                              ECClassId,
-                              COALESCE([sr].[CodeValue], [sr].[UserLabel]) AS [SheetNumber],
-                              [sr].[EntryPriority] AS [NodePriority],
-                              [sr].[Parent].[Id] AS [NodeParentId]
-                          FROM
-                              [bis].[SheetReference] [sr]
-
-                          UNION ALL
-
-                          SELECT
-                              [sif].[ECInstanceId],
-                              ECClassId,
-                              COALESCE([sif].[CodeValue], [sif].[UserLabel]) AS [SheetNumber],
-                              [sif].[EntryPriority] AS [NodePriority],
-                              [sif].[Parent].[Id] AS [NodeParentId]
-                          FROM
-                              [bis].[SheetIndexFolder] [sif]
-                      ) child ON child.NodeParentId = parent.ECInstanceId
-                  )
-                  -- Final result: Returns only SheetReference node due to inner join
-                  SELECT
-                      sr.ECInstanceId AS [ECInstanceId],
-                      ec_classid('SheetNumbering', 'SheetReferenceView') [ECClassId],
-                      t.SheetNumber AS SheetNumber,
-                      CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber
-                  FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
-                  ORDER BY t.SortPath
-                  )
+                    ORDER BY t.SortPath
+                    )
                 </Query>
             </QueryView>
         </ECCustomAttributes>
         <ECProperty propertyName="SheetNumber" typeName="string" description="The formatted sheet identifier of the sheet"/>
+        <ECProperty propertyName="GroupNumber" typeName="int" description="The sequential number of this sheet within its parent group, ordered by entry priority"/>
         <ECProperty propertyName="PageNumber" typeName="int" description="The global sequential page number of this sheet across the entire sheet index tree"/>
     </ECEntityClass>
 </ECSchema>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -24,12 +24,11 @@
                 <Query>
                     SELECT
                         [sr].Parent.id AS ECInstanceId,
-                        COALESCE([sf].ECClassId, [si].ECClassId) AS [ECClassId],
+                        [e].ECClassId AS [ECClassId],
                         -- The number of SheetReferences that share a parent, again, cast to an integer
                         CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
                     FROM bis.SheetReference [sr] 
-                    LEFT JOIN bis.SheetIndex [si] ON si.ECInstanceId = [sr].Parent.id
-                    LEFT JOIN bis.SheetIndexFolder [sf] ON sf.ECInstanceId = [sr].Parent.id
+                    INNER JOIN bis.Element e ON sr.Parent.id = e.ECInstanceId
                 </Query>
             </QueryView>
         </ECCustomAttributes>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -18,22 +18,24 @@
         </SchemaLayerInfo>
     </ECCustomAttributes>
 
-    <ECEntityClass typeName="SheetIndexFolderView" modifier="Abstract" displayLabel="SheetIndex Folder View" description="View that returns the number of children in folder (This can include the number of children under the SheetIndex)">
+    <ECEntityClass typeName="SheetIndexContainerView" modifier="Abstract" displayLabel="SheetIndex Container View" description="View that returns the number of children under a parent. This can be either a SheetIndex or SheetIndexFolder.">
         <ECCustomAttributes>
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>
                     SELECT
                         [sr].Parent.id AS ECInstanceId,
-                        ec_classid('SheetNumbering', 'SheetIndexFolderView') [ECClassId],
+                        COALESCE([sf].ECClassId, [si].ECClassId) AS [ECClassId],
                         -- The number of SheetReferences that share a parent, again, cast to an integer
                         CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
-                    FROM bis.SheetReference [sr]
+                    FROM bis.SheetReference [sr] 
+                    LEFT JOIN bis.SheetIndex [si] ON si.ECInstanceId = [sr].Parent.id
+                    LEFT JOIN bis.SheetIndexFolder [sf] ON sf.ECInstanceId = [sr].Parent.id
                 </Query>
             </QueryView>
         </ECCustomAttributes>
         <ECProperty propertyName="GroupCount" typeName="int" description="The total number of sheets within the same parent group as this sheet"/>
     </ECEntityClass>
-    <ECEntityClass typeName="SheetIndexView" modifier="Abstract" displayLabel="SheetIndex View" description="View that returns the total number of sheets in a sheet index">
+    <ECEntityClass typeName="SheetIndexView" modifier="Abstract" displayLabel="SheetIndex View" description="View that returns the total number of sheets in a SheetIndex">
         <ECCustomAttributes>
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>
@@ -48,12 +50,13 @@
                         --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
 
                         -- Recursively traverses the tree from root to leaves, building hierarchical paths.
-                        treeTraversal ([ECInstanceId], [ECClassId], [DirectParentId]) AS (
+                        treeTraversal ([ECInstanceId], [ECClassId], [DirectParentId], [RootId]) AS (
                         -- Start with root nodes-SheetIndexes
                         SELECT
                             si.ECInstanceId,
                             si.ECClassId,
-                            NULL AS [DirectParentId]
+                            NULL AS [DirectParentId],
+                            si.ECInstanceId AS [RootId]
                         FROM bis:SheetIndex si
 
                         UNION ALL
@@ -61,7 +64,8 @@
                             SELECT
                             child.ECInstanceId,
                             child.ECClassId,
-                            child.NodeParentId AS [DirectParentId]
+                            child.NodeParentId AS [DirectParentId],
+                            parent.RootId AS [RootId]
                             FROM treeTraversal parent
                         JOIN (
                         -- A table of all possible children joined to their parents
@@ -82,12 +86,12 @@
                                     [bis].[SheetIndexFolder] [sif]
                             ) child ON child.NodeParentId = parent.ECInstanceId
                         )
-                        -- Final result: Returns only SheetReference node due to inner join
+                        -- Final result: Counts the sheet under eact group of SheetIndex
                         SELECT
-                            sr.ECInstanceId AS [ECInstanceId],
-                            ec_classid('SheetNumbering', 'SheetIndexView') [ECClassId],
-                            CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount
-                        FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
+                            RootId AS ECInstanceId,
+                            ec_classid('bis', 'SheetIndex') AS ECClassId,
+                            COUNT(ECInstanceId) AS PageCount
+                        FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference') GROUP BY RootId
                     )
                 </Query>
             </QueryView>
@@ -163,16 +167,17 @@
                     )
                     -- Final result: Returns only SheetReference node due to inner join
                     SELECT
-                        sr.ECInstanceId AS [ECInstanceId],
-                        ec_classid('SheetNumbering', 'SheetReferenceView') [ECClassId],
-                        t.SheetNumber AS SheetNumber,
+                        ECInstanceId,
+                        ECClassId,
+                        SheetNumber,
                         -- Partitioning by class to filter to SheetReferences
-                        CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber,
+                        CAST(ROW_NUMBER() OVER (PARTITION BY ECClassId ORDER BY SortPath) AS INTEGER) AS [PageNumber],
                         -- An assigned a Row Number for rows that share a parent and are ordered by their EntryPriority 
                         --   and cast to an integer because it's a long otherwise for some reason
-                        CAST(ROW_NUMBER() OVER (PARTITION BY [sr].[Parent].[Id] ORDER BY EntryPriority) AS INTEGER) AS [GroupNumber]
-                    FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
-                    ORDER BY t.SortPath
+                        CAST(ROW_NUMBER() OVER (PARTITION BY DirectParentId ORDER BY Priority) AS INTEGER) AS [GroupNumber]
+                    FROM treeTraversal
+                    WHERE ECClassId = ec_classid('bis', 'SheetReference')
+                    ORDER BY SortPath
                     )
                 </Query>
             </QueryView>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -89,7 +89,7 @@
                         SELECT
                             RootId AS ECInstanceId,
                             ec_classid('bis', 'SheetIndex') AS ECClassId,
-                            COUNT(ECInstanceId) AS PageCount
+                            CAST(COUNT(ECInstanceId) AS INTEGER) AS PageCount
                         FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference') GROUP BY RootId
                     )
                 </Query>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -166,7 +166,7 @@
                         sr.ECInstanceId AS [ECInstanceId],
                         ec_classid('SheetNumbering', 'SheetReferenceView') [ECClassId],
                         t.SheetNumber AS SheetNumber,
-                        -- Partitioning by class to filter by SheetReferences
+                        -- Partitioning by class to filter to SheetReferences
                         CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber,
                         -- An assigned a Row Number for rows that share a parent and are ordered by their EntryPriority 
                         --   and cast to an integer because it's a long otherwise for some reason

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="SheetNumberingViews" alias="snumViews" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="Contains classes and relationships for sheet numbering.">
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>   
+    <ECSchemaReference name="ECDbMap" version="02.00.04" alias="ecdbmap"/>
+
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>NotForProduction</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+
+       <ECEntityClass typeName="SheetIndexFolderView" modifier="Abstract" displayLabel="Group numbers" description="Group numbers for a sheet it's in a SheetIndex">
+        <ECCustomAttributes>
+            <QueryView xmlns="ECDbMap.02.00.04">
+                <Query>
+                  SELECT
+                    [sr].Sheet.id AS ECInstanceId,
+                    ec_classid('SheetNumbering', 'SheetIndexFolderView') [ECClassId],
+                    -- An assigned a Row Number for rows that share a parent and are ordered by their EntryPriority 
+                    --   and cast to an integer because it's a long otherwise for some reason
+                    CAST(ROW_NUMBER() OVER (PARTITION BY [sr].[Parent].[Id] ORDER BY EntryPriority) AS INTEGER) AS [GroupNumber],
+                    -- The number of SheetReferences that share a parent, again, cast to an integer
+                    CAST(COUNT([sr].[ECInstanceId]) OVER (PARTITION BY [sr].[Parent].[Id]) AS INTEGER) AS [GroupCount]
+                  FROM bis.SheetReference [sr]
+                </Query>
+            </QueryView>
+        </ECCustomAttributes>
+        <ECProperty propertyName="GroupNumber" typeName="int" description="The sequential number of this sheet within its parent group, ordered by entry priority"/>
+        <ECProperty propertyName="GroupCount" typeName="int" description="The total number of sheets within the same parent group as this sheet"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="SheetIndexView" modifier="Abstract" displayLabel="Group numbers" description="Group numbers for a sheet it's in a SheetIndex">
+        <ECCustomAttributes>
+            <QueryView xmlns="ECDbMap.02.00.04">
+                <Query>
+                  SELECT 
+                    ECInstanceId,
+                    ECClassId,
+                    PageCount
+                  FROM (
+                    WITH
+                    -- General Notes:
+                    -- There are a number of times that column names are aliased arbitrarily.
+                    --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
+
+                    -- Recursively traverses the tree from root to leaves, building hierarchical paths.
+                    treeTraversal ([ECInstanceId], [ECClassId], [DirectParentId]) AS (
+                      -- Start with root nodes-SheetIndexes
+                      SELECT
+                      si.ECInstanceId,
+                      si.ECClassId,
+                      NULL AS [DirectParentId]
+                      FROM bis:SheetIndex si
+
+                      UNION ALL
+                      -- Recursively add children to parents, building hierarchical sort paths
+                      SELECT
+                      child.ECInstanceId,
+                      child.ECClassId,
+                      child.NodeParentId AS [DirectParentId]
+                      FROM treeTraversal parent
+                      JOIN (
+                      -- A table of all possible children joined to their parents
+                        SELECT
+                          [sr].[ECInstanceId],
+                          ECClassId,
+                          [sr].[Parent].[Id] AS [NodeParentId]
+                        FROM
+                          [bis].[SheetReference] [sr]
+
+                        UNION ALL
+
+                        SELECT
+                          [sif].[ECInstanceId],
+                          ECClassId,
+                          [sif].[Parent].[Id] AS [NodeParentId]
+                        FROM
+                          [bis].[SheetIndexFolder] [sif]
+                      ) child ON child.NodeParentId = parent.ECInstanceId
+                    )
+                    -- Final result: Returns only SheetReference node due to inner join
+                    SELECT
+                      sr.sheet.id AS [ECInstanceId],
+                      ec_classid('SheetNumbering', 'SheetIndexView') [ECClassId],
+                      CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount
+                    FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
+                  )
+                </Query>
+            </QueryView>
+        </ECCustomAttributes>
+        <ECProperty propertyName="PageCount" typeName="int" description="The total number of sheet references across the entire sheet index tree"/>
+    </ECEntityClass>
+    <ECEntityClass typeName="SheetReferenceView" modifier="Abstract" displayLabel="Page and Group numbers" description="Calculates the Page and Group numbers for the SheetReferences in a SheetIndex">
+        <ECCustomAttributes>
+            <QueryView xmlns="ECDbMap.02.00.04">
+                <Query>
+                  SELECT 
+                      ECInstanceId,
+                      ECClassId,
+                      SheetNumber,
+                      PageNumber
+                  FROM (
+                  WITH
+                  -- General Notes:
+                  -- There are a number of times that column names are aliased arbitrarily.
+                  --  This is to avoid an issue with CTEs not respecting qualifiers.  See this issue: https://github.com/iTwin/itwinjs-core/issues/8571
+
+                  -- Recursively traverses the tree from root to leaves, building hierarchical paths.
+                  -- Creates a global ordering based on depth-frist traversal with respect to EntryPriority.
+                  -- The SortPath ensures proper tree traversal order for sequential number assignment.
+                  -- AssemblyPath is included only for debugging purposes 
+                  treeTraversal ([ECInstanceId], [ECClassId], [SheetNumber], [Priority], [DirectParentId], [AssemblyPath], [SortPath]) AS (
+                      -- Start with root nodes-SheetIndexes
+                      SELECT
+                      si.ECInstanceId,
+                      si.ECClassId,
+                      COALESCE([si].[CodeValue], [si].[UserLabel]) AS [SheetNumber],
+                      0 AS [Priority],
+                      NULL AS [DirectParentId],
+                      COALESCE([si].[CodeValue], [si].[UserLabel]) AS [AssemblyPath],
+                      -- Use string padding for consistent sorting - pad to 10 digits with leading zeros
+                      SUBSTR('0000000000' || CAST(0 AS TEXT), -10) AS [SortPath]
+                      FROM bis:SheetIndex si
+
+                      UNION ALL
+                      -- Recursively add children to parents, building hierarchical sort paths
+                      SELECT
+                      child.ECInstanceId,
+                      child.ECClassId,
+                      child.SheetNumber,
+                      child.NodePriority AS [Priority],
+                      child.NodeParentId AS [DirectParentId],
+                      parent.AssemblyPath || '->' || child.SheetNumber AS [AssemblyPath],
+                      parent.SortPath || '.' || SUBSTR('0000000000' || CAST(COALESCE(child.NodePriority, 0) AS TEXT), -10) AS [SortPath]
+                      FROM treeTraversal parent
+                      JOIN (
+                      -- A table of all possible children joined to their parents
+                          SELECT
+                              [sr].[ECInstanceId],
+                              ECClassId,
+                              COALESCE([sr].[CodeValue], [sr].[UserLabel]) AS [SheetNumber],
+                              [sr].[EntryPriority] AS [NodePriority],
+                              [sr].[Parent].[Id] AS [NodeParentId]
+                          FROM
+                              [bis].[SheetReference] [sr]
+
+                          UNION ALL
+
+                          SELECT
+                              [sif].[ECInstanceId],
+                              ECClassId,
+                              COALESCE([sif].[CodeValue], [sif].[UserLabel]) AS [SheetNumber],
+                              [sif].[EntryPriority] AS [NodePriority],
+                              [sif].[Parent].[Id] AS [NodeParentId]
+                          FROM
+                              [bis].[SheetIndexFolder] [sif]
+                      ) child ON child.NodeParentId = parent.ECInstanceId
+                  )
+                  -- Final result: Returns only SheetReference node due to inner join
+                  SELECT
+                      sr.sheet.id AS [ECInstanceId],
+                      ec_classid('SheetNumbering', 'SheetReferenceView') [ECClassId],
+                      t.SheetNumber AS SheetNumber,
+                      CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber
+                  FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
+                  ORDER BY t.SortPath
+                  )
+                </Query>
+            </QueryView>
+        </ECCustomAttributes>
+        <ECProperty propertyName="SheetNumber" typeName="string" description="The formatted sheet identifier of the sheet"/>
+        <ECProperty propertyName="PageNumber" typeName="int" description="The global sequential page number of this sheet across the entire sheet index tree"/>
+    </ECEntityClass>
+</ECSchema>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -18,7 +18,7 @@
         </SchemaLayerInfo>
     </ECCustomAttributes>
 
-       <ECEntityClass typeName="SheetIndexFolderView" modifier="Abstract" displayLabel="Group numbers" description="Group numbers for a sheet it's in a SheetIndex">
+    <ECEntityClass typeName="SheetIndexFolderView" modifier="Abstract" displayLabel="Group numbers" description="Group numbers for a sheet it's in a SheetIndex">
         <ECCustomAttributes>
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -23,7 +23,7 @@
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>
                   SELECT
-                    [sr].Sheet.id AS ECInstanceId,
+                    [sr].ECInstanceId AS ECInstanceId,
                     ec_classid('SheetNumbering', 'SheetIndexFolderView') [ECClassId],
                     -- An assigned a Row Number for rows that share a parent and are ordered by their EntryPriority 
                     --   and cast to an integer because it's a long otherwise for some reason
@@ -88,7 +88,7 @@
                     )
                     -- Final result: Returns only SheetReference node due to inner join
                     SELECT
-                      sr.sheet.id AS [ECInstanceId],
+                      sr.ECInstanceId AS [ECInstanceId],
                       ec_classid('SheetNumbering', 'SheetIndexView') [ECClassId],
                       CAST((SELECT COUNT(*) FROM treeTraversal WHERE ECClassId = ec_classid('bis', 'SheetReference')) AS INTEGER) AS PageCount
                     FROM treeTraversal t JOIN bis.SheetReference sr ON sr.ECInstanceId = t.ECInstanceId
@@ -166,7 +166,7 @@
                   )
                   -- Final result: Returns only SheetReference node due to inner join
                   SELECT
-                      sr.sheet.id AS [ECInstanceId],
+                      sr.ECInstanceId AS [ECInstanceId],
                       ec_classid('SheetNumbering', 'SheetReferenceView') [ECClassId],
                       t.SheetNumber AS SheetNumber,
                       CAST(ROW_NUMBER() OVER (PARTITION BY t.ECClassId ORDER BY t.SortPath) AS INTEGER) AS PageNumber

--- a/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/SheetNumberingViews.ecschema.xml
@@ -33,7 +33,7 @@
         </ECCustomAttributes>
         <ECProperty propertyName="GroupCount" typeName="int" description="The total number of sheets within the same parent group as this sheet"/>
     </ECEntityClass>
-    <ECEntityClass typeName="SheetIndex View" modifier="Abstract" displayLabel="SheetIndex View" description="View that returns the total number of sheets in a sheet index">
+    <ECEntityClass typeName="SheetIndexView" modifier="Abstract" displayLabel="SheetIndex View" description="View that returns the total number of sheets in a sheet index">
         <ECCustomAttributes>
             <QueryView xmlns="ECDbMap.02.00.04">
                 <Query>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6225,5 +6225,19 @@
       "date": "Unknown",
       "dynamic": "No"
     }
+  ],
+  "SheetNumberingViews": [
+    {
+      "name": "SheetNumberingViews",
+      "path": "Domains\\4-Application\\DrawingProduction\\SheetNumberingViews.ecschema.xml",
+      "released": false,
+      "version": "01.00.00",
+      "comment": "Working Copy",
+      "sha1": "",
+      "author": "",
+      "approved": "No",
+      "date": "Unknown",
+      "dynamic": "No"
+    }
   ]
 }


### PR DESCRIPTION
Added ECView gathering all calculated SheeNumber Info related to Sheet.  This is intended to work with fields and provide a list of properties that should "appear to the user" as a properties of a sheet.

Questions:

1. When dealing with referenced schemas, how much does the path version matter, specifically with BisCore?  Is there a possibility of a lower patch version of a schema getting imported because of a referenced schema?
2. (Maybe more of a BWG question) Should the Sheet Id be a property on the SheetNumberInfo?  Would that make a better ECInstanceId?  Should there be some sort of relationship between a Sheet and the SheetNumberingInfo classes?

After this, we will quickly follow this PR with another looking to release this schema.