### PR TITLE
Address typo in xml displayLabel attribute.

### DIFF
--- a/Domains/1-Common/LinearReferencing/LinearReferencing.ecschema.xml
+++ b/Domains/1-Common/LinearReferencing/LinearReferencing.ecschema.xml
@@ -127,7 +127,7 @@
     <ECEntityClass typeName="LinearLocationRecord" displayLabel="Linear Location Record" description="ILinearLocationElement-implementation attaching Linear Referencing Location to a bis:Element not inherently Linearly-Referenced." modifier="Sealed">
         <BaseClass>LinearLocationRecordElement</BaseClass>
     </ECEntityClass>
-    <ECEntityClass typeName="IReferent" display="Referent-Element" description="Mix-in to be supported by Element-subclasses that can play the role of a Referent (known location along a Linear-Element)." modifier="Abstract">
+    <ECEntityClass typeName="IReferent" displayLabel="Referent-Element" description="Mix-in to be supported by Element-subclasses that can play the role of a Referent (known location along a Linear-Element)." modifier="Abstract">
         <BaseClass>ILinearlyLocated</BaseClass>
         <ECCustomAttributes>
             <IsMixin xmlns='CoreCustomAttributes.01.00.00'>


### PR DESCRIPTION
The displayLabel attribute was misspelled "display" which means the attribute was ignored.