### PR TITLE
Release OpenSiteViews 01.00.00 and CivilSpatial 01.00.03

### DIFF
--- a/Domains/2-DisciplinePhysical/Civil/SpatialComposition/CivilSpatial/Released/CivilSpatial.01.00.03.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/Civil/SpatialComposition/CivilSpatial/Released/CivilSpatial.01.00.03.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="CivilSpatial" alias="cvsp" version="01.00.04" description="Schema modeling the spatial breakdown of concepts common across Civil domains such as Road, Rail or Site." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+<ECSchema schemaName="CivilSpatial" alias="cvsp" version="01.00.03" description="Schema modeling the spatial breakdown of concepts common across Civil domains such as Road, Rail or Site." xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.13" alias="bis"/>
@@ -13,7 +13,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.00">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>DisciplinePhysical</Value>

--- a/Domains/4-Application/OpenSite/OpenSiteViews.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSiteViews.ecschema.xml
@@ -26,7 +26,7 @@
                 <Query>
                     SELECT
                         COALESCE(pa.ECInstanceId, pr.ECInstanceId) [ECInstanceId],
-                        ec_classid('OpenSiteViews', 'ParkingInformationView') [ECClassId],
+                        COALESCE(pa.ECClassId, pr.ECClassId) [ECClassId],
                         SUM(pr.ParkingSpaceCount) [ParkingSpaceCount],
                         SUM(pr.ProblemSpaceCount) [ProblemSpaceCount]
                     FROM OpenSite:ParkingRowPath prp
@@ -34,7 +34,7 @@
                     JOIN CivilSpatial:ParkingRow pr ON relPrp.TargetECInstanceId=pr.ECInstanceId
                     LEFT JOIN SpatialComposition:SpatialStructureElementAggregatesElements relPa ON pr.ECInstanceId=relPa.TargetECInstanceId
                     LEFT JOIN CivilSpatial:ParkingArea pa ON relPa.SourceECInstanceId=pa.ECInstanceId
-                    GROUP BY COALESCE(pa.ECInstanceId, pr.ECInstanceId);
+                    GROUP BY COALESCE(pa.ECInstanceId, pr.ECInstanceId), COALESCE(pa.ECClassId, pr.ECClassId);
                 </Query>
             </QueryView>
         </ECCustomAttributes>

--- a/Domains/4-Application/OpenSite/Released/OpenSiteViews.01.00.00.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSiteViews.01.00.00.ecschema.xml
@@ -26,15 +26,15 @@
                 <Query>
                     SELECT
                         COALESCE(pa.ECInstanceId, pr.ECInstanceId) [ECInstanceId],
-                        ec_classid('OpenSiteViews', 'ParkingInformationView') [ECClassId],
+                        COALESCE(pa.ECClassId, pr.ECClassId) [ECClassId],
                         SUM(pr.ParkingSpaceCount) [ParkingSpaceCount],
-                        CAST(0 AS INTEGER) [ProblemSpaceCount]
+                        SUM(pr.ProblemSpaceCount) [ProblemSpaceCount]
                     FROM OpenSite:ParkingRowPath prp
                     JOIN OpenSite:ElementDrivesElementsLinearly relPrp ON prp.ECInstanceId=relPrp.SourceECInstanceId
                     JOIN CivilSpatial:ParkingRow pr ON relPrp.TargetECInstanceId=pr.ECInstanceId
                     LEFT JOIN SpatialComposition:SpatialStructureElementAggregatesElements relPa ON pr.ECInstanceId=relPa.TargetECInstanceId
                     LEFT JOIN CivilSpatial:ParkingArea pa ON relPa.SourceECInstanceId=pa.ECInstanceId
-                    GROUP BY COALESCE(pa.ECInstanceId, pr.ECInstanceId);
+                    GROUP BY COALESCE(pa.ECInstanceId, pr.ECInstanceId), COALESCE(pa.ECClassId, pr.ECClassId);
                 </Query>
             </QueryView>
         </ECCustomAttributes>

--- a/Domains/4-Application/OpenSite/Released/OpenSiteViews.01.00.00.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSiteViews.01.00.00.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSiteViews" alias="opnsiteViews" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite Views" description="Views that introduce derived concepts based on the OpenSite schema.">
+<ECSchema schemaName="OpenSiteViews" alias="opnsiteViews" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite Views" description="Views that introduce derived concepts based on the OpenSite schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="ECDbMap" version="02.00.04" alias="ecdbmap"/>
@@ -13,7 +13,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>
@@ -28,7 +28,7 @@
                         COALESCE(pa.ECInstanceId, pr.ECInstanceId) [ECInstanceId],
                         ec_classid('OpenSiteViews', 'ParkingInformationView') [ECClassId],
                         SUM(pr.ParkingSpaceCount) [ParkingSpaceCount],
-                        SUM(pr.ProblemSpaceCount) [ProblemSpaceCount]
+                        CAST(0 AS INTEGER) [ProblemSpaceCount]
                     FROM OpenSite:ParkingRowPath prp
                     JOIN OpenSite:ElementDrivesElementsLinearly relPrp ON prp.ECInstanceId=relPrp.SourceECInstanceId
                     JOIN CivilSpatial:ParkingRow pr ON relPrp.TargetECInstanceId=pr.ECInstanceId

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6597,13 +6597,27 @@
       "name": "OpenSiteViews",
       "path": "Domains\\4-Application\\OpenSite\\OpenSiteViews.ecschema.xml",
       "released": false,
-      "version": "01.00.00",
+      "version": "01.00.01",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",
       "approved": "No",
       "date": "Unknown",
       "dynamic": "No"
+    },
+    {
+      "name": "OpenSiteViews",
+      "path": "Domains\\4-Application\\OpenSite\\Released\\OpenSiteViews.01.00.00.ecschema.xml",
+      "released": true,
+      "version": "01.00.00",
+      "comment": "First Release",
+      "verifier": "Diego Diaz",
+      "sha1": "55d3c9cc2787a7cc67922fa8d7a7642fd66e0fb3",
+      "verified": "Yes",
+      "author": "Felix.Girard",
+      "date": "5/19/2026",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "CivilSpatial": [
@@ -6611,7 +6625,7 @@
       "name": "CivilSpatial",
       "path": "Domains\\2-DisciplinePhysical\\Civil\\SpatialComposition\\CivilSpatial\\CivilSpatial.ecschema.xml",
       "released": false,
-      "version": "01.00.03",
+      "version": "01.00.04",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",
@@ -6658,6 +6672,20 @@
       "verified": "Yes",
       "author": "Felix.Girard",
       "date": "10/23/2025",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "CivilSpatial",
+      "path": "Domains\\2-DisciplinePhysical\\Civil\\SpatialComposition\\CivilSpatial\\Released\\CivilSpatial.01.00.03.ecschema.xml",
+      "released": true,
+      "version": "01.00.03",
+      "comment": "Added Problem Spaces for Parking Row",
+      "verifier": "Diego.Diaz",
+      "sha1": "8e464380ea902569087074f1e019b482c8cc5ba5",
+      "verified": "Yes",
+      "author": "Felix.Girard",
+      "date": "5/19/2026",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
- Civil Spatial added a Problem Spaces count for Parking Rows
- First release of `OpenSiteViews` to allow calculated properties like Parking Spaces and Problem Spaces to be calculated instead of persisted.