### PR TITLE
Release OpenSite 01.00.21

### DIFF
--- a/Domains/4-Application/OpenSite/Released/OpenSite.01.00.21.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSite.01.00.21.ecschema.xml
@@ -16,7 +16,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/Domains/4-Application/OpenSite/Released/OpenSite.01.00.21.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSite.01.00.21.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.22" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.21" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6458,10 +6458,10 @@
       "version": "01.00.21",
       "comment": "",
       "verifier": "Diego.Diaz",
-      "sha1": "480d72772eb1a4894f763602fab9973d4d76f538",
+      "sha1": "4296734a0587a48cbf82e8e031acced57f0cd1e5",
       "verified": "Yes",
       "author": "Emily.Zhang",
-      "date": "3/30/2026",
+      "date": "3/31/2026",
       "dynamic": "No",
       "approved": "Yes"
     }

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6177,7 +6177,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.21",
+      "version": "01.00.22",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",
@@ -6448,6 +6448,20 @@
       "verified": "Yes",
       "author": "Danny.Lewis",
       "date": "3/11/2026",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "OpenSite",
+      "path": "Domains\\4-Application\\OpenSite\\Released\\OpenSite.01.00.21.ecschema.xml",
+      "released": true,
+      "version": "01.00.21",
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "480d72772eb1a4894f763602fab9973d4d76f538",
+      "verified": "Yes",
+      "author": "Emily.Zhang",
+      "date": "3/30/2026",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
Release version 01.00.2` of the OpenSite Schema for OpenSite+

Please see the following PR's to see the changes that were made to the schema for this release:
[OpenSite - Change polymorphism of relationship#683](https://github.com/iTwin/bis-schemas/pull/683/changes)
[[OpenSite] Update Control Vertex and Control Ditch Rule Props#684](https://github.com/iTwin/bis-schemas/pull/684)