### PR TITLE
Link view attachment with placeholder

### DIFF
--- a/Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="DrawingProductionExperimental" alias="dpex" version="01.01.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="This schema contains an experimental implementation of concepts associated with Drawing Production.">
+<ECSchema schemaName="DrawingProductionExperimental" alias="dpex" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="This schema contains an experimental implementation of concepts associated with Drawing Production.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>   
@@ -20,15 +20,14 @@
     <ECEntityClass typeName="ViewAttachmentPlaceHolder" displayLabel="View Attachment Placeholder" modifier="None" description="An area on a sheet where a view is to be placed.">
         <BaseClass>bis:GraphicalElement2d</BaseClass>
     </ECEntityClass>
-    
-    <ECEntityClass typeName="ViewAttachmentWithPlaceHolder" displayLabel="View Attachment (with placeholder)" modifier="None" description="Attachment wrapper exposing placeholder link.">
+    <ECEntityClass typeName="ViewAttachmentWithPlaceHolder" displayLabel="View Attachment (with placeholder)" modifier="None" description="A ViewAttachment that fills a ViewAttachmentPlaceHolder region on a sheet.">
       <BaseClass>bis:ViewAttachment</BaseClass>
-      <ECNavigationProperty propertyName="placeHolder" relationshipName="ViewAttachmentFulfillsPlaceHolder" direction="Forward" displayLabel="PlaceHolder" description="The sheet region this ViewAttachment fills."/>
+      <ECNavigationProperty propertyName="placeHolder" relationshipName="ViewAttachmentFulfillsPlaceHolder" direction="Forward" displayLabel="PlaceHolder" description="The placeholder this ViewAttachment fills."/>
     </ECEntityClass>
 
     <ECRelationshipClass typeName="ViewAttachmentFulfillsPlaceHolder" strength="referencing" modifier="Sealed"
         description="Relates a ViewAttachmentWithPlaceHolder to the ViewAttachmentPlaceHolder it fills.">
-        <Source multiplicity="(0..1)" roleLabel="fills" polymorphic="true">
+        <Source multiplicity="(0..*)" roleLabel="fills" polymorphic="true">
             <Class class="ViewAttachmentWithPlaceHolder"/>
         </Source>
         <Target multiplicity="(0..1)" roleLabel="is filled by" polymorphic="true">

--- a/Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="DrawingProductionExperimental" alias="dpex" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="This schema contains an experimental implementation of concepts associated with Drawing Production.">
+<ECSchema schemaName="DrawingProductionExperimental" alias="dpex" version="01.01.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="This schema contains an experimental implementation of concepts associated with Drawing Production.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>   
@@ -19,7 +19,6 @@
 
     <ECEntityClass typeName="ViewAttachmentPlaceHolder" displayLabel="View Attachment Placeholder" modifier="None" description="An area on a sheet where a view is to be placed.">
         <BaseClass>bis:GraphicalElement2d</BaseClass>
-        <ECNavigationProperty propertyName="overridesPrototypePlaceholder" relationshipName="PlaceholderOverride" direction="Forward" displayLabel="Overrides Prototype Placeholder" description="The prototype placeholder this local override was copied from. Absent when the placeholder matches the prototype."/>
     </ECEntityClass>
     
     <ECEntityClass typeName="ViewAttachmentWithPlaceHolder" displayLabel="View Attachment (with placeholder)" modifier="None" description="Attachment wrapper exposing placeholder link.">

--- a/Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml
@@ -19,5 +19,22 @@
 
     <ECEntityClass typeName="ViewAttachmentPlaceHolder" displayLabel="View Attachment Placeholder" modifier="None" description="An area on a sheet where a view is to be placed.">
         <BaseClass>bis:GraphicalElement2d</BaseClass>
+        <ECNavigationProperty propertyName="overridesPrototypePlaceholder" relationshipName="PlaceholderOverride" direction="Forward" displayLabel="Overrides Prototype Placeholder" description="The prototype placeholder this local override was copied from. Absent when the placeholder matches the prototype."/>
     </ECEntityClass>
+    
+    <ECEntityClass typeName="ViewAttachmentWithPlaceHolder" displayLabel="View Attachment (with placeholder)" modifier="None" description="Attachment wrapper exposing placeholder link.">
+      <BaseClass>bis:ViewAttachment</BaseClass>
+      <ECNavigationProperty propertyName="placeHolder" relationshipName="ViewAttachmentFulfillsPlaceHolder" direction="Forward" displayLabel="PlaceHolder" description="The sheet region this ViewAttachment fills."/>
+    </ECEntityClass>
+
+    <ECRelationshipClass typeName="ViewAttachmentFulfillsPlaceHolder" strength="referencing" modifier="Sealed"
+        description="Relates a ViewAttachmentWithPlaceHolder to the ViewAttachmentPlaceHolder it fills.">
+        <Source multiplicity="(0..1)" roleLabel="fills" polymorphic="true">
+            <Class class="ViewAttachmentWithPlaceHolder"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is filled by" polymorphic="true">
+            <Class class="ViewAttachmentPlaceHolder"/>
+        </Target>
+    </ECRelationshipClass>
+
 </ECSchema>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6695,7 +6695,7 @@
       "name": "DrawingProductionExperimental",
       "path": "Domains\\4-Application\\DrawingProduction\\DrawingProductionExperimental.ecschema.xml",
       "released": false,
-      "version": "01.01.00",
+      "version": "01.00.01",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Josh.Schifter",

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6693,9 +6693,9 @@
   "DrawingProductionExperimental": [
     {
       "name": "DrawingProductionExperimental",
-      "path": "Domains/4-Application/DrawingProduction/DrawingProductionExperimental.ecschema.xml",
+      "path": "Domains\\4-Application\\DrawingProduction\\DrawingProductionExperimental.ecschema.xml",
       "released": false,
-      "version": "01.00.00",
+      "version": "01.01.00",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Josh.Schifter",


### PR DESCRIPTION
DrawingProductionExperimental v01.00.01 — Link ViewAttachment with Placeholder

Adds the initial ViewAttachment-Placeholder relationship to DrawingProductionExperimental:

`ViewAttachmentPlaceholder` : a GraphicalElement2d representing an area on a sheet where a view is to be placed.
`ViewAttachmentWithPlaceholder` : a ViewAttachment subclass with a placeHolder nav property pointing to the placeholder it fulfills.
`ViewAttachmentFulfillsPlaceholder` : a referencing relationship with `ViewAttachmentWithPlaceholder` as Source and `ViewAttachmentPlaceholder` as Target, ensuring the nav property sits correctly on the source side.