### PR TITLE
Add ec3.3 draft schema

### DIFF
--- a/System/json_schema/ec33-draft/ecschema-item.schema.json
+++ b/System/json_schema/ec33-draft/ecschema-item.schema.json
@@ -1,0 +1,651 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem",
+  "title": "SchemaItem",
+  "description": "First draft of an EC3.3 Json representation of any SchemaItem",
+  "type": "object",
+  "required": [
+    "schemaItemType",
+    "name",
+    "schema"
+  ],
+  "definitions": {
+    "ecversion": {
+      "type": "string",
+      "pattern": "^([0-9]{2}).([0-9]{2}).([0-9]{2})$"
+    },
+    "ecname": {
+      "type": "string",
+      "pattern": "^([a-zA-Z_.]+[a-zA-Z0-9_.]*)$"
+    },
+    "fullECName": {
+      "type": "string",
+      "pattern": "^([a-zA-Z_.]+[a-zA-Z0-9_.]*)\\.([a-zA-Z_.]+[a-zA-Z0-9_.]*)$"
+    },
+    "formatString": {
+      "type": "string",
+      "pattern": "([\\w,:]+)(\\(([^\\)]+)\\))?(\\[([^\\|\\]]+)([\\|])?([^\\]]+)?\\])?(\\[([^\\|\\]]+)([\\|])?([^\\]]+)?\\])?(\\[([^\\|\\]]+)([\\|])?([^\\]]+)?\\])?(\\[([^\\|\\]]+)([\\|])?([^\\]]+)?\\])?"
+    },
+    "schemaItemType": {
+      "type": "string",
+      "description": "All supported SchemaItem types within an ECSchema",
+      "enum": [
+        "EntityClass",
+        "Mixin",
+        "StructClass",
+        "RelationshipClass",
+        "CustomAttributeClass",
+        "Enumeration",
+        "KindOfQuantity",
+        "PropertyCategory",
+        "Unit",
+        "InvertedUnit",
+        "Constant",
+        "Phenomenon",
+        "UnitSystem",
+        "Format"
+      ]
+    },
+    "classModifier": {
+      "type": "string",
+      "enum": [
+        "none",
+        "abstract",
+        "sealed"
+      ],
+      "default": "None"
+    },
+    "customAttributeContainerType": {
+      "type": "string"
+    },
+    "schemaItemProperties": {
+      "type": "object",
+      "required": [
+        "name",
+        "schemaItemType"
+      ],
+      "properties": {
+        "$schema": { "type": "string"},
+        "name": { "$ref": "#/definitions/ecname" },
+        "schemaItemType": { "$ref": "#/definitions/schemaItemType" },
+        "schema": { "$ref": "#/definitions/ecname" },
+        "schemaVersion": { "$ref": "#/definitions/ecversion" },
+        "description": { "type": "string" },
+        "displayLabel": { "type": "string" } 
+      }
+    },
+    "Class": {
+      "type": "object",
+      "allOf":[
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type": "object",
+          "properties": {
+            "modifier": { "$ref": "#/definitions/classModifier" },
+            "baseClass": { "$ref": "#/definitions/fullECName" },
+            "customAttributes": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": [
+                {
+                  "type": "object",
+                  "required": [
+                    "className"
+                  ],
+                  "properties": {
+                    "className": { "$ref": "#/definitions/fullECName" }
+                  }
+                }
+              ]
+            },
+            "propertiesContents": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": [
+                {
+                  "type": "object",
+                  "oneOf": [
+                    { "$ref": "#/definitions/PrimitiveProperty" },
+                    { "$ref": "#/definitions/StructProperty" },
+                    { "$ref": "#/definitions/PrimitiveArrayProperty" },
+                    { "$ref": "#/definitions/StructArrayProperty" },
+                    { "$ref": "#/definitions/NavigationProperty" }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "EntityClass": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/Class"},
+        {
+          "type": "object",
+          "properties": {
+            "mixin": { "$ref": "#/definitions/fullECName" }
+          }
+        }
+      ]
+    },
+    "Mixin": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/Class"},
+        {
+          "type": "object",
+          "properties": {
+            "appliesTo": { "$ref": "#/definitions/fullECName" }
+          }
+        }
+      ]
+    },
+    "relationshipStrength": {
+      "type": "string",
+      "enum": [
+        "embedding",
+        "referencing",
+        "holding"
+      ]
+    },
+    "strengthDirection": {
+      "type": "string",
+      "enum": [
+        "forward",
+        "backward"
+      ]
+    },
+    "RelationshipClass": {
+      "type": "object",
+      "required": [
+        "modifier"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/Class"},
+        {
+          "type": "object",
+          "required":[
+            "source",
+            "target"
+          ],
+          "properties": {
+            "strength": { "$ref": "#/definitions/relationshipStrength" },
+            "strengthDirection": { "$ref": "#/definitions/strengthDirection" },
+            "source": { "$ref": "#/definitions/RelationshipConstraint" },
+            "target": { "$ref": "#/definitions/RelationshipConstraint" }
+          }
+        }
+      ]
+    },
+    "RelationshipConstraint": {
+      "type": "object",
+      "required": [
+        "multiplicity",
+        "roleLabel",
+        "polymorphic",
+        "constraintClasses"
+      ],
+      "properties": {
+        "multiplicity": {
+          "type": "string",
+          "pattern": "\\(\\d..(\\d|\\*)\\)"
+        },
+        "roleLabel": { "type": "string" },
+        "polymorphic": { "type":"boolean" },
+        "abstractConstraint": { "$ref": "#/definitions/fullECName" },
+        "constraintClasses": {
+          "type": "array",
+          "uniqueItems": true,
+          "items":[
+            { "$ref": "#/definitions/fullECName" }
+          ]
+        }
+      }
+    },
+    "StructClass": { "$ref": "#/definitions/Class"},
+    "CustomAttributeClass": {
+      "type": "object",
+      "required": [
+        "appliedTo"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/Class"},
+        {
+          "type": "object",
+          "properties": {
+            "appliedTo": { "$ref": "#/definitions/customAttributeContainerType" }
+          }
+        }
+      ]
+    },
+    "KindOfQuantity": {
+      "type": "object",
+      "required": [
+        "persistenceUnit",
+        "precision"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type": "object",
+          "properties": {
+            "persistenceUnit": { "$ref": "#/definitions/ecname" },
+            "precision": { "type":"number" },
+            "presentationUnits": {
+              "items": { "$ref": "#/definitions/formatString" }
+            }
+          }
+        }
+      ]
+    },
+    "Enumeration": {
+      "type": "object",
+      "required": [
+        "backingTypeName",
+        "isStrict",
+        "enumerators"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type": "object",
+          "properties": {
+            "backingTypeName": {
+              "type": "string",
+              "enum": [
+                "int",
+                "string"
+              ]
+            },
+            "isStrict": { "type": "boolean" },
+            "enumerators": {
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/Enumerator" }
+            }
+          }
+        }
+      ]
+    },
+    "Enumerator": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/definitions/ecname" },
+        "value": { "type": ["string", "number"] },
+        "label": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "PropertyCategory": {
+      "type": "object",
+      "required": [
+        "priority"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type": "object",
+          "properties": {
+            "priority": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "Unit": {
+      "type": "object",
+      "required": [
+        "phenomenon",
+        "unitSystem",
+        "definition"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type":"object",
+          "properties": {
+            "phenomenon": { "$ref": "#/definitions/ecname" },
+            "unitSystem": { "$ref": "#/definitions/ecname" },
+            "definition": { "type": "string" },
+            "numerator": {
+              "type": "number",
+              "default": 1
+            },
+            "denominator": {
+              "type": "number",
+              "minimum": 1,
+              "default": 1
+            },
+            "offset": {
+              "type": "number",
+              "default": 0
+            }
+          }
+        }
+      ]
+    },
+    "InvertedUnit": {
+      "type": "object",
+      "required": [
+        "invertsUnit",
+        "unitSystem"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type":"object",
+          "properties": {
+            "invertsUnit": { "$ref": "#/definitions/ecname" },
+            "unitSystem": { "$ref": "#/definitions/ecname" }
+          }
+        }
+      ]
+    },
+    "Constant": {
+      "type": "object",
+      "required": [
+        "numerator",
+        "phenomenon",
+        "definition"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type":"object",
+          "properties": {
+            "phenomenon": { "$ref": "#/definitions/ecname" },
+            "definition": { "type": "string" },
+            "numerator": {
+              "type": "number",
+              "minimum": 0
+            },
+            "denominator": {
+              "type": "number",
+              "minimum": 1,
+              "default": 1
+            }
+          }
+        }
+      ]
+    },
+    "Phenomenon": {
+      "type": "object",
+      "required": [
+        "definition"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type":"object",
+          "properties": {
+            "definition": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "UnitSystem": { "$ref": "#/definitions/schemaItemProperties"},
+    "Format": {
+      "type": "object",
+      "required": [
+        "precision",
+        "type"
+      ],
+      "allOf": [
+        { "$ref": "#/definitions/schemaItemProperties" },
+        {
+          "type":"object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "decimal",
+                "fractional",
+                "station",
+                "scientific"
+              ]
+            },
+            "precision": {
+              "type": "number",
+              "// TODO Update pattern": ""
+            },
+            "roundFactor": {
+              "type":"number"
+            },
+            "minWidth": {
+              "type":"integer",
+              "minimum": 0
+            },
+            "showSignOption": {
+              "type": "string",
+              "enum": [
+                "noSign",
+                "onlyNegative",
+                "signAlways",
+                "negativeParentheses"
+              ]
+            },
+            "formatTraits": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "(trailZeroes|keepSingleZero|zeroEmpty|keepDecimalPoint|applyRounding|fractionDash|showUnitLabel|prependUnitLabel|use1000Separator|exponentOnlyNegative|[,|;])+"
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "trailZeroes",
+                      "keepSingleZero",
+                      "zeroEmpty",
+                      "keepDecimalPoint",
+                      "applyRounding",
+                      "fractionDash",
+                      "showUnitLabel",
+                      "prependUnitLabel",
+                      "use1000Separator",
+                      "exponentOnlyNegative"
+                    ]
+                  }
+                }
+              ]
+            },
+            "decimalSeparator": {
+              "type": "string",
+              "maxLength": 1
+            },
+            "thousandSeparator": {
+              "type": "string",
+              "maxLength": 1
+            },
+            "uomSeparator": {
+              "type": "string",
+              "maxLength": 1
+            },
+            "scientificType": {
+              "type": "string",
+              "enum": [
+                "normalized",
+                "zeroNormalized"
+              ]
+            },
+            "stationOffsetSize": {
+              "type": "number",
+              "minimum": 0
+            },
+            "stationSeparator": {
+              "type": "string",
+              "maxLength": 1
+            },
+            "composite": {
+              "type": "object",
+              "properties": {
+                "spacer": {
+                  "type": "string"
+                },
+                "includeZero": {
+                  "type": "boolean"
+                },
+                "units": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 4,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "$ref": "#/definitions/ecname" },
+                      "label": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primitiveTypes": {
+      "type": "string",
+      "enum": [
+        "binary",
+        "bool",
+        "boolean",
+        "dateTime",
+        "double",
+        "int",
+        "long",
+        "point2d",
+        "point3d",
+        "string",
+        "Bentley.Geometry.Common.IGeometry"
+      ]
+    },
+    "propertyTypes": {
+      "type": "string",
+      "enum": [
+        "PrimitiveProperty",
+        "StructProperty",
+        "PrimitiveArrayProperty",
+        "StructArrayProperty",
+        "NavigationProperty"
+      ]
+    },
+    "Property": {
+      "type": "object",
+      "required": [
+        "name",
+        "propertyType"
+      ],
+      "properties": {
+        "name": { "$ref": "#/definitions/ecname" },
+        "propertyType": { "$ref": "#/definitions/propertyTypes" },
+        "description": { "type": "string" },
+        "displayLabel": { "type": "string" },
+        "readOnly": { "type":"boolean" },
+        "category": { "ref": "#/definitions/fullECName" }
+      }
+    },
+    "PrimitiveProperty": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/Property" },
+        {
+          "required": [
+            "typeName"
+          ],
+          "properties": {
+            "typeName": {
+              "oneOf":[
+                { "$ref": "#/definitions/primitiveTypes" },
+                { "$ref": "#/definitions/fullECName" }
+              ]
+            },
+            "extendedTypeName": { "type": "string" },
+            "minimumLength": { "type": "number" },
+            "maximumLength": { "type": "number" },
+            "minimumValue": { "type": "number" },
+            "maximumValue": { "type": "number" },
+            "kindOfQuantity": { "$ref": "#/definitions/fullECName" }
+          }
+        }
+      ]
+    },
+    "arrayAttributes": {
+      "type": "object",
+      "properties": {
+        "minOccurs": { "type": "number" },
+        "maxOccurs": { "type": "number" }
+      }
+    },
+    "PrimitiveArrayProperty": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/PrimitiveProperty"},
+        { "$ref": "#/definitions/arrayAttributes"}
+      ]
+    },
+    "StructProperty": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/Property" },
+        {
+          "properties": {
+            "typeName": { "$ref": "#/definitions/fullECName" }
+          }
+        }
+      ]
+    },
+    "StructArrayProperty": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/StructProperty" },
+        { "$ref": "#/definitions/arrayAttributes" }
+      ]
+    },
+    "NavigationProperty": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/Property" },
+        {
+          "properties": {
+            "relationshipName": { "$ref": "#/definitions/fullECName" },
+            "direction": {
+              "type": "string",
+              "enum": [
+                "backward",
+                "forward"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "anyOf":[
+    {"$ref": "#/definitions/EntityClass"},
+    {"$ref": "#/definitions/Mixin"},
+    {"$ref": "#/definitions/StructClass"},
+    {"$ref": "#/definitions/RelationshipClass"},
+    {"$ref": "#/definitions/CustomAttributeClass"},
+    {"$ref": "#/definitions/KindOfQuantity"},
+    {"$ref": "#/definitions/Enumeration"},
+    {"$ref": "#/definitions/PropertyCategory"},
+    {"$ref": "#/definitions/Unit"},
+    {"$ref": "#/definitions/InvertedUnit"},
+    {"$ref": "#/definitions/Constant"},
+    {"$ref": "#/definitions/Phenomenon"},
+    {"$ref": "#/definitions/UnitSystem"},
+    {"$ref": "#/definitions/Format"}
+  ]
+}

--- a/System/json_schema/ec33-draft/ecschema.schema.json
+++ b/System/json_schema/ec33-draft/ecschema.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://dev.bentley.com/json_schemas/ec/33/draft-01/ecschema",
+  "title": "ECSchema",
+  "description": "First draft for the EC3.3 Json representation of an ECSchema.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "name",
+    "version",
+    "alias"
+  ],
+  "definitions": {
+    "schemaReference": {
+      "type": "object",
+      "required": [
+        "name",
+        "version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem#/definitions/ecname" },
+        "version": { "$ref": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem#/definitions/ecversion" }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": { "$ref": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem#/definitions/ecname" },
+    "version": { "$ref": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem#/definitions/ecversion" },
+    "alias": { "$ref": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem#/definitions/ecname" },
+    "description": { "type": "string" },
+    "displayLabel": { "type": "string" },
+    "schemaReferences": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/schemaReference" }
+    },
+    "schemaItems": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "https://dev.bentley.com/json_schemas/ec/33/draft-01/schemaitem#" }
+    },
+    "customAttributes": {
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new JSON schema definition for the EC3.3 draft representation of an `ECSchema`. The schema establishes the structure and validation rules for ECSchema objects, including required properties, references to external definitions, and constraints on additional properties.

The only changes between the 2 schema.json files in this ec3.3 draft and ec3.2 are the `$id` and `$ref` values that previously pointed to `ec/32`, updating them to `ec/33`.