### PR TITLE
Corrected the PipeOwnsCircularShapeAspect relationship, so this one refers to a pipe. 

### DIFF
--- a/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
+++ b/Domains/3-DisciplineOther/Hydraulics/SewerHydraulicAnalysis.ecschema.xml
@@ -958,8 +958,23 @@
         <ECProperty propertyName="PipeDiameter" typeName="double" displayLabel="Diameter" category="HydraulicData" kindOfQuantity="rru:LENGTH_SHORT"/>
     </ECEntityClass>
 
+    <ECRelationshipClass typeName="PipeOwnsCircularShapeAspect2" strength="embedding" strengthDirection="Forward" modifier="Sealed">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="Pipe" />
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="owned by" polymorphic="true">
+            <Class class="CircularPipeShapeAspect" />
+        </Target>
+    </ECRelationshipClass>
+
     <ECRelationshipClass typeName="PipeOwnsCircularShapeAspect" strength="embedding" strengthDirection="Forward" modifier="Sealed">
         <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <ECCustomAttributes>
+            <Deprecated xmlns="CoreCustomAttributes.01.00.03">
+                <Description>Use the new PipeOwnsCircularShapeAspect2 class instead.</Description>
+            </Deprecated>
+        </ECCustomAttributes>
         <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
             <Class class="GravityStructure" />
         </Source>


### PR DESCRIPTION
Corrected the aspect relationship, so this one refers to a pipe. Previously we had a cut and paste error and it was referring to the gravity structure. Unfortunately we can't just fix the relationship, we need to deprecate it and create a new, corrected one.