### PR TITLE
fix: correct typo M_PER_DAy → M_PER_DAY in Units schema

### DIFF
--- a/System/Released/Units.01.00.00.ecschema.xml
+++ b/System/Released/Units.01.00.00.ecschema.xml
@@ -449,7 +449,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.01.ecschema.xml
+++ b/System/Released/Units.01.00.01.ecschema.xml
@@ -451,7 +451,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.02.ecschema.xml
+++ b/System/Released/Units.01.00.02.ecschema.xml
@@ -454,7 +454,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.03.ecschema.xml
+++ b/System/Released/Units.01.00.03.ecschema.xml
@@ -498,7 +498,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.04.ecschema.xml
+++ b/System/Released/Units.01.00.04.ecschema.xml
@@ -498,7 +498,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.05.ecschema.xml
+++ b/System/Released/Units.01.00.05.ecschema.xml
@@ -499,7 +499,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.06.ecschema.xml
+++ b/System/Released/Units.01.00.06.ecschema.xml
@@ -509,7 +509,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.07.ecschema.xml
+++ b/System/Released/Units.01.00.07.ecschema.xml
@@ -509,7 +509,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.08.ecschema.xml
+++ b/System/Released/Units.01.00.08.ecschema.xml
@@ -510,7 +510,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.09.ecschema.xml
+++ b/System/Released/Units.01.00.09.ecschema.xml
@@ -511,7 +511,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />

--- a/System/Released/Units.01.00.10.ecschema.xml
+++ b/System/Released/Units.01.00.10.ecschema.xml
@@ -518,7 +518,7 @@
     <Unit typeName="M_PER_SEC" phenomenon="VELOCITY" unitSystem="SI" definition="M*S(-1)" displayLabel="m/s" />
     <Unit typeName="M_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*MIN(-1)" displayLabel="m/min" />
     <Unit typeName="M_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*HR(-1)" displayLabel="m/h" />
-    <Unit typeName="M_PER_DAy" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
+    <Unit typeName="M_PER_DAY" phenomenon="VELOCITY" unitSystem="METRIC" definition="M*DAY(-1)" displayLabel="m/day" />
     <Unit typeName="MM_PER_SEC" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*S(-1)" displayLabel="mm/sec" />
     <Unit typeName="MM_PER_MIN" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*MIN(-1)" displayLabel="mm/min" />
     <Unit typeName="MM_PER_HR" phenomenon="VELOCITY" unitSystem="METRIC" definition="MM*HR(-1)" displayLabel="mm/h" />


### PR DESCRIPTION
Fixes #710

## Changes

Corrects a consistent lowercase `y` typo in the `typeName` attribute across all 11 released versions of the Units schema:

- `typeName="M_PER_DAy"` → `typeName="M_PER_DAY"`

Files changed:
- `System/Released/Units.01.00.00.ecschema.xml`
- `System/Released/Units.01.00.01.ecschema.xml`
- `System/Released/Units.01.00.02.ecschema.xml`
- `System/Released/Units.01.00.03.ecschema.xml`
- `System/Released/Units.01.00.04.ecschema.xml`
- `System/Released/Units.01.00.05.ecschema.xml`
- `System/Released/Units.01.00.06.ecschema.xml`
- `System/Released/Units.01.00.07.ecschema.xml`
- `System/Released/Units.01.00.08.ecschema.xml`
- `System/Released/Units.01.00.09.ecschema.xml`
- `System/Released/Units.01.00.10.ecschema.xml`