### PR TITLE
Add DefaultToolsUnits Schema

### DIFF
--- a/Domains/4-Application/OpenSite/Released/OpenSite.01.00.14.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSite.01.00.14.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.15" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.14" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
@@ -16,7 +16,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -5965,7 +5965,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.14",
+      "version": "01.00.15",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",
@@ -6138,6 +6138,20 @@
       "verified": "Yes",
       "author": "Felix.Girard",
       "date": "9/19/2025",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "OpenSite",
+      "path": "Domains\\4-Application\\OpenSite\\Released\\OpenSite.01.00.14.ecschema.xml",
+      "released": true,
+      "version": "01.00.14",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "55a2102fbc3778d391f5bbd046c275135d34b69d",
+      "verified": "Yes",
+      "author": "Danny.Lewis",
+      "date": "10/14/2025",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
This pull request introduces a new schema for default unit definitions that can be used across multiple iTwin applications. The key changes include the addition of the `DefaultToolsUnits` ECSchema XML file, which defines standard kinds of quantities (such as length, area, volume, angle, etc.), and updates the schema inventory to register this new schema.

**Schema Addition:**

* Added new ECSchema file `DefaultToolsUnits.ecschema.xml` in the `Domains/4-Application/DefaultTools` directory, defining standard kinds of quantities for tools and components, including length, area, volume, angle, bearing, time, and percentage.

**Schema Registration:**

* Updated `SchemaInventory.json` to register the new `DefaultToolsUnits` schema, including metadata such as author, version, and status.