### PR TITLE
Add ElectricDistribution domain schema (01.00.00)

### DIFF
--- a/Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml
@@ -5,16 +5,17 @@
 |  * Target layer: 2-DisciplinePhysical
 |  * See design.md for full design context and UPM mapping decisions.
 |  *
-|  * NOTE: Schema reference versions confirmed against iTwin/bis-schemas as of
-|  * 2026-06-19:
-|  *   BisCore 01.00.15 (required by Analytical 01.00.02)
-|  *   Analytical 01.00.02 (actual schema header)
-|  *   DistributionSystems 01.00.03 (actual schema header)
-|  *   AecUnits 01.00.03 (schema name corrected from AECUnits; confirmed against repo)
-|  *   Units 01.00.06 (minimum released version containing u:OHM_M)
-|  *   Formats 01.00.00 (only released version; required for f: alias in custom KOQs)
-|  *   CoreCustomAttributes 01.00.03 (confirmed)
-|  *   BisCustomAttributes 01.00.00 (confirmed)
+|  * Per iTwin/bis-schemas PR #733 review (Alfredo Contreras): this schema now
+|  * EXTENDS the shared PowerSystemResourcesPhysical (psrp) base instead of
+|  * deriving the physical classes directly from bis:PhysicalElement, so electric
+|  * distribution is a sub-domain of the common power-system schema rather than a
+|  * parallel one. Reference versions aligned to psrp 01.00.02's requirements:
+|  *   BisCore 01.00.25 (psrp requirement)
+|  *   Analytical 01.00.02
+|  *   DistributionSystems 01.00.02 (psrp requirement; 01.00.03 is not released)
+|  *   PowerSystemResourcesPhysical 01.00.02 (NEW — shared power-system base)
+|  *   AecUnits 01.00.03 / Units 01.00.06 / Formats 01.00.00
+|  *   CoreCustomAttributes 01.00.04 (psrp requirement) / BisCustomAttributes 01.00.00
 |  *
 |  * NOTE: u:OHM and u:OHM_M confirmed as valid unit typeNames in System/Units.ecschema.xml.
 |  * anlyt:AnalyticalSimulatesSpatialElement confirmed as the correct "analyzes" relationship.
@@ -27,17 +28,18 @@
     displayLabel="Electric Distribution"
     description="BIS domain schema for overhead electric distribution infrastructure including poles, attachments, conductors, structural analysis, and field inspection.">
 
-    <ECSchemaReference name="BisCore"              version="01.00.15" alias="bis"/>
-    <ECSchemaReference name="Analytical"           version="01.00.02" alias="anlyt"/>
-    <ECSchemaReference name="DistributionSystems"  version="01.00.03" alias="dsys"/>
-    <ECSchemaReference name="AecUnits"             version="01.00.03" alias="AECU"/>
-    <ECSchemaReference name="Units"                version="01.00.06" alias="u"/>
-    <ECSchemaReference name="Formats"              version="01.00.00" alias="f"/>
-    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
-    <ECSchemaReference name="BisCustomAttributes"  version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="BisCore"                     version="01.00.25" alias="bis"/>
+    <ECSchemaReference name="Analytical"                  version="01.00.02" alias="anlyt"/>
+    <ECSchemaReference name="DistributionSystems"         version="01.00.02" alias="dsys"/>
+    <ECSchemaReference name="PowerSystemResourcesPhysical" version="01.00.02" alias="psrp"/>
+    <ECSchemaReference name="AecUnits"                    version="01.00.03" alias="AECU"/>
+    <ECSchemaReference name="Units"                       version="01.00.06" alias="u"/>
+    <ECSchemaReference name="Formats"                     version="01.00.00" alias="f"/>
+    <ECSchemaReference name="CoreCustomAttributes"        version="01.00.04" alias="CoreCA"/>
+    <ECSchemaReference name="BisCustomAttributes"         version="01.00.00" alias="bisCA"/>
 
     <ECCustomAttributes>
-        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.04">
             <SupportedUse>NotForProduction</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
@@ -368,7 +370,7 @@
 
     <ECEntityClass typeName="DistributionPole" displayLabel="Distribution Pole"
         description="A placed overhead distribution pole instance. Implements IDistributionElement (structural participant in the distribution system, not a flow element).">
-        <BaseClass>bis:PhysicalElement</BaseClass>
+        <BaseClass>psrp:Structure</BaseClass>
         <BaseClass>dsys:IDistributionElement</BaseClass>
         <ECProperty propertyName="InstallDate"           typeName="dateTime"           displayLabel="Install Date"           description="Not in UPM; sourced from utility GIS"/>
         <ECProperty propertyName="SetDepth"              typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Set Depth"              description="UPM PoleGeometry.set_depth"/>
@@ -401,7 +403,7 @@
 
     <ECEntityClass typeName="PoleAttachment" modifier="Abstract" displayLabel="Pole Attachment"
         description="Abstract base for all pole-mounted attachment types. Subclasses assembled to DistributionPole via DistributionPoleAssemblesAttachments.">
-        <BaseClass>bis:PhysicalElement</BaseClass>
+        <BaseClass>psrp:AuxiliaryEquipment</BaseClass>
         <ECProperty propertyName="AttachmentHeight" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Attachment Height" description="Height above grade; UPM attachment_height.value_si converted"/>
         <ECProperty propertyName="DirectionDegrees" typeName="double" kindOfQuantity="AECU:ANGLE"  displayLabel="Direction"         description="Compass bearing (0=N, 90=E); UPM direction_deg"/>
         <ECProperty propertyName="InstallDate"      typeName="dateTime"                            displayLabel="Install Date"      description="Not in UPM; sourced from GIS"/>
@@ -454,7 +456,7 @@
 
     <ECEntityClass typeName="AnchorAssembly" displayLabel="Anchor Assembly"
         description="A ground-mounted anchor assembly. Associated to the pole via GuyWireConnectsToAnchor but is NOT a PoleAttachment subtype (ground-mounted, not pole-mounted).">
-        <BaseClass>bis:PhysicalElement</BaseClass>
+        <BaseClass>psrp:Foundation</BaseClass>
         <ECProperty propertyName="AnchorType"  typeName="AnchorType" displayLabel="Anchor Type" description="Not in UPM Anchor model; sourced from anchor catalog or metadata"/>
         <ECProperty propertyName="EmbedDepth"  typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Embed Depth" description="Not in UPM Anchor model"/>
         <ECProperty propertyName="SoilClass"   typeName="string"     displayLabel="Soil Class"  description="For grounding analysis use GroundingConfiguration.SoilClass instead"/>
@@ -462,8 +464,7 @@
 
     <ECEntityClass typeName="OverheadConductor" displayLabel="Overhead Conductor"
         description="A conductor span between two poles. Modeled as a standalone element (not nested under Insulator as in UPM). Populated from UPM Insulator.spans; each Span becomes one OverheadConductor.">
-        <BaseClass>bis:PhysicalElement</BaseClass>
-        <BaseClass>dsys:IDistributionFlowElement</BaseClass>
+        <BaseClass>psrp:Equipment</BaseClass>
         <ECProperty propertyName="WireId"               typeName="string"             displayLabel="Wire ID"               description="Wire label (e.g. Phase A, Neutral N); UPM Span.wire_id"/>
         <ECProperty propertyName="FeederId"             typeName="string"             displayLabel="Feeder ID"             description="Feeder/project scope prefix used for conductor cross-pole stitching (e.g. project_line_one); separates the namespace prefix from WireId"/>
         <ECProperty propertyName="WireCode"             typeName="string"             displayLabel="Wire Code"             description="Conductor size label (e.g. ACSR 336, 2/0 ACSR); UPM Span.size"/>
@@ -482,7 +483,6 @@
     <ECEntityClass typeName="DistributionTransformer" displayLabel="Distribution Transformer"
         description="A distribution transformer mounted on a pole. Implements IDistributionFlowElement as it directly facilitates power distribution.">
         <BaseClass>PoleAttachment</BaseClass>
-        <BaseClass>dsys:IDistributionFlowElement</BaseClass>
         <ECProperty propertyName="RatedKva"               typeName="double" kindOfQuantity="AECU:POWER"            displayLabel="Rated kVA"               description="UPM TransformerNameplate.rated_kva; stored as W"/>
         <ECProperty propertyName="CoolingClass"           typeName="TransformerCoolingClass"                       displayLabel="Cooling Class"           description="UPM TransformerNameplate.cooling_class"/>
         <ECProperty propertyName="PrimaryVoltageKv"       typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Primary Voltage"         description="UPM TransformerNameplate.primary_voltage_kv; stored as V"/>

--- a/Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml
@@ -1,0 +1,871 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) 2025 EPC Studio. All rights reserved.
+|  * Proposed BIS domain schema for overhead electric distribution infrastructure.
+|  * Target layer: 2-DisciplinePhysical
+|  * See design.md for full design context and UPM mapping decisions.
+|  *
+|  * NOTE: Schema reference versions confirmed against iTwin/bis-schemas as of
+|  * 2026-06-19:
+|  *   BisCore 01.00.15 (required by Analytical 01.00.02)
+|  *   Analytical 01.00.02 (actual schema header)
+|  *   DistributionSystems 01.00.03 (actual schema header)
+|  *   AecUnits 01.00.03 (schema name corrected from AECUnits; confirmed against repo)
+|  *   Units 01.00.06 (minimum released version containing u:OHM_M)
+|  *   Formats 01.00.00 (only released version; required for f: alias in custom KOQs)
+|  *   CoreCustomAttributes 01.00.03 (confirmed)
+|  *   BisCustomAttributes 01.00.00 (confirmed)
+|  *
+|  * NOTE: u:OHM and u:OHM_M confirmed as valid unit typeNames in System/Units.ecschema.xml.
+|  * anlyt:AnalyticalSimulatesSpatialElement confirmed as the correct "analyzes" relationship.
+|  * bis:InformationContentElement has NotSubclassableInReferencingSchemas; ClearanceViolation
+|  * and PoleInspection correctly use bis:InformationRecordElement.
+|  * Run ec-validator before submitting the upstream PR.
+======================================================================================= -->
+<ECSchema schemaName="ElectricDistribution" alias="edist" version="01.00.00"
+    xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2"
+    displayLabel="Electric Distribution"
+    description="BIS domain schema for overhead electric distribution infrastructure including poles, attachments, conductors, structural analysis, and field inspection.">
+
+    <ECSchemaReference name="BisCore"              version="01.00.15" alias="bis"/>
+    <ECSchemaReference name="Analytical"           version="01.00.02" alias="anlyt"/>
+    <ECSchemaReference name="DistributionSystems"  version="01.00.03" alias="dsys"/>
+    <ECSchemaReference name="AecUnits"             version="01.00.03" alias="AECU"/>
+    <ECSchemaReference name="Units"                version="01.00.06" alias="u"/>
+    <ECSchemaReference name="Formats"              version="01.00.00" alias="f"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECSchemaReference name="BisCustomAttributes"  version="01.00.00" alias="bisCA"/>
+
+    <ECCustomAttributes>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
+            <SupportedUse>NotForProduction</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>DisciplinePhysical</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+
+    <!-- Domain-specific KindOfQuantity not covered by AECUnits.
+         u:OHM = SI ohm (derived unit); u:OHM_M = ohm-metre for soil resistivity.
+         Verify unit alias strings against the BIS Units schema before PR. -->
+    <KindOfQuantity typeName="EDIST_RESISTANCE"   displayLabel="Resistance"       persistenceUnit="u:OHM"   relativeError="0.001" presentationUnits="f:DefaultRealU(4)[u:OHM]"/>
+    <KindOfQuantity typeName="EDIST_RESISTIVITY"  displayLabel="Soil Resistivity"  persistenceUnit="u:OHM_M" relativeError="0.001" presentationUnits="f:DefaultRealU(4)[u:OHM_M]"/>
+
+    <!-- ============================================================
+         ENUMERATIONS
+         ============================================================ -->
+
+    <ECEnumeration typeName="PoleMaterial" backingTypeName="int" isStrict="true"
+        description="Material composition of a distribution pole.">
+        <ECEnumerator name="Wood"       value="0" displayLabel="Wood"/>
+        <ECEnumerator name="Steel"      value="1" displayLabel="Steel"/>
+        <ECEnumerator name="Concrete"   value="2" displayLabel="Concrete"/>
+        <ECEnumerator name="Composite"  value="3" displayLabel="Composite"/>
+        <ECEnumerator name="Fiberglass" value="4" displayLabel="Fiberglass"/>
+    </ECEnumeration>
+
+    <ECEnumeration typeName="PoleConditionRating" backingTypeName="int" isStrict="true"
+        description="Field condition rating for a placed pole instance.">
+        <ECEnumerator name="Good"     value="0" displayLabel="Good"/>
+        <ECEnumerator name="Fair"     value="1" displayLabel="Fair"/>
+        <ECEnumerator name="Poor"     value="2" displayLabel="Poor"/>
+        <ECEnumerator name="Critical" value="3" displayLabel="Critical"/>
+    </ECEnumeration>
+
+    <ECEnumeration typeName="CrossarmMaterial" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Wood"      value="0" displayLabel="Wood"/>
+        <ECEnumerator name="Steel"     value="1" displayLabel="Steel"/>
+        <ECEnumerator name="Fiberglass" value="2" displayLabel="Fiberglass"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: UPM FramingBreakdown.crossarm_structure Literal but adapters
+         may introduce additional values. -->
+    <ECEnumeration typeName="CrossarmSide" backingTypeName="int" isStrict="false"
+        description="Single- or double-arm configuration on a crossarm.">
+        <ECEnumerator name="Single"  value="0" displayLabel="Single"/>
+        <ECEnumerator name="Double"  value="1" displayLabel="Double"/>
+        <ECEnumerator name="Mixed"   value="2" displayLabel="Mixed"/>
+        <ECEnumerator name="Unknown" value="3" displayLabel="Unknown"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: no UPM Literal; connector maps from anchor catalog. -->
+    <ECEnumeration typeName="AnchorType" backingTypeName="int" isStrict="false">
+        <ECEnumerator name="ScrewAuger" value="0" displayLabel="Screw Auger"/>
+        <ECEnumerator name="Expanding"  value="1" displayLabel="Expanding"/>
+        <ECEnumerator name="Concrete"   value="2" displayLabel="Concrete"/>
+        <ECEnumerator name="Rock"       value="3" displayLabel="Rock"/>
+        <ECEnumerator name="StubPole"   value="4" displayLabel="Stub Pole"/>
+        <ECEnumerator name="Deadman"    value="5" displayLabel="Deadman"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: UPM insulator_type is freeform; union across SPIDA, OCalc,
+         PLS-POLE adapters produces these canonical values. Connector maps. -->
+    <ECEnumeration typeName="InsulatorType" backingTypeName="int" isStrict="false">
+        <ECEnumerator name="Pin"     value="0" displayLabel="Pin"/>
+        <ECEnumerator name="Deadend" value="1" displayLabel="Deadend"/>
+        <ECEnumerator name="Clamp"   value="2" displayLabel="Clamp"/>
+        <ECEnumerator name="Bracket" value="3" displayLabel="Bracket"/>
+        <ECEnumerator name="Unknown" value="4" displayLabel="Unknown"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: derived from clearance.py _USAGE_GROUP_FALLBACK_VOLTAGE dict;
+         adapters may emit additional usage groups. -->
+    <ECEnumeration typeName="ConductorUsageGroup" backingTypeName="int" isStrict="false"
+        description="Electrical usage classification of an overhead conductor span.">
+        <ECEnumerator name="Primary"             value="0"  displayLabel="Primary"/>
+        <ECEnumerator name="Secondary"           value="1"  displayLabel="Secondary"/>
+        <ECEnumerator name="Neutral"             value="2"  displayLabel="Neutral"/>
+        <ECEnumerator name="PrimaryNeutral"      value="3"  displayLabel="Primary Neutral"/>
+        <ECEnumerator name="Streetlight"         value="4"  displayLabel="Streetlight"/>
+        <ECEnumerator name="Communication"       value="5"  displayLabel="Communication"/>
+        <ECEnumerator name="CommunicationBundle" value="6"  displayLabel="Communication Bundle"/>
+        <ECEnumerator name="CommunicationService" value="7" displayLabel="Communication Service"/>
+        <ECEnumerator name="SecondaryDrop"       value="8"  displayLabel="Secondary Drop"/>
+        <ECEnumerator name="StaticWire"          value="9"  displayLabel="Static Wire"/>
+        <ECEnumerator name="GroundWire"          value="10" displayLabel="Ground Wire"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: closed set of sag analysis temperature/load states. -->
+    <ECEnumeration typeName="ConductorSagConditionType" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Initial"  value="0" displayLabel="Initial"/>
+        <ECEnumerator name="Final"    value="1" displayLabel="Final"/>
+        <ECEnumerator name="Loaded"   value="2" displayLabel="Loaded"/>
+        <ECEnumerator name="FullIce"  value="3" displayLabel="Full Ice"/>
+        <ECEnumerator name="Extreme"  value="4" displayLabel="Extreme"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: guy grade from metadata; field values vary by adapter. -->
+    <ECEnumeration typeName="GuyGrade" backingTypeName="int" isStrict="false">
+        <ECEnumerator name="EHS"           value="0" displayLabel="Extra High Strength"/>
+        <ECEnumerator name="HS"            value="1" displayLabel="High Strength"/>
+        <ECEnumerator name="SiloGuy"       value="2" displayLabel="Silo Guy"/>
+        <ECEnumerator name="SoftDrawCopper" value="3" displayLabel="Soft Draw Copper"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: no UPM Literal; inferred from program name. -->
+    <ECEnumeration typeName="InspectionMethod" backingTypeName="int" isStrict="false">
+        <ECEnumerator name="Visual"      value="0" displayLabel="Visual"/>
+        <ECEnumerator name="Sounding"    value="1" displayLabel="Sounding"/>
+        <ECEnumerator name="Boring"      value="2" displayLabel="Boring"/>
+        <ECEnumerator name="ChemicalTest" value="3" displayLabel="Chemical Test"/>
+        <ECEnumerator name="Ultrasonic"  value="4" displayLabel="Ultrasonic"/>
+        <ECEnumerator name="PoleTreat"   value="5" displayLabel="Pole Treat"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: matches UPM Literal["pass","marginal","fail"] on
+         InspectionSection.pole_test_result and .verdict. -->
+    <ECEnumeration typeName="InspectionVerdict" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Pass"     value="0" displayLabel="Pass"/>
+        <ECEnumerator name="Marginal" value="1" displayLabel="Marginal"/>
+        <ECEnumerator name="Fail"     value="2" displayLabel="Fail"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: no UPM enum; derived from visual_findings narrative. -->
+    <ECEnumeration typeName="FindingType" backingTypeName="int" isStrict="false">
+        <ECEnumerator name="SurfaceRot"        value="0" displayLabel="Surface Rot"/>
+        <ECEnumerator name="InteriorRot"       value="1" displayLabel="Interior Rot"/>
+        <ECEnumerator name="Crack"             value="2" displayLabel="Crack"/>
+        <ECEnumerator name="Woodpecker"        value="3" displayLabel="Woodpecker Damage"/>
+        <ECEnumerator name="PhysicalDamage"    value="4" displayLabel="Physical Damage"/>
+        <ECEnumerator name="LeaningExcessive"  value="5" displayLabel="Excessive Lean"/>
+        <ECEnumerator name="HardwareDamaged"   value="6" displayLabel="Hardware Damaged"/>
+        <ECEnumerator name="AttachmentLoose"   value="7" displayLabel="Attachment Loose"/>
+        <ECEnumerator name="Other"             value="8" displayLabel="Other"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: matches UPM Literal["info","warning","error","critical"]
+         on ClearanceFinding.severity. -->
+    <ECEnumeration typeName="FindingSeverity" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Info"     value="0" displayLabel="Info"/>
+        <ECEnumerator name="Warning"  value="1" displayLabel="Warning"/>
+        <ECEnumerator name="Error"    value="2" displayLabel="Error"/>
+        <ECEnumerator name="Critical" value="3" displayLabel="Critical"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: matches UPM Literal["vertical","horizontal","radial","unknown"]
+         on ClearanceRelationship.dimension. -->
+    <ECEnumeration typeName="ClearanceDimension" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Vertical"   value="0" displayLabel="Vertical"/>
+        <ECEnumerator name="Horizontal" value="1" displayLabel="Horizontal"/>
+        <ECEnumerator name="Radial"     value="2" displayLabel="Radial"/>
+        <ECEnumerator name="Unknown"    value="3" displayLabel="Unknown"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: same value set as FindingSeverity, kept separate for
+         schema clarity (clearance vs. inspection finding contexts differ). -->
+    <ECEnumeration typeName="ClearanceSeverity" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="Info"     value="0" displayLabel="Info"/>
+        <ECEnumerator name="Warning"  value="1" displayLabel="Warning"/>
+        <ECEnumerator name="Error"    value="2" displayLabel="Error"/>
+        <ECEnumerator name="Critical" value="3" displayLabel="Critical"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: Custom and RUS1724E200 may expand; NESC/GO95 are stable. -->
+    <ECEnumeration typeName="AnalysisCode" backingTypeName="int" isStrict="false"
+        description="Structural loading code applied in an analysis. Orthogonal to grade and district.">
+        <ECEnumerator name="NESC"        value="0" displayLabel="NESC"/>
+        <ECEnumerator name="GO95"        value="1" displayLabel="GO 95"/>
+        <ECEnumerator name="RUS1724E200" value="2" displayLabel="RUS Bulletin 1724E-200"/>
+        <ECEnumerator name="Custom"      value="3" displayLabel="Custom"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM NescGrade = Literal["B","C","C_WITH_CROSSINGS","N"]
+         from domain/loading/grades.py. -->
+    <ECEnumeration typeName="NescGrade" backingTypeName="int" isStrict="true"
+        description="NESC construction grade. Orthogonal to AnalysisCode and NescDistrict.">
+        <ECEnumerator name="B"               value="0" displayLabel="Grade B"/>
+        <ECEnumerator name="C"               value="1" displayLabel="Grade C"/>
+        <ECEnumerator name="C_WITH_CROSSINGS" value="2" displayLabel="Grade C with Crossings"/>
+        <ECEnumerator name="N"               value="3" displayLabel="Grade N"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM GO95Grade = Literal["A","B","C","F"]
+         from domain/loading/grades.py. -->
+    <ECEnumeration typeName="GO95Grade" backingTypeName="int" isStrict="true"
+        description="GO 95 construction grade. Orthogonal to AnalysisCode and GO95Zone.">
+        <ECEnumerator name="A" value="0" displayLabel="Grade A"/>
+        <ECEnumerator name="B" value="1" displayLabel="Grade B"/>
+        <ECEnumerator name="C" value="2" displayLabel="Grade C"/>
+        <ECEnumerator name="F" value="3" displayLabel="Grade F"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM NescDistrict from domain/loading/zones.py. -->
+    <ECEnumeration typeName="NescDistrict" backingTypeName="int" isStrict="true"
+        description="NESC Rule 250B geographic loading district.">
+        <ECEnumerator name="Heavy"                   value="0" displayLabel="Heavy"/>
+        <ECEnumerator name="Medium"                  value="1" displayLabel="Medium"/>
+        <ECEnumerator name="Light"                   value="2" displayLabel="Light"/>
+        <ECEnumerator name="WarmIslandUnder9000Ft"   value="3" displayLabel="Warm Island Under 9000 ft"/>
+        <ECEnumerator name="WarmIslandOver9000Ft"    value="4" displayLabel="Warm Island Over 9000 ft"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM GO95Zone = Literal["HEAVY","LIGHT"]
+         from domain/loading/zones.py. -->
+    <ECEnumeration typeName="GO95Zone" backingTypeName="int" isStrict="true"
+        description="GO 95 Rule 43 elevation-based loading zone.">
+        <ECEnumerator name="Heavy" value="0" displayLabel="Heavy"/>
+        <ECEnumerator name="Light" value="1" displayLabel="Light"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM InstallType = Literal["install","replacement"] in grades.py.
+         load_case_builder.py uses "NEW"/"REPLACEMENT" — connector maps both vocabularies:
+         "install" | "NEW" -> Install; "replacement" | "REPLACEMENT" -> Replacement. -->
+    <ECEnumeration typeName="ConstructionType" backingTypeName="int" isStrict="true"
+        description="Whether the analysis is for a new installation or a replacement pole.">
+        <ECEnumerator name="Install"     value="0" displayLabel="New Installation"/>
+        <ECEnumerator name="Replacement" value="1" displayLabel="Replacement"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM TransformerNameplate.cooling_class
+         Literal["ONAN","ONAF","ODAF"]. -->
+    <ECEnumeration typeName="TransformerCoolingClass" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="ONAN" value="0" displayLabel="ONAN"/>
+        <ECEnumerator name="ONAF" value="1" displayLabel="ONAF"/>
+        <ECEnumerator name="ODAF" value="2" displayLabel="ODAF"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM TransformerNameplate.phase_config
+         Literal["single_phase","three_phase"]. -->
+    <ECEnumeration typeName="TransformerPhaseConfig" backingTypeName="int" isStrict="true">
+        <ECEnumerator name="SinglePhase" value="0" displayLabel="Single Phase"/>
+        <ECEnumerator name="ThreePhase"  value="1" displayLabel="Three Phase"/>
+    </ECEnumeration>
+
+    <!-- isStrict=false: UPM Equipment.equipment_type is freeform; union across
+         SPIDA, OCalc, PLS-POLE adapters. Connector maps adapter strings to this enum. -->
+    <ECEnumeration typeName="EquipmentType" backingTypeName="int" isStrict="false"
+        description="Classification of pole-mounted equipment other than distribution transformers.">
+        <ECEnumerator name="Transformer"       value="0"  displayLabel="Transformer"/>
+        <ECEnumerator name="StreetLight"       value="1"  displayLabel="Street Light"/>
+        <ECEnumerator name="CutoutArrestor"    value="2"  displayLabel="Cutout / Arrester"/>
+        <ECEnumerator name="Riser"             value="3"  displayLabel="Riser"/>
+        <ECEnumerator name="TerminationBracket" value="4" displayLabel="Termination Bracket"/>
+        <ECEnumerator name="Capacitor"         value="5"  displayLabel="Capacitor"/>
+        <ECEnumerator name="Regulator"         value="6"  displayLabel="Regulator"/>
+        <ECEnumerator name="Recloser"          value="7"  displayLabel="Recloser"/>
+        <ECEnumerator name="Switch"            value="8"  displayLabel="Switch"/>
+        <ECEnumerator name="Arrester"          value="9"  displayLabel="Arrester"/>
+        <ECEnumerator name="Communication"     value="10" displayLabel="Communication"/>
+        <ECEnumerator name="Catv"              value="11" displayLabel="CATV"/>
+        <ECEnumerator name="Telco"             value="12" displayLabel="Telco"/>
+        <ECEnumerator name="Fiber"             value="13" displayLabel="Fiber"/>
+    </ECEnumeration>
+
+    <!-- isStrict=true: UPM EnvironmentalDesignContext.fire_threat_zone
+         Literal["none","tier_2","tier_3"]. -->
+    <ECEnumeration typeName="FireThreatZone" backingTypeName="int" isStrict="true"
+        description="CPUC fire threat zone classification for a pole location.">
+        <ECEnumerator name="None"  value="0" displayLabel="None"/>
+        <ECEnumerator name="Tier2" value="1" displayLabel="Tier 2"/>
+        <ECEnumerator name="Tier3" value="2" displayLabel="Tier 3"/>
+    </ECEnumeration>
+
+    <!-- ============================================================
+         DEFINITION ELEMENTS
+         ============================================================ -->
+
+    <ECEntityClass typeName="AvianZone" displayLabel="Avian Zone"
+        description="A utility- or regulatory-designated avian protection zone. Poles reference zones via edist:PoleIsInAvianZone (many-to-many). Connector upserts by ZoneId then inserts one relationship per entry in AvianContext.in_avian_zones.">
+        <BaseClass>bis:DefinitionElement</BaseClass>
+        <ECProperty propertyName="ZoneId"    typeName="string" displayLabel="Zone ID"   description="Utility or regulatory zone identifier (e.g. PGE_AVIAN_ZONE_5)"/>
+        <ECProperty propertyName="ZoneName"  typeName="string" displayLabel="Zone Name"/>
+        <ECProperty propertyName="Authority" typeName="string" displayLabel="Authority"  description="Designating body (e.g. PGE, CPUC)"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="LoadCaseDefinition" displayLabel="Load Case Definition"
+        description="Reusable loading code configuration. One definition per NESC/GO95 grade+district+construction combination. Referenced by PoleLoadingResult.LoadCaseId.">
+        <BaseClass>bis:DefinitionElement</BaseClass>
+        <ECProperty propertyName="AnalysisCode"          typeName="AnalysisCode"    displayLabel="Analysis Code"/>
+        <ECProperty propertyName="NescGrade"             typeName="NescGrade"       displayLabel="NESC Grade"            description="Null when AnalysisCode is GO95"/>
+        <ECProperty propertyName="GO95Grade"             typeName="GO95Grade"       displayLabel="GO 95 Grade"           description="Null when AnalysisCode is NESC"/>
+        <ECProperty propertyName="NescDistrict"          typeName="NescDistrict"    displayLabel="NESC Loading District" description="Null when AnalysisCode is GO95"/>
+        <ECProperty propertyName="GO95Zone"              typeName="GO95Zone"        displayLabel="GO 95 Loading Zone"    description="Null when AnalysisCode is NESC"/>
+        <ECProperty propertyName="ConstructionType"      typeName="ConstructionType" displayLabel="Construction Type"/>
+        <ECProperty propertyName="NescRevision"          typeName="string"          displayLabel="NESC Revision"         description="e.g. NESC 2023, NESC 2012-2017"/>
+        <ECProperty propertyName="GO95Revision"          typeName="string"          displayLabel="GO 95 Revision"        description="e.g. GO95 01-2020"/>
+        <ECProperty propertyName="WindSpeed"             typeName="double" kindOfQuantity="AECU:VELOCITY"    displayLabel="Wind Speed"    description="Design wind speed at conductor height"/>
+        <ECProperty propertyName="IceThickness"          typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Ice Thickness" description="Radial ice accretion"/>
+        <ECProperty propertyName="WindOnIce"             typeName="boolean"         displayLabel="Wind on Ice"/>
+        <ECProperty propertyName="TemperatureLow"        typeName="double" kindOfQuantity="AECU:TEMPERATURE" displayLabel="Low Temperature"/>
+        <ECProperty propertyName="TemperatureHigh"       typeName="double" kindOfQuantity="AECU:TEMPERATURE" displayLabel="High Temperature"/>
+        <ECProperty propertyName="OverloadCapacityFactor" typeName="double"         displayLabel="Overload Capacity Factor" description="Dimensionless factor applied to allowable stress"/>
+        <ECProperty propertyName="WindLoadFactor"        typeName="double"          displayLabel="Wind Load Factor"         description="LRFD wind load factor; dimensionless"/>
+        <ECProperty propertyName="Description"           typeName="string"          displayLabel="Description"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="ClearanceRequirement" displayLabel="Clearance Requirement"
+        description="Reusable clearance rule profile definition. Referenced by ClearanceCheck.ProfileRef.">
+        <BaseClass>bis:DefinitionElement</BaseClass>
+        <ECProperty propertyName="RuleProfile"       typeName="string"      displayLabel="Rule Profile"    description="e.g. CPUC_GO95, NESC_2023"/>
+        <ECProperty propertyName="RuleVersion"       typeName="string"      displayLabel="Rule Version"    description="e.g. 01-2020"/>
+        <ECProperty propertyName="TableId"           typeName="string"      displayLabel="Table ID"        description="e.g. Table 1, Table 232-1"/>
+        <ECProperty propertyName="ApplicableCode"    typeName="AnalysisCode" displayLabel="Applicable Code"/>
+        <ECProperty propertyName="StandardSection"   typeName="string"      displayLabel="Standard Section" description="e.g. NESC Rule 232"/>
+        <ECProperty propertyName="RequiredClearance" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Required Clearance"/>
+        <ECProperty propertyName="ConditionClass"    typeName="string"      displayLabel="Condition Class"  description="Normal, Loaded, or Extreme"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         PHYSICAL TYPES
+         ============================================================ -->
+
+    <ECEntityClass typeName="DistributionPoleType" displayLabel="Distribution Pole Type"
+        description="Catalog/specification record for a class of distribution pole (species, class, height). Shared across multiple DistributionPole instances via DistributionPoleIsOfType.">
+        <BaseClass>bis:PhysicalType</BaseClass>
+        <ECProperty propertyName="PoleClass"                    typeName="string"       displayLabel="Pole Class"                    description="ANSI/NESC class (1, 2, H1, H2, etc.)"/>
+        <ECProperty propertyName="ManufacturedHeight"           typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Manufactured Height"           description="Nominal pole length; UPM PoleGeometry.manufactured_height"/>
+        <ECProperty propertyName="PoleMaterial"                 typeName="PoleMaterial" displayLabel="Pole Material"                 description="Inferred from UPM PoleGeometry.pole_species"/>
+        <ECProperty propertyName="PoleSpecies"                  typeName="string"       displayLabel="Pole Species"                  description="Freeform (WRC, DF, SYP, GL, Steel, Concrete)"/>
+        <ECProperty propertyName="NominalGroundlineStrength"    typeName="double" kindOfQuantity="AECU:MOMENT"       displayLabel="Nominal Groundline Strength"    description="ANSI O5.1 tabulated groundline bending strength"/>
+        <ECProperty propertyName="NominalTipCircumference"      typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Nominal Tip Circumference"      description="UPM PoleGeometry.pole_top_circumference"/>
+        <ECProperty propertyName="NominalGroundlineCircumference" typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Nominal Groundline Circumference" description="Derived from ANSI O5.1 class+height+species table"/>
+        <ECProperty propertyName="TreatmentType"                typeName="string"       displayLabel="Treatment Type"                description="Preservative treatment (CCA, Penta, copper_naphthenate)"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         PHYSICAL ELEMENTS
+         ============================================================ -->
+
+    <ECEntityClass typeName="DistributionPole" displayLabel="Distribution Pole"
+        description="A placed overhead distribution pole instance. Implements IDistributionElement (structural participant in the distribution system, not a flow element).">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <BaseClass>dsys:IDistributionElement</BaseClass>
+        <ECProperty propertyName="InstallDate"           typeName="dateTime"           displayLabel="Install Date"           description="Not in UPM; sourced from utility GIS"/>
+        <ECProperty propertyName="SetDepth"              typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Set Depth"              description="UPM PoleGeometry.set_depth"/>
+        <ECProperty propertyName="GroundlineCircumference" typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Groundline Circumference" description="Measured; UPM PoleGeometry.ground_line_circumference"/>
+        <ECProperty propertyName="PoleTipCircumference"  typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Pole Tip Circumference"  description="Measured; UPM PoleGeometry.pole_top_circumference"/>
+        <ECProperty propertyName="Elevation"             typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Elevation"              description="WGS84 ellipsoid elevation; UPM PoleGeometry.elevation_m"/>
+        <ECProperty propertyName="HeadingDegrees"        typeName="double" kindOfQuantity="AECU:ANGLE"        displayLabel="Heading"                description="Compass bearing (0=N, 90=E); UPM PoleGeometry.heading_deg"/>
+        <ECProperty propertyName="GpsAccuracyMeters"     typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="GPS Accuracy"           description="GPS horizontal uncertainty; UPM PoleGeometry.gps_accuracy_m"/>
+        <ECProperty propertyName="ConditionRating"       typeName="PoleConditionRating" displayLabel="Condition Rating"      description="Not a direct UPM field; derived from inspection verdict"/>
+        <ECProperty propertyName="MapNumber"             typeName="string"              displayLabel="Map Number"            description="Utility GIS map label; UPM PoleIdentity.pole_id"/>
+        <ECProperty propertyName="StructureNumber"       typeName="string"              displayLabel="Structure Number"      description="Utility asset ID; UPM PoleIdentity.structure_id"/>
+        <ECProperty propertyName="StructureName"         typeName="string"              displayLabel="Structure Name"        description="UPM PoleIdentity.structure_name"/>
+        <ECProperty propertyName="PoleOwner"             typeName="string"              displayLabel="Pole Owner"            description="Owner of record; not in UPM — sourced from GIS"/>
+        <ECProperty propertyName="JointUse"              typeName="boolean"             displayLabel="Joint Use"             description="Whether joint use attachments are present"/>
+        <ECProperty propertyName="FramingFaultCount"     typeName="int"                 displayLabel="Framing Fault Count"   description="Count of framing fault findings from validate_framing; UPM framing.framing_fault_findings[]"/>
+        <!-- Verdict summary — mirrored from AnalyticalModel for BIC Data Visualization coloring without joining to the analytical model -->
+        <ECProperty propertyName="LoadingStatus"         typeName="string"              displayLabel="Loading Status"        description="PASS / FAIL / MARGINAL; from verdicts.loading.status"/>
+        <ECProperty propertyName="UtilizationRatio"      typeName="double"              displayLabel="Utilization Ratio"     description="Governing utilization ratio (0–1+); from verdicts.loading.percent_used / 100"/>
+        <ECProperty propertyName="ClearanceStatus"       typeName="string"              displayLabel="Clearance Status"      description="PASS / FAIL / MARGINAL; from verdicts.clearance.status"/>
+        <ECProperty propertyName="ClearanceViolationCount" typeName="int"               displayLabel="Clearance Violation Count" description="Total clearance violations; from verdicts.clearance.violation_count"/>
+        <!-- Component-level safety factors — exposes per-component SF breakdown for BIC coloring by failure mode -->
+        <ECProperty propertyName="BendingSafetyFactor"   typeName="double"              displayLabel="Bending Safety Factor"    description="Computed bending SF; from verdicts.loading.bending_sf"/>
+        <ECProperty propertyName="BendingRequiredSF"     typeName="double"              displayLabel="Bending Required SF"      description="Code-required bending SF; from verdicts.loading.bending_req_sf"/>
+        <ECProperty propertyName="BucklingSafetyFactor"  typeName="double"              displayLabel="Buckling Safety Factor"   description="Computed buckling SF; from verdicts.loading.buckling_sf"/>
+        <ECProperty propertyName="BucklingRequiredSF"    typeName="double"              displayLabel="Buckling Required SF"     description="Code-required buckling SF; from verdicts.loading.buckling_req_sf"/>
+        <ECProperty propertyName="FoundationSafetyFactor" typeName="double"             displayLabel="Foundation Safety Factor" description="Computed foundation overturning SF; from verdicts.loading.foundation_sf"/>
+        <ECProperty propertyName="FoundationRequiredSF"  typeName="double"              displayLabel="Foundation Required SF"   description="Code-required foundation SF; from verdicts.loading.foundation_req_sf"/>
+        <ECProperty propertyName="GoverningComponent"    typeName="string"              displayLabel="Governing Component"      description="Failure mode with lowest SF margin; from verdicts.loading.worst_component"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="PoleAttachment" modifier="Abstract" displayLabel="Pole Attachment"
+        description="Abstract base for all pole-mounted attachment types. Subclasses assembled to DistributionPole via DistributionPoleAssemblesAttachments.">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECProperty propertyName="AttachmentHeight" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Attachment Height" description="Height above grade; UPM attachment_height.value_si converted"/>
+        <ECProperty propertyName="DirectionDegrees" typeName="double" kindOfQuantity="AECU:ANGLE"  displayLabel="Direction"         description="Compass bearing (0=N, 90=E); UPM direction_deg"/>
+        <ECProperty propertyName="InstallDate"      typeName="dateTime"                            displayLabel="Install Date"      description="Not in UPM; sourced from GIS"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="Crossarm" displayLabel="Crossarm"
+        description="A crossarm mounted on a distribution pole. Insulators are assembled as children via PhysicalElementAssemblesElements; Insulator.CrossarmId preserves the UPM crossarm_id for external reference.">
+        <BaseClass>PoleAttachment</BaseClass>
+        <ECProperty propertyName="CrossarmType" typeName="string"       displayLabel="Crossarm Type" description="Freeform; e.g. Wood - 8 ft Double; UPM Crossarm.crossarm_type"/>
+        <ECProperty propertyName="Offset"       typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Offset"       description="Horizontal distance from pole center; UPM Crossarm.offset"/>
+        <ECProperty propertyName="ArmSide"      typeName="CrossarmSide" displayLabel="Arm Side"    description="UPM Crossarm.side / FramingBreakdown.crossarm_structure"/>
+        <ECProperty propertyName="ArmLength"    typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Arm Length"   description="Not a direct UPM field; inferred from span geometry or catalog"/>
+        <ECProperty propertyName="ArmMaterial"  typeName="CrossarmMaterial" displayLabel="Arm Material" description="Not in UPM; inferred from crossarm_type string"/>
+        <ECProperty propertyName="ArmSize"      typeName="string"       displayLabel="Arm Size"     description="e.g. 3.5x4.5; not in UPM"/>
+        <ECProperty propertyName="BraceType"    typeName="string"       displayLabel="Brace Type"   description="None, Single, Double; not in UPM"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="Insulator" displayLabel="Insulator"
+        description="An insulator position on a pole or crossarm. Conductor spans attached to this insulator are modeled as standalone OverheadConductor elements.">
+        <BaseClass>PoleAttachment</BaseClass>
+        <ECProperty propertyName="InsulatorType"      typeName="InsulatorType" displayLabel="Insulator Type"    description="UPM Insulator.insulator_type; freeform mapped to enum"/>
+        <ECProperty propertyName="CrossarmId"         typeName="string"        displayLabel="Crossarm ID"       description="External reference to parent crossarm; null for pole-mounted; UPM Insulator.crossarm_id"/>
+        <ECProperty propertyName="VerticalOffset"     typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Vertical Offset"   description="UPM Insulator.vertical_offset"/>
+        <ECProperty propertyName="HorizontalOffset"   typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Horizontal Offset" description="UPM Insulator.horizontal_offset"/>
+        <ECProperty propertyName="VoltageRating"      typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Voltage Rating"  description="Not in UPM; sourced from wire catalog"/>
+        <ECProperty propertyName="PhaseDesignation"   typeName="string"        displayLabel="Phase Designation" description="A, B, C, N; not in UPM"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="SpanGuy" displayLabel="Span Guy"
+        description="A guy wire running pole-to-pole (not to a ground anchor). SPIDA models these as paired structures sharing ExternalId; each end has one SpanGuy entry.">
+        <BaseClass>PoleAttachment</BaseClass>
+        <ECProperty propertyName="ExternalId" typeName="string" displayLabel="External ID" description="Shared ID across paired poles for renderer reconstruction; UPM SpanGuy.external_id"/>
+        <ECProperty propertyName="Distance"   typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Distance"    description="Horizontal wire length; UPM SpanGuy.distance"/>
+        <ECProperty propertyName="GuySize"    typeName="string" displayLabel="Guy Size"    description="Freeform; e.g. 3/8 EHS; UPM SpanGuy.size"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="GuyWire" displayLabel="Guy Wire"
+        description="A ground-anchored guy wire attached to a distribution pole. Connected to AnchorAssembly via GuyWireConnectsToAnchor.">
+        <BaseClass>PoleAttachment</BaseClass>
+        <ECProperty propertyName="AnchorId"         typeName="string"    displayLabel="Anchor ID"         description="External reference to connected anchor; UPM Guy.anchor_id"/>
+        <ECProperty propertyName="GuyType"          typeName="string"    displayLabel="Guy Type"          description="Freeform; e.g. Down Guy; UPM Guy.guy_type"/>
+        <ECProperty propertyName="GuySize"          typeName="string"    displayLabel="Guy Size"          description="e.g. 3/8 EHS, 7/16 HS; from Guy.metadata"/>
+        <ECProperty propertyName="GuyGrade"         typeName="GuyGrade"  displayLabel="Guy Grade"         description="From Guy.metadata; promoted from UPM metadata dict"/>
+        <ECProperty propertyName="GuyStrand"        typeName="string"    displayLabel="Guy Strand"        description="e.g. 7x; from Guy.metadata"/>
+        <ECProperty propertyName="LeadDistance"     typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Lead Distance"     description="Horizontal distance to anchor; from Guy.metadata"/>
+        <ECProperty propertyName="DownAngle"        typeName="double" kindOfQuantity="AECU:ANGLE"  displayLabel="Down Angle"        description="Angle from horizontal; from Guy.metadata"/>
+        <ECProperty propertyName="PreloadedTension" typeName="double" kindOfQuantity="AECU:FORCE"  displayLabel="Preloaded Tension" description="From Guy.metadata"/>
+        <ECProperty propertyName="AllowableTension" typeName="double" kindOfQuantity="AECU:FORCE"  displayLabel="Allowable Tension" description="From Guy.metadata"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="AnchorAssembly" displayLabel="Anchor Assembly"
+        description="A ground-mounted anchor assembly. Associated to the pole via GuyWireConnectsToAnchor but is NOT a PoleAttachment subtype (ground-mounted, not pole-mounted).">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECProperty propertyName="AnchorType"  typeName="AnchorType" displayLabel="Anchor Type" description="Not in UPM Anchor model; sourced from anchor catalog or metadata"/>
+        <ECProperty propertyName="EmbedDepth"  typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Embed Depth" description="Not in UPM Anchor model"/>
+        <ECProperty propertyName="SoilClass"   typeName="string"     displayLabel="Soil Class"  description="For grounding analysis use GroundingConfiguration.SoilClass instead"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="OverheadConductor" displayLabel="Overhead Conductor"
+        description="A conductor span between two poles. Modeled as a standalone element (not nested under Insulator as in UPM). Populated from UPM Insulator.spans; each Span becomes one OverheadConductor.">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <BaseClass>dsys:IDistributionFlowElement</BaseClass>
+        <ECProperty propertyName="WireId"               typeName="string"             displayLabel="Wire ID"               description="Wire label (e.g. Phase A, Neutral N); UPM Span.wire_id"/>
+        <ECProperty propertyName="FeederId"             typeName="string"             displayLabel="Feeder ID"             description="Feeder/project scope prefix used for conductor cross-pole stitching (e.g. project_line_one); separates the namespace prefix from WireId"/>
+        <ECProperty propertyName="WireCode"             typeName="string"             displayLabel="Wire Code"             description="Conductor size label (e.g. ACSR 336, 2/0 ACSR); UPM Span.size"/>
+        <ECProperty propertyName="ConductorUsageGroup"  typeName="ConductorUsageGroup" displayLabel="Conductor Usage Group" description="UPM Attachment.attachment_type or span metadata"/>
+        <ECProperty propertyName="NominalVoltage"       typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Nominal Voltage"       description="UPM Attachment.voltage_v"/>
+        <ECProperty propertyName="SpanLength"           typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Span Length"           description="Horizontal span length; UPM Span.length"/>
+        <ECProperty propertyName="AttachmentHeightNear" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Attachment Height (Near)" description="Height at near pole from parent Insulator.attachment_height"/>
+        <ECProperty propertyName="AttachmentHeightFar"  typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Attachment Height (Far)"  description="Height at far-pole insulator"/>
+        <ECProperty propertyName="RotationDegrees"      typeName="double" kindOfQuantity="AECU:ANGLE"  displayLabel="Rotation"              description="Compass bearing from near pole; UPM Span.rotation_deg"/>
+        <ECProperty propertyName="EndpointType"         typeName="string"             displayLabel="Endpoint Type"         description="PREVIOUS_POLE, OTHER_POLE, etc.; UPM Span.endpoint_type"/>
+        <ECProperty propertyName="IsInsulated"          typeName="boolean"            displayLabel="Is Insulated"          description="Not in UPM"/>
+        <ECProperty propertyName="CoverType"            typeName="string"             displayLabel="Cover Type"            description="Tree wire, bare, spacer; not in UPM"/>
+        <ECProperty propertyName="TensionGroup"         typeName="string"             displayLabel="Tension Group"         description="full or slack; UPM Span.metadata.tension_type"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="DistributionTransformer" displayLabel="Distribution Transformer"
+        description="A distribution transformer mounted on a pole. Implements IDistributionFlowElement as it directly facilitates power distribution.">
+        <BaseClass>PoleAttachment</BaseClass>
+        <BaseClass>dsys:IDistributionFlowElement</BaseClass>
+        <ECProperty propertyName="RatedKva"               typeName="double" kindOfQuantity="AECU:POWER"            displayLabel="Rated kVA"               description="UPM TransformerNameplate.rated_kva; stored as W"/>
+        <ECProperty propertyName="CoolingClass"           typeName="TransformerCoolingClass"                       displayLabel="Cooling Class"           description="UPM TransformerNameplate.cooling_class"/>
+        <ECProperty propertyName="PrimaryVoltageKv"       typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Primary Voltage"         description="UPM TransformerNameplate.primary_voltage_kv; stored as V"/>
+        <ECProperty propertyName="SecondaryVoltageV"      typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Secondary Voltage"       description="UPM TransformerNameplate.secondary_voltage_v; stored as V"/>
+        <ECProperty propertyName="PhaseConfig"            typeName="TransformerPhaseConfig"                        displayLabel="Phase Configuration"     description="UPM TransformerNameplate.phase_config"/>
+        <ECProperty propertyName="ConnectionType"         typeName="string"                                        displayLabel="Connection Type"         description="Freeform; e.g. Delta-Wye; UPM TransformerNameplate.connection_type"/>
+        <ECProperty propertyName="LossRatioR"             typeName="double"                                        displayLabel="Loss Ratio R"            description="PCC/PNL ratio; IEEE C57.91 thermal model; UPM TransformerNameplate.loss_ratio_R"/>
+        <ECProperty propertyName="ActualLoadKva"          typeName="double" kindOfQuantity="AECU:POWER"            displayLabel="Actual Load kVA"         description="Measured or SCADA load; UPM TransformerNameplate.actual_load_kva; stored as W"/>
+        <ECProperty propertyName="RatedTopOilRiseC"       typeName="double" kindOfQuantity="AECU:TEMPERATURE"      displayLabel="Rated Top Oil Rise"      description="IEEE C57.91 thermal parameter; UPM TransformerNameplate.rated_top_oil_rise_c; stored as K"/>
+        <ECProperty propertyName="RatedHottestSpotRiseC"  typeName="double" kindOfQuantity="AECU:TEMPERATURE"      displayLabel="Rated Hottest Spot Rise" description="IEEE C57.91 thermal parameter; UPM TransformerNameplate.rated_hottest_spot_rise_c; stored as K"/>
+        <ECProperty propertyName="EquipmentSize"          typeName="string"                                        displayLabel="Equipment Size"          description="Freeform size label; UPM Equipment.equipment_size"/>
+        <ECProperty propertyName="BottomHeight"           typeName="double" kindOfQuantity="AECU:LENGTH"           displayLabel="Bottom Height"           description="Lower edge height above grade; UPM Equipment.bottom_height"/>
+        <ECProperty propertyName="SerialNumber"           typeName="string"                                        displayLabel="Serial Number"           description="Not in UPM"/>
+        <ECProperty propertyName="ServiceNetworkId"       typeName="string"                                        displayLabel="Service Network ID"      description="Interim placeholder for UPM ServiceNetworkRef.network_id. Upgrade to a relationship when the Universal Service Model BIS schema is available."/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="PoleEquipment" displayLabel="Pole Equipment"
+        description="General pole-mounted equipment other than distribution transformers (street lights, capacitors, regulators, reclosers, switches, cutouts, arresters, risers, communication equipment).">
+        <BaseClass>PoleAttachment</BaseClass>
+        <ECProperty propertyName="EquipmentType" typeName="EquipmentType" displayLabel="Equipment Type" description="UPM Equipment.equipment_type; freeform mapped to enum"/>
+        <ECProperty propertyName="EquipmentSize" typeName="string"        displayLabel="Equipment Size" description="UPM Equipment.equipment_size"/>
+        <ECProperty propertyName="BottomHeight"  typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Bottom Height" description="Lower edge height above grade; UPM Equipment.bottom_height"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         ANALYTICAL ELEMENTS
+         ============================================================ -->
+
+    <ECEntityClass typeName="PoleLoadingAnalysis" displayLabel="Pole Loading Analysis"
+        description="One structural analysis run for a distribution pole. Lives in an AnalyticalModel. Per-load-case results are PoleLoadingResult aspects. BIS-only: no UPM dataclass counterpart.">
+        <BaseClass>anlyt:AnalyticalElement</BaseClass>
+        <ECProperty propertyName="AnalysisDate"              typeName="dateTime" displayLabel="Analysis Date"/>
+        <ECProperty propertyName="AnalysisSoftware"          typeName="string"   displayLabel="Analysis Software"         description="SPIDAcalc, O-Calc Pro, PLS-POLE, EPC Studio"/>
+        <ECProperty propertyName="AnalysisSoftwareVersion"   typeName="string"   displayLabel="Analysis Software Version"/>
+        <ECProperty propertyName="OverallPassFail"           typeName="boolean"  displayLabel="Overall Pass/Fail"         description="True = all load cases pass"/>
+        <ECProperty propertyName="GoverningUtilizationRatio" typeName="double"   displayLabel="Governing Utilization Ratio" description="Highest ratio across all load cases; dimensionless"/>
+        <ECProperty propertyName="GoverningLoadCase"         typeName="string"   displayLabel="Governing Load Case"       description="Name of governing load case"/>
+        <ECProperty propertyName="GoverningLoadComponent"    typeName="string"   displayLabel="Governing Load Component"  description="Wire tension, wind, vertical, etc."/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="ClearanceCheck" displayLabel="Clearance Check"
+        description="An attachment-pair clearance analysis for a distribution pole. Lives in an AnalyticalModel. One per attachment pair per analysis run.">
+        <BaseClass>anlyt:AnalyticalElement</BaseClass>
+        <ECProperty propertyName="CheckDate"             typeName="dateTime"         displayLabel="Check Date"/>
+        <ECProperty propertyName="ProfileRef"            typeName="string"           displayLabel="Profile Reference"    description="Rule set applied; UPM ClearanceCheck.profile.rule_profile"/>
+        <ECProperty propertyName="TableId"               typeName="string"           displayLabel="Table ID"             description="Table 1, Table 2, Table 232-1, etc.; UPM ClearanceCheck.table_id"/>
+        <ECProperty propertyName="ClearanceTypeId"       typeName="int"              displayLabel="Clearance Type ID"    description="Numeric clearance type from rule table; UPM ClearanceCheck.clearance_type_id"/>
+        <ECProperty propertyName="Dimension"             typeName="ClearanceDimension" displayLabel="Dimension"          description="UPM ClearanceRelationship.dimension"/>
+        <ECProperty propertyName="SameSupport"           typeName="boolean"          displayLabel="Same Support"         description="Subject and object on same pole; UPM ClearanceRelationship.same_support"/>
+        <ECProperty propertyName="SubjectAttachmentId"   typeName="string"           displayLabel="Subject Attachment ID" description="UPM ClearanceRelationship.subject_attachment_id"/>
+        <ECProperty propertyName="ObjectAttachmentId"    typeName="string"           displayLabel="Object Attachment ID"  description="UPM ClearanceRelationship.object_attachment_id"/>
+        <ECProperty propertyName="SubjectVoltageV"       typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Subject Voltage"    description="UPM ClearanceCheck.subject_voltage_v; stored as V"/>
+        <ECProperty propertyName="ObjectVoltageV"        typeName="double" kindOfQuantity="AECU:ELECTRIC_POTENTIAL" displayLabel="Object Voltage"     description="UPM ClearanceCheck.object_voltage_v; stored as V"/>
+        <ECProperty propertyName="RequiredClearance"     typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Required Clearance"   description="UPM ClearanceCheck.required.value_si"/>
+        <ECProperty propertyName="ActualClearance"       typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Actual Clearance"     description="UPM ClearanceCheck.actual.value_si"/>
+        <ECProperty propertyName="ClearanceDelta"        typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Clearance Delta"      description="Positive = margin, negative = violation; UPM ClearanceCheck.delta"/>
+        <ECProperty propertyName="Passed"                typeName="boolean"          displayLabel="Passed"               description="UPM ClearanceCheck.passed"/>
+        <ECProperty propertyName="Message"               typeName="string"           displayLabel="Message"              description="UPM ClearanceCheck.message"/>
+        <ECProperty propertyName="OverallPassFail"       typeName="boolean"          displayLabel="Overall Pass/Fail"    description="Aggregate result for this check set"/>
+        <ECProperty propertyName="MinimumClearanceFound" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Minimum Clearance Found" description="Worst-case clearance found in this analysis"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         INFORMATION ELEMENTS
+         ============================================================ -->
+
+    <ECEntityClass typeName="PoleInspection" displayLabel="Pole Inspection"
+        description="Field inspection record for a distribution pole. Linked to the pole via PoleInspectionInspectsPole. Individual findings are InspectionFinding aspects.">
+        <BaseClass>bis:InformationRecordElement</BaseClass>
+        <ECProperty propertyName="InspectionDate"       typeName="dateTime"        displayLabel="Inspection Date"    description="UPM InspectionSection.last_inspection_date"/>
+        <ECProperty propertyName="Inspector"            typeName="string"          displayLabel="Inspector"          description="UPM InspectionSection.inspector"/>
+        <ECProperty propertyName="InspectionProgram"    typeName="string"          displayLabel="Inspection Program" description="e.g. Annual Pole Test and Treat; UPM InspectionSection.program"/>
+        <ECProperty propertyName="InspectionMethod"     typeName="InspectionMethod" displayLabel="Inspection Method" description="Not a UPM Literal; inferred from program name or defaulted to Boring for PTT records"/>
+        <ECProperty propertyName="PoleTestResult"       typeName="InspectionVerdict" displayLabel="Pole Test Result" description="UPM InspectionSection.pole_test_result"/>
+        <ECProperty propertyName="SoundTestResult"      typeName="string"          displayLabel="Sound Test Result"  description="Freeform; e.g. no_decay, hollow_at_groundline; UPM InspectionSection.sound_test_result"/>
+        <ECProperty propertyName="BoreholeTestResult"   typeName="string"          displayLabel="Borehole Test Result" description="UPM InspectionSection.borehole_test_result"/>
+        <ECProperty propertyName="GroundlineDecayPct"   typeName="double"          displayLabel="Groundline Decay %" description="Percent of original circumference lost to decay; UPM InspectionSection.groundline_decay_pct"/>
+        <ECProperty propertyName="ResidualStrengthPct"  typeName="double"          displayLabel="Residual Strength %" description="Post-decay strength as percent of original; UPM InspectionSection.residual_strength_pct"/>
+        <ECProperty propertyName="ShellThicknessIn"     typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Shell Thickness"      description="From boring measurement; UPM InspectionSection.shell_thickness_in"/>
+        <ECProperty propertyName="TreatedBool"          typeName="boolean"         displayLabel="Treated"            description="Whether pole has been chemically treated; UPM InspectionSection.treated_bool"/>
+        <ECProperty propertyName="TreatmentType"        typeName="string"          displayLabel="Treatment Type"     description="Freeform; e.g. CCA-C, copper_naphthenate; UPM InspectionSection.treatment_type"/>
+        <ECProperty propertyName="LastTreatmentDate"    typeName="dateTime"        displayLabel="Last Treatment Date" description="UPM InspectionSection.last_treatment_date"/>
+        <ECProperty propertyName="ConditionFactor"      typeName="double"          displayLabel="Condition Factor"   description="(effective_circ/orig_circ)^3 — remaining strength fraction; UPM InspectionRecord.condition_factor"/>
+        <ECProperty propertyName="OrigCircumferenceIn"      typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Original Circumference"  description="As-installed groundline circumference (capacity baseline); UPM InspectionRecord.orig_circ_in"/>
+        <ECProperty propertyName="CurrentCircumferenceIn"   typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Current Circumference"   description="Current external measured circumference; UPM InspectionRecord.current_circ_in"/>
+        <ECProperty propertyName="EffectiveCircumferenceIn" typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Effective Circumference" description="Sound-wood equivalent-solid circumference after decay removal; UPM InspectionRecord.effective_circ_in"/>
+        <ECProperty propertyName="GlShellAvgIn"         typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="GL Shell Average"      description="Groundline shell average from boring; UPM InspectionRecord.gl_shell_avg"/>
+        <ECProperty propertyName="WoodStrengthPct"      typeName="double"          displayLabel="Wood Strength %"    description="Utility-computed percent of original strength remaining; UPM InspectionRecord.wood_strength_pct"/>
+        <ECProperty propertyName="VisualFindings"       typeName="string"          displayLabel="Visual Findings"    description="Freeform narrative; UPM InspectionSection.visual_findings"/>
+        <ECProperty propertyName="Recommendation"       typeName="string"          displayLabel="Recommendation"     description="Freeform; e.g. Re-inspect in 5 yrs, Replace; UPM InspectionSection.recommendation"/>
+        <ECProperty propertyName="Verdict"              typeName="InspectionVerdict" displayLabel="Verdict"          description="UPM InspectionSection.verdict"/>
+        <ECProperty propertyName="InspectionStandard"   typeName="string"          displayLabel="Inspection Standard" description="ANSI O5.1, RUS, Utility custom; not in UPM"/>
+        <ECProperty propertyName="NextInspectionDate"   typeName="dateTime"        displayLabel="Next Inspection Date" description="Not in UPM"/>
+        <ECProperty propertyName="Notes"                typeName="string"          displayLabel="Notes"              description="Supplemental notes; not in UPM"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="ClearanceViolation" displayLabel="Clearance Violation"
+        description="A recorded clearance violation finding. One per violation identified in a clearance analysis.">
+        <BaseClass>bis:InformationRecordElement</BaseClass>
+        <ECProperty propertyName="Severity"           typeName="ClearanceSeverity" displayLabel="Severity"           description="UPM ClearanceFinding.severity"/>
+        <ECProperty propertyName="Category"           typeName="string"            displayLabel="Category"           description="UPM ClearanceFinding.category"/>
+        <ECProperty propertyName="RequiredClearance"  typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Required Clearance"/>
+        <ECProperty propertyName="ActualClearance"    typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Actual Clearance"/>
+        <ECProperty propertyName="DeficiencyAmount"   typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Deficiency Amount" description="Negative = violation magnitude; UPM ClearanceCheck.delta"/>
+        <ECProperty propertyName="LocationDescription" typeName="string"           displayLabel="Location Description"/>
+        <ECProperty propertyName="StandardSection"    typeName="string"            displayLabel="Standard Section"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         ELEMENT ASPECTS — UNIQUE (one per host element)
+         ============================================================ -->
+
+    <ECEntityClass typeName="GroundingConfiguration" displayLabel="Grounding Configuration"
+        description="Per-pole grounding rod configuration for IEEE 142 resistance calculation. One per DistributionPole.">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="RodCount"              typeName="int"    displayLabel="Rod Count"         description="Number of ground rods; UPM Grounding.rod_count"/>
+        <ECProperty propertyName="RodLengthFt"           typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Rod Length"        description="Length per rod; UPM Grounding.rod_length_ft"/>
+        <ECProperty propertyName="RodDiameterIn"         typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Rod Diameter"      description="Diameter per rod; UPM Grounding.rod_diameter_in"/>
+        <ECProperty propertyName="RodSpacingFt"          typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Rod Spacing"       description="Spacing in multi-rod arrays; UPM Grounding.rod_spacing_ft"/>
+        <ECProperty propertyName="SoilResistivityOhmM"   typeName="double" kindOfQuantity="EDIST_RESISTIVITY" displayLabel="Soil Resistivity"  description="Soil resistivity in ohm-metres; UPM Grounding.soil_resistivity_ohm_m"/>
+        <ECProperty propertyName="SoilClass"             typeName="string"  displayLabel="Soil Class"        description="Freeform soil classification; UPM Grounding.soil_class"/>
+        <ECProperty propertyName="MeasuredResistanceOhm" typeName="double" kindOfQuantity="EDIST_RESISTANCE"  displayLabel="Measured Resistance" description="Fall-of-potential test result; overrides analytical estimate; UPM Grounding.measured_resistance_ohm"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="EnvironmentalDesignContext" displayLabel="Environmental Design Context"
+        description="Per-pole design environmental conditions for IEEE 738 ampacity, IEEE C57.91 transformer thermal, and sag-tension analyses. One per DistributionPole.">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="AmbientTempDesignF" typeName="double" kindOfQuantity="AECU:TEMPERATURE" displayLabel="Design Ambient Temperature" description="Design ambient temperature for IEEE 738; UPM EnvironmentalDesignContext.ambient_temp_design_f; stored as K"/>
+        <ECProperty propertyName="WindDesignFps"      typeName="double" kindOfQuantity="AECU:VELOCITY"    displayLabel="Design Wind Speed"         description="Design wind speed for IEEE 738; UPM EnvironmentalDesignContext.wind_design_fps; stored as m/s"/>
+        <ECProperty propertyName="SolarFluxWPerFt2"   typeName="double"                                   displayLabel="Solar Flux (W/ft2)"        description="Solar irradiance for IEEE 738; UPM EnvironmentalDesignContext.solar_flux_w_per_ft2; no standard BIS KOQ for W/ft2"/>
+        <ECProperty propertyName="IceRadialIn"        typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Radial Ice Accretion"      description="For sag-tension analysis; UPM EnvironmentalDesignContext.ice_radial_in"/>
+        <ECProperty propertyName="FireThreatZone"     typeName="FireThreatZone"                           displayLabel="Fire Threat Zone"          description="UPM EnvironmentalDesignContext.fire_threat_zone Literal[none/tier_2/tier_3]"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="VegetationContext" displayLabel="Vegetation Context"
+        description="Per-pole vegetation clearance state from tree-trim survey or LiDAR scan. One per DistributionPole.">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="CurrentClearanceIn"                typeName="double" kindOfQuantity="AECU:LENGTH_SHORT" displayLabel="Current Tree Clearance"           description="Current tree-to-conductor clearance; UPM VegetationContext.current_clearance_in"/>
+        <ECProperty propertyName="VegetationInspectionDate"          typeName="dateTime"                                  displayLabel="Vegetation Inspection Date"        description="Date of last tree-trim survey; UPM VegetationContext.last_inspection_date"/>
+        <ECProperty propertyName="DominantConductorInsulationType"   typeName="string"                                    displayLabel="Dominant Conductor Insulation Type" description="Freeform; e.g. bare, tree_wire; UPM VegetationContext.dominant_conductor_insulation_type"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="AvianProtectionContext" displayLabel="Avian Protection Context"
+        description="Per-pole avian mitigation state per IEEE 1656. Zone membership modeled separately via PoleIsInAvianZone. One per DistributionPole.">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="WildlifeCoverPresent"      typeName="boolean"   displayLabel="Wildlife Cover Present"      description="UPM AvianContext.wildlife_cover_present"/>
+        <ECProperty propertyName="BushingCoverPresent"       typeName="boolean"   displayLabel="Bushing Cover Present"       description="UPM AvianContext.bushing_cover_present"/>
+        <ECProperty propertyName="LastAvianInspectionDate"   typeName="dateTime"  displayLabel="Last Avian Inspection Date"  description="UPM AvianContext.last_avian_inspection_date"/>
+        <ECProperty propertyName="AvianRetrofitComplete"     typeName="boolean"   displayLabel="Avian Retrofit Complete"     description="IEEE 1656 retrofit fully installed; UPM AvianContext.avian_retrofit_complete"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="ClearanceSummary" displayLabel="Clearance Summary"
+        description="Pole-level rollup of clearance check results. Mirrors UPM ClearanceSummary. One per DistributionPole.">
+        <BaseClass>bis:ElementUniqueAspect</BaseClass>
+        <ECProperty propertyName="Status"         typeName="string" displayLabel="Status"          description="pass, fail, or unknown; UPM ClearanceSummary.status"/>
+        <ECProperty propertyName="TotalIssues"    typeName="int"    displayLabel="Total Issues"    description="UPM ClearanceSummary.total_issues"/>
+        <ECProperty propertyName="Table1Issues"   typeName="int"    displayLabel="Table 1 Issues"  description="Conductor-to-ground/crossing; UPM ClearanceSummary.table_1_issues"/>
+        <ECProperty propertyName="Table2Issues"   typeName="int"    displayLabel="Table 2 Issues"  description="Conductor-to-conductor; UPM ClearanceSummary.table_2_issues"/>
+        <ECProperty propertyName="CriticalIssues" typeName="int"    displayLabel="Critical Issues" description="UPM ClearanceSummary.critical_issues"/>
+        <ECProperty propertyName="MinorIssues"    typeName="int"    displayLabel="Minor Issues"    description="UPM ClearanceSummary.minor_issues"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         ELEMENT ASPECTS — MULTI (many per host element)
+         ============================================================ -->
+
+    <ECEntityClass typeName="PoleLoadingResult" displayLabel="Pole Loading Result"
+        description="Per-load-case structural analysis result. Multiple per PoleLoadingAnalysis. BIS-only: populated from SPIDAcalc analysisResults, OCalc per-case output, or PLS-POLE component utilization.">
+        <BaseClass>bis:ElementMultiAspect</BaseClass>
+        <ECProperty propertyName="LoadCaseId"          typeName="string"  displayLabel="Load Case ID"          description="References LoadCaseDefinition CodeValue; UPM load case name"/>
+        <ECProperty propertyName="UtilizationRatio"    typeName="double"  displayLabel="Utilization Ratio"     description="actualRatio / allowedRatio; 0.0-1.0+; dimensionless"/>
+        <ECProperty propertyName="PassFail"            typeName="boolean" displayLabel="Pass/Fail"             description="SPIDA analysisResults.passes"/>
+        <ECProperty propertyName="ActualMoment"        typeName="double" kindOfQuantity="AECU:MOMENT" displayLabel="Actual Moment"        description="Groundline moment from moment-method tools (SPIDAcalc, O-Calc)"/>
+        <ECProperty propertyName="AllowableMoment"     typeName="double" kindOfQuantity="AECU:MOMENT" displayLabel="Allowable Moment"/>
+        <ECProperty propertyName="GoverningComponent"  typeName="string"  displayLabel="Governing Component"   description="Which load direction or component governed (PLS: pole shaft, guy, anchor)"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="InspectionFinding" displayLabel="Inspection Finding"
+        description="An individual structural or condition finding from a pole inspection. Multiple per PoleInspection.">
+        <BaseClass>bis:ElementMultiAspect</BaseClass>
+        <ECProperty propertyName="FindingType"    typeName="FindingType"   displayLabel="Finding Type"    description="Not a UPM Literal; derived from visual_findings narrative"/>
+        <ECProperty propertyName="Severity"       typeName="FindingSeverity" displayLabel="Severity"      description="UPM ClearanceFinding.severity pattern"/>
+        <ECProperty propertyName="HeightLocation" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Height Location" description="Height above grade where finding was observed"/>
+        <ECProperty propertyName="Description"    typeName="string"        displayLabel="Description"/>
+        <ECProperty propertyName="PhotoReference" typeName="string"        displayLabel="Photo Reference" description="URI to attached photo"/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="ConductorSagCondition" displayLabel="Conductor Sag Condition"
+        description="Sag geometry at a specific temperature or load state on one overhead conductor. Multiple per OverheadConductor.">
+        <BaseClass>bis:ElementMultiAspect</BaseClass>
+        <ECProperty propertyName="Condition"                typeName="ConductorSagConditionType" displayLabel="Condition"/>
+        <ECProperty propertyName="Temperature"              typeName="double" kindOfQuantity="AECU:TEMPERATURE" displayLabel="Temperature"               description="Analysis temperature; stored as K"/>
+        <ECProperty propertyName="MidspanSag"               typeName="double" kindOfQuantity="AECU:LENGTH"      displayLabel="Midspan Sag"/>
+        <ECProperty propertyName="HorizontalTension"        typeName="double" kindOfQuantity="AECU:FORCE"       displayLabel="Horizontal Tension"/>
+        <ECProperty propertyName="VerticalClearanceAtMidspan" typeName="double" kindOfQuantity="AECU:LENGTH"    displayLabel="Vertical Clearance at Midspan" description="Clearance to grade at midspan"/>
+    </ECEntityClass>
+
+    <!-- ============================================================
+         RELATIONSHIPS
+         ============================================================ -->
+
+    <!-- Type / instance -->
+    <ECRelationshipClass typeName="DistributionPoleIsOfType" strength="referencing" modifier="None"
+        displayLabel="Distribution Pole Is Of Type"
+        description="Relates a placed DistributionPole instance to its DistributionPoleType catalog record.">
+        <BaseClass>bis:PhysicalElementIsOfType</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="is of type" polymorphic="true">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is type of" polymorphic="true">
+            <Class class="DistributionPoleType"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Assembly -->
+    <ECRelationshipClass typeName="DistributionPoleAssemblesAttachments" strength="embedding" modifier="None"
+        displayLabel="Distribution Pole Assembles Attachments"
+        description="A distribution pole assembles its directly mounted attachments (crossarms, guys, insulators, equipment). Crossarm-to-Insulator assembly uses the same relationship class at the next hierarchy level.">
+        <BaseClass>bis:PhysicalElementAssemblesElements</BaseClass>
+        <Source multiplicity="(0..1)" roleLabel="assembles" polymorphic="true">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is assembled by" polymorphic="true">
+            <Class class="PoleAttachment"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Analytical: loading analysis → pole.
+         BaseClass is anlyt:AnalyticalSimulatesSpatialElement (the only "analyzes" relationship
+         in the Analytical schema). DistributionPole extends bis:PhysicalElement which extends
+         bis:SpatialElement, so it satisfies the base class target constraint. -->
+    <ECRelationshipClass typeName="PoleLoadingAnalysisAnalyzesPole" strength="referencing" modifier="None"
+        displayLabel="Pole Loading Analysis Analyzes Pole"
+        description="Associates a PoleLoadingAnalysis analytical element to the DistributionPole it simulates/analyzes.">
+        <BaseClass>anlyt:AnalyticalSimulatesSpatialElement</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="analyzes" polymorphic="true">
+            <Class class="PoleLoadingAnalysis"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is analyzed by" polymorphic="true">
+            <Class class="DistributionPole"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Analytical: clearance check → pole -->
+    <ECRelationshipClass typeName="ClearanceCheckAnalyzesPole" strength="referencing" modifier="None"
+        displayLabel="Clearance Check Analyzes Pole"
+        description="Associates a ClearanceCheck to the DistributionPole whose attachment clearances were checked.">
+        <BaseClass>anlyt:AnalyticalSimulatesSpatialElement</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="analyzes" polymorphic="true">
+            <Class class="ClearanceCheck"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is analyzed by" polymorphic="true">
+            <Class class="DistributionPole"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Reference: guy wire → anchor -->
+    <ECRelationshipClass typeName="GuyWireConnectsToAnchor" strength="referencing" modifier="None"
+        displayLabel="Guy Wire Connects To Anchor"
+        description="Associates a GuyWire to its AnchorAssembly. UPM Guy.anchor_id is the external reference that the connector resolves to an AnchorAssembly element.">
+        <BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="connects to" polymorphic="true">
+            <Class class="GuyWire"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is connected by" polymorphic="true">
+            <Class class="AnchorAssembly"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Reference: pole → avian zone (many-to-many) -->
+    <ECRelationshipClass typeName="PoleIsInAvianZone" strength="referencing" modifier="None"
+        displayLabel="Pole Is In Avian Zone"
+        description="Many-to-many: a DistributionPole belongs to zero or more AvianZones; a zone contains many poles. Connector inserts one relationship instance per entry in AvianContext.in_avian_zones.">
+        <BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="is in zone" polymorphic="true">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="contains pole" polymorphic="true">
+            <Class class="AvianZone"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Reference: inspection → pole -->
+    <ECRelationshipClass typeName="PoleInspectionInspectsPole" strength="referencing" modifier="None"
+        displayLabel="Pole Inspection Inspects Pole"
+        description="Associates a PoleInspection record to the DistributionPole it documents.">
+        <BaseClass>bis:ElementRefersToElements</BaseClass>
+        <Source multiplicity="(0..*)" roleLabel="inspects" polymorphic="true">
+            <Class class="PoleInspection"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is inspected by" polymorphic="true">
+            <Class class="DistributionPole"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Aspect ownership — UniqueAspect relationships -->
+    <ECRelationshipClass typeName="DistributionPoleOwnsGroundingConfiguration" strength="embedding" modifier="None"
+        displayLabel="Distribution Pole Owns Grounding Configuration">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="GroundingConfiguration"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="DistributionPoleOwnsEnvironmentalContext" strength="embedding" modifier="None"
+        displayLabel="Distribution Pole Owns Environmental Design Context">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="EnvironmentalDesignContext"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="DistributionPoleOwnsVegetationContext" strength="embedding" modifier="None"
+        displayLabel="Distribution Pole Owns Vegetation Context">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="VegetationContext"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="DistributionPoleOwnsAvianProtectionContext" strength="embedding" modifier="None"
+        displayLabel="Distribution Pole Owns Avian Protection Context">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="AvianProtectionContext"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="DistributionPoleOwnsClearanceSummary" strength="embedding" modifier="None"
+        displayLabel="Distribution Pole Owns Clearance Summary">
+        <BaseClass>bis:ElementOwnsUniqueAspect</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="DistributionPole"/>
+        </Source>
+        <Target multiplicity="(0..1)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ClearanceSummary"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <!-- Aspect ownership — MultiAspect relationships -->
+    <ECRelationshipClass typeName="PoleLoadingAnalysisOwnsPoleLoadingResult" strength="embedding" modifier="None"
+        displayLabel="Pole Loading Analysis Owns Pole Loading Result">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="PoleLoadingAnalysis"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="false">
+            <Class class="PoleLoadingResult"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="PoleInspectionOwnsInspectionFinding" strength="embedding" modifier="None"
+        displayLabel="Pole Inspection Owns Inspection Finding">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="PoleInspection"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="false">
+            <Class class="InspectionFinding"/>
+        </Target>
+    </ECRelationshipClass>
+
+    <ECRelationshipClass typeName="OverheadConductorOwnsSagCondition" strength="embedding" modifier="None"
+        displayLabel="Overhead Conductor Owns Sag Condition">
+        <BaseClass>bis:ElementOwnsMultiAspects</BaseClass>
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="false">
+            <Class class="OverheadConductor"/>
+        </Source>
+        <Target multiplicity="(0..*)" roleLabel="is owned by" polymorphic="false">
+            <Class class="ConductorSagCondition"/>
+        </Target>
+    </ECRelationshipClass>
+
+</ECSchema>

--- a/Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml
@@ -353,7 +353,7 @@
 
     <ECEntityClass typeName="DistributionPoleType" displayLabel="Distribution Pole Type"
         description="Catalog/specification record for a class of distribution pole (species, class, height). Shared across multiple DistributionPole instances via DistributionPoleIsOfType.">
-        <BaseClass>bis:PhysicalType</BaseClass>
+        <BaseClass>psrp:PolePhysicalType</BaseClass>
         <ECProperty propertyName="PoleClass"                    typeName="string"       displayLabel="Pole Class"                    description="ANSI/NESC class (1, 2, H1, H2, etc.)"/>
         <ECProperty propertyName="ManufacturedHeight"           typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Manufactured Height"           description="Nominal pole length; UPM PoleGeometry.manufactured_height"/>
         <ECProperty propertyName="PoleMaterial"                 typeName="PoleMaterial" displayLabel="Pole Material"                 description="Inferred from UPM PoleGeometry.pole_species"/>
@@ -370,7 +370,7 @@
 
     <ECEntityClass typeName="DistributionPole" displayLabel="Distribution Pole"
         description="A placed overhead distribution pole instance. Implements IDistributionElement (structural participant in the distribution system, not a flow element).">
-        <BaseClass>psrp:Structure</BaseClass>
+        <BaseClass>psrp:Pole</BaseClass>
         <BaseClass>dsys:IDistributionElement</BaseClass>
         <ECProperty propertyName="InstallDate"           typeName="dateTime"           displayLabel="Install Date"           description="Not in UPM; sourced from utility GIS"/>
         <ECProperty propertyName="SetDepth"              typeName="double" kindOfQuantity="AECU:LENGTH"       displayLabel="Set Depth"              description="UPM PoleGeometry.set_depth"/>
@@ -402,8 +402,12 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="PoleAttachment" modifier="Abstract" displayLabel="Pole Attachment"
-        description="Abstract base for all pole-mounted attachment types. Subclasses assembled to DistributionPole via DistributionPoleAssemblesAttachments.">
-        <BaseClass>psrp:AuxiliaryEquipment</BaseClass>
+        description="Mixin for pole-mounted attachments. Applied to attachment classes that each derive from their natural psrp base (Structure or Equipment branch); carries the shared attachment properties and is the target of DistributionPoleAssemblesAttachments.">
+        <ECCustomAttributes>
+            <IsMixin xmlns="CoreCustomAttributes.01.00.04">
+                <AppliesToEntityClass>bis:PhysicalElement</AppliesToEntityClass>
+            </IsMixin>
+        </ECCustomAttributes>
         <ECProperty propertyName="AttachmentHeight" typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Attachment Height" description="Height above grade; UPM attachment_height.value_si converted"/>
         <ECProperty propertyName="DirectionDegrees" typeName="double" kindOfQuantity="AECU:ANGLE"  displayLabel="Direction"         description="Compass bearing (0=N, 90=E); UPM direction_deg"/>
         <ECProperty propertyName="InstallDate"      typeName="dateTime"                            displayLabel="Install Date"      description="Not in UPM; sourced from GIS"/>
@@ -411,6 +415,7 @@
 
     <ECEntityClass typeName="Crossarm" displayLabel="Crossarm"
         description="A crossarm mounted on a distribution pole. Insulators are assembled as children via PhysicalElementAssemblesElements; Insulator.CrossarmId preserves the UPM crossarm_id for external reference.">
+        <BaseClass>psrp:CableSupports</BaseClass>
         <BaseClass>PoleAttachment</BaseClass>
         <ECProperty propertyName="CrossarmType" typeName="string"       displayLabel="Crossarm Type" description="Freeform; e.g. Wood - 8 ft Double; UPM Crossarm.crossarm_type"/>
         <ECProperty propertyName="Offset"       typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Offset"       description="Horizontal distance from pole center; UPM Crossarm.offset"/>
@@ -423,6 +428,7 @@
 
     <ECEntityClass typeName="Insulator" displayLabel="Insulator"
         description="An insulator position on a pole or crossarm. Conductor spans attached to this insulator are modeled as standalone OverheadConductor elements.">
+        <BaseClass>psrp:Insulator</BaseClass>
         <BaseClass>PoleAttachment</BaseClass>
         <ECProperty propertyName="InsulatorType"      typeName="InsulatorType" displayLabel="Insulator Type"    description="UPM Insulator.insulator_type; freeform mapped to enum"/>
         <ECProperty propertyName="CrossarmId"         typeName="string"        displayLabel="Crossarm ID"       description="External reference to parent crossarm; null for pole-mounted; UPM Insulator.crossarm_id"/>
@@ -434,6 +440,7 @@
 
     <ECEntityClass typeName="SpanGuy" displayLabel="Span Guy"
         description="A guy wire running pole-to-pole (not to a ground anchor). SPIDA models these as paired structures sharing ExternalId; each end has one SpanGuy entry.">
+        <BaseClass>psrp:SpanGuy</BaseClass>
         <BaseClass>PoleAttachment</BaseClass>
         <ECProperty propertyName="ExternalId" typeName="string" displayLabel="External ID" description="Shared ID across paired poles for renderer reconstruction; UPM SpanGuy.external_id"/>
         <ECProperty propertyName="Distance"   typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Distance"    description="Horizontal wire length; UPM SpanGuy.distance"/>
@@ -442,6 +449,7 @@
 
     <ECEntityClass typeName="GuyWire" displayLabel="Guy Wire"
         description="A ground-anchored guy wire attached to a distribution pole. Connected to AnchorAssembly via GuyWireConnectsToAnchor.">
+        <BaseClass>psrp:GuyWire</BaseClass>
         <BaseClass>PoleAttachment</BaseClass>
         <ECProperty propertyName="AnchorId"         typeName="string"    displayLabel="Anchor ID"         description="External reference to connected anchor; UPM Guy.anchor_id"/>
         <ECProperty propertyName="GuyType"          typeName="string"    displayLabel="Guy Type"          description="Freeform; e.g. Down Guy; UPM Guy.guy_type"/>
@@ -455,8 +463,8 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="AnchorAssembly" displayLabel="Anchor Assembly"
-        description="A ground-mounted anchor assembly. Associated to the pole via GuyWireConnectsToAnchor but is NOT a PoleAttachment subtype (ground-mounted, not pole-mounted).">
-        <BaseClass>psrp:Foundation</BaseClass>
+        description="A ground-mounted anchor assembly. Associated to the pole via GuyWireConnectsToAnchor but is NOT a PoleAttachment (ground-mounted, not pole-mounted).">
+        <BaseClass>psrp:AnchorCage</BaseClass>
         <ECProperty propertyName="AnchorType"  typeName="AnchorType" displayLabel="Anchor Type" description="Not in UPM Anchor model; sourced from anchor catalog or metadata"/>
         <ECProperty propertyName="EmbedDepth"  typeName="double" kindOfQuantity="AECU:LENGTH" displayLabel="Embed Depth" description="Not in UPM Anchor model"/>
         <ECProperty propertyName="SoilClass"   typeName="string"     displayLabel="Soil Class"  description="For grounding analysis use GroundingConfiguration.SoilClass instead"/>
@@ -464,7 +472,7 @@
 
     <ECEntityClass typeName="OverheadConductor" displayLabel="Overhead Conductor"
         description="A conductor span between two poles. Modeled as a standalone element (not nested under Insulator as in UPM). Populated from UPM Insulator.spans; each Span becomes one OverheadConductor.">
-        <BaseClass>psrp:Equipment</BaseClass>
+        <BaseClass>psrp:Conductor</BaseClass>
         <ECProperty propertyName="WireId"               typeName="string"             displayLabel="Wire ID"               description="Wire label (e.g. Phase A, Neutral N); UPM Span.wire_id"/>
         <ECProperty propertyName="FeederId"             typeName="string"             displayLabel="Feeder ID"             description="Feeder/project scope prefix used for conductor cross-pole stitching (e.g. project_line_one); separates the namespace prefix from WireId"/>
         <ECProperty propertyName="WireCode"             typeName="string"             displayLabel="Wire Code"             description="Conductor size label (e.g. ACSR 336, 2/0 ACSR); UPM Span.size"/>
@@ -481,7 +489,8 @@
     </ECEntityClass>
 
     <ECEntityClass typeName="DistributionTransformer" displayLabel="Distribution Transformer"
-        description="A distribution transformer mounted on a pole. Implements IDistributionFlowElement as it directly facilitates power distribution.">
+        description="A distribution transformer mounted on a pole. Inherits IDistributionFlowElement via psrp:Transformer → Equipment.">
+        <BaseClass>psrp:Transformer</BaseClass>
         <BaseClass>PoleAttachment</BaseClass>
         <ECProperty propertyName="RatedKva"               typeName="double" kindOfQuantity="AECU:POWER"            displayLabel="Rated kVA"               description="UPM TransformerNameplate.rated_kva; stored as W"/>
         <ECProperty propertyName="CoolingClass"           typeName="TransformerCoolingClass"                       displayLabel="Cooling Class"           description="UPM TransformerNameplate.cooling_class"/>
@@ -501,6 +510,7 @@
 
     <ECEntityClass typeName="PoleEquipment" displayLabel="Pole Equipment"
         description="General pole-mounted equipment other than distribution transformers (street lights, capacitors, regulators, reclosers, switches, cutouts, arresters, risers, communication equipment).">
+        <BaseClass>psrp:AuxiliaryEquipment</BaseClass>
         <BaseClass>PoleAttachment</BaseClass>
         <ECProperty propertyName="EquipmentType" typeName="EquipmentType" displayLabel="Equipment Type" description="UPM Equipment.equipment_type; freeform mapped to enum"/>
         <ECProperty propertyName="EquipmentSize" typeName="string"        displayLabel="Equipment Size" description="UPM Equipment.equipment_size"/>

--- a/Domains/2-DisciplinePhysical/ElectricDistribution/README.md
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/README.md
@@ -1,0 +1,129 @@
+# ElectricDistribution
+
+A [BIS](https://www.itwinjs.org/bis/guide/) domain schema for overhead electric
+distribution infrastructure — poles, attachments, conductors, transformers,
+structural loading analysis, field inspection, and clearance checking.
+
+**Layer:** 2-DisciplinePhysical
+**Schema name:** `ElectricDistribution` · alias `edist` · version `01.00.00`
+
+The physical classes extend the shared **`PowerSystemResourcesPhysical`** (`psrp`)
+base, so electric distribution is a sub-domain of the common power-system schema
+alongside substation rather than a parallel one.
+
+---
+
+## Contents
+
+### Physical Elements
+
+| Class | Base | Notes |
+|---|---|---|
+| `DistributionPole` | `psrp:Structure` + `dsys:IDistributionElement` | Primary structural host |
+| `PoleAttachment` | `psrp:AuxiliaryEquipment` (abstract) | Base for all pole-mounted hardware |
+| `Crossarm` | `PoleAttachment` | Horizontal timber or steel arm |
+| `Insulator` | `PoleAttachment` | Pin, disc, or deadend insulator |
+| `SpanGuy` | `PoleAttachment` | Guy attachment point on the pole |
+| `GuyWire` | `PoleAttachment` | Tensioned cable from pole to anchor |
+| `AnchorAssembly` | `psrp:Foundation` | Ground anchor terminating a guy wire |
+| `OverheadConductor` | `psrp:Equipment` (inherits `dsys:IDistributionFlowElement`) | Primary, neutral, or secondary wire |
+| `DistributionTransformer` | `PoleAttachment` (inherits `dsys:IDistributionFlowElement`) | Single- or three-phase transformer |
+| `PoleEquipment` | `PoleAttachment` | Capacitors, regulators, switches, arresters |
+
+### Type Catalog
+
+| Class | Base |
+|---|---|
+| `DistributionPoleType` | `bis:PhysicalType` |
+
+### Analytical Elements
+
+| Class | Base |
+|---|---|
+| `PoleLoadingAnalysis` | `anlyt:AnalyticalElement` |
+| `ClearanceCheck` | `anlyt:AnalyticalElement` |
+
+### Information Records
+
+| Class | Base |
+|---|---|
+| `PoleInspection` | `bis:InformationRecordElement` |
+| `ClearanceViolation` | `bis:InformationRecordElement` |
+
+### Aspects
+
+| Class | Kind | Host |
+|---|---|---|
+| `GroundingConfiguration` | UniqueAspect | `DistributionPole` |
+| `EnvironmentalDesignContext` | UniqueAspect | `DistributionPole` |
+| `VegetationContext` | UniqueAspect | `DistributionPole` |
+| `AvianProtectionContext` | UniqueAspect | `DistributionPole` |
+| `ClearanceSummary` | UniqueAspect | `DistributionPole` |
+| `PoleLoadingResult` | MultiAspect | `PoleLoadingAnalysis` |
+| `InspectionFinding` | MultiAspect | `PoleInspection` |
+| `ConductorSagCondition` | MultiAspect | `OverheadConductor` |
+
+### Definition Elements
+
+`AvianZone`, `LoadCaseDefinition`, `ClearanceRequirement`
+
+### Enumerations (25)
+
+`PoleMaterial`, `PoleConditionRating`, `CrossarmMaterial`, `CrossarmSide`, `AnchorType`, `InsulatorType`, `ConductorUsageGroup`, `ConductorSagConditionType`, `GuyGrade`, `InspectionMethod`, `InspectionVerdict`, `FindingType`, `FindingSeverity`, `ClearanceDimension`, `ClearanceSeverity`, `AnalysisCode`, `NescGrade`, `GO95Grade`, `NescDistrict`, `GO95Zone`, `ConstructionType`, `TransformerCoolingClass`, `TransformerPhaseConfig`, `EquipmentType`, `FireThreatZone`
+
+### Custom KindOfQuantity
+
+| Name | Persistence unit | Notes |
+|---|---|---|
+| `EDIST_RESISTANCE` | `u:OHM` | Grounding resistance |
+| `EDIST_RESISTIVITY` | `u:OHM_M` | Soil resistivity |
+
+All other quantities use `AECU:` KindOfQuantities from AecUnits.
+
+---
+
+## Schema References
+
+| Schema | Version | Alias |
+|---|---|---|
+| BisCore | 01.00.25 | `bis` |
+| Analytical | 01.00.02 | `anlyt` |
+| DistributionSystems | 01.00.02 | `dsys` |
+| PowerSystemResourcesPhysical | 01.00.02 | `psrp` |
+| AecUnits | 01.00.03 | `AECU` |
+| Units | 01.00.06 | `u` |
+| Formats | 01.00.00 | `f` |
+| CoreCustomAttributes | 01.00.04 | `CoreCA` |
+| BisCustomAttributes | 01.00.00 | `bisCA` |
+
+Versions are aligned to the requirements of `PowerSystemResourcesPhysical 01.00.02`.
+Units 01.00.06 is the minimum released version containing `u:OHM_M` (electrical resistivity).
+
+---
+
+## Validating
+
+From the repository root:
+
+```bash
+npm run validateSchemas -- --name ElectricDistribution --wip
+```
+
+Expected output: `Schema Validation Succeeded. No rule violations found.`
+
+---
+
+## Design
+
+See [design.md](./design.md) for full property tables, the overhead-distribution
+field mapping, enumeration value rationale, relationship descriptions, and the
+open design decisions / alternatives considered.
+
+The schema's property set and enumeration values were derived from the data
+models of the three dominant overhead distribution analysis tools — SPIDAcalc
+(SPIDA/JSON), PLS-POLE / PLS-CADD, and O-Calc Pro (PPLX/XML) — and cover NESC and
+GO-95 jurisdictions.
+
+---
+
+Proposed by Julius Guay IV, Bentley Systems.

--- a/Domains/2-DisciplinePhysical/ElectricDistribution/README.md
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/README.md
@@ -17,24 +17,30 @@ alongside substation rather than a parallel one.
 
 ### Physical Elements
 
+Each class derives from its specific `psrp` class (not a generic base), reusing
+the power-system domain hierarchy. `PoleAttachment` is a **mixin** (applies to
+`bis:PhysicalElement`) carrying the shared attachment properties + the assembly
+relationship target, since the attachment classes land on different psrp branches
+(`Structure` vs `Equipment`).
+
 | Class | Base | Notes |
 |---|---|---|
-| `DistributionPole` | `psrp:Structure` + `dsys:IDistributionElement` | Primary structural host |
-| `PoleAttachment` | `psrp:AuxiliaryEquipment` (abstract) | Base for all pole-mounted hardware |
-| `Crossarm` | `PoleAttachment` | Horizontal timber or steel arm |
-| `Insulator` | `PoleAttachment` | Pin, disc, or deadend insulator |
-| `SpanGuy` | `PoleAttachment` | Guy attachment point on the pole |
-| `GuyWire` | `PoleAttachment` | Tensioned cable from pole to anchor |
-| `AnchorAssembly` | `psrp:Foundation` | Ground anchor terminating a guy wire |
-| `OverheadConductor` | `psrp:Equipment` (inherits `dsys:IDistributionFlowElement`) | Primary, neutral, or secondary wire |
-| `DistributionTransformer` | `PoleAttachment` (inherits `dsys:IDistributionFlowElement`) | Single- or three-phase transformer |
-| `PoleEquipment` | `PoleAttachment` | Capacitors, regulators, switches, arresters |
+| `DistributionPole` | `psrp:Pole` + `dsys:IDistributionElement` | `Pole → OverheadStructure → Structure` |
+| `Crossarm` | `psrp:CableSupports` + `PoleAttachment` | `CableSupports → Structure` |
+| `Insulator` | `psrp:Insulator` + `PoleAttachment` | reuses `psrp:Insulator` (`AuxiliaryEquipment`) |
+| `SpanGuy` | `psrp:SpanGuy` + `PoleAttachment` | `SpanGuy → Cable → Structure` |
+| `GuyWire` | `psrp:GuyWire` + `PoleAttachment` | `GuyWire → SupportWire → OverheadStructure` |
+| `AnchorAssembly` | `psrp:AnchorCage` | `AnchorCage → UndergroundStructure → Structure` |
+| `OverheadConductor` | `psrp:Conductor` | `Conductor → Equipment` (inherits `dsys:IDistributionFlowElement`) |
+| `DistributionTransformer` | `psrp:Transformer` + `PoleAttachment` | `Transformer → Equipment` |
+| `PoleEquipment` | `psrp:AuxiliaryEquipment` + `PoleAttachment` | non-transformer pole equipment |
+| `PoleAttachment` | *mixin* (`IsMixin`, applies to `bis:PhysicalElement`) | shared attachment props + assembly target |
 
 ### Type Catalog
 
 | Class | Base |
 |---|---|
-| `DistributionPoleType` | `bis:PhysicalType` |
+| `DistributionPoleType` | `psrp:PolePhysicalType` |
 
 ### Analytical Elements
 

--- a/Domains/2-DisciplinePhysical/ElectricDistribution/design.md
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/design.md
@@ -1,0 +1,1140 @@
+# ElectricDistribution BIS Domain Schema — Design Context
+
+This document provides design context to author the
+`ElectricDistribution` ECSchema (`edist`) as a formal BIS domain schema proposal
+for the `iTwin/bis-schemas` repository. It captures the conceptual model, UPM
+mapping decisions, schema layer placement, and authoring conventions.
+
+
+---
+
+## Purpose
+
+The goal is to author a new BIS Discipline-Physical domain schema —
+`ElectricDistribution` — that covers overhead electric distribution
+infrastructure. This schema is intended to:
+
+1. Formalize the Universal Pole Model (UPM) as a standards-grade BIS domain
+2. Enable iTwin connectors (SPIDAcalc, O-Calc Pro, PLS-POLE, UPM native) to
+   write to a shared semantic model in Bentley Infrastructure Cloud
+3. Be proposed upstream to the `iTwin/bis-schemas` repository via pull request
+4. Serve as the schema backbone for EPC Studio's Bentley Infrastructure Cloud
+   integration
+5. Support the DistribuTECH 2027 talk on AI agents for distribution pole loading
+   and clearance analysis
+
+---
+
+## BIS Schema Architecture Background
+
+### Layer placement
+
+BIS schemas are organized into layers. This schema belongs at layer
+**2-DisciplinePhysical**, alongside building, civil, and structural domains.
+It references schemas from:
+
+- `2-DisciplinePhysical`: `PowerSystemResourcesPhysical` (alias `psrp`) — the
+  **shared power-system base schema** this domain extends. Distribution physical
+  classes derive from `psrp:Structure` / `psrp:Equipment` / `psrp:AuxiliaryEquipment`
+  / `psrp:Foundation` so they share the same bases as the substation+ domain
+  (per iTwin/bis-schemas PR #733 review).
+- `0-Core`: `BisCore` — `psrp` bases ultimately subclass `bis:PhysicalElement`
+- `0-Core`: `Analytical` — for loading analysis elements
+- `1-Common`: `DistributionSystems` (alias `dsys`) — flow/control mixin source
+  (`IDistributionElement`, `IDistributionFlowElement`); also referenced by `psrp`
+- `1-Common`: `AecUnits` — for unit definitions (length, force, stress, angle)
+
+### ECSchema file format
+
+Schemas are authored in ECXML 3.2 format. File naming convention:
+`ElectricDistribution.ecschema.xml`. Released versions copy to
+`Released/ElectricDistribution.MM.mm.bb.ecschema.xml`.
+
+### Key BIS modeling patterns used here
+
+- **Type/Instance split**: `bis:PhysicalType` holds catalog/spec data shared
+  across many instances. `bis:PhysicalElement` holds instance-specific field
+  data (location, install date, condition).
+- **Physical + Analytical separation**: Physical elements live in a
+  `PhysicalModel`. Corresponding analytical results (loading, clearance) live
+  in an `AnalyticalModel` linked by relationships.
+- **Assembly relationships**: `bis:PhysicalElementAssemblesElements` expresses
+  that a pole assembles its attachments.
+- **ElementAspects**: Used for inspection findings and per-case loading results
+  that augment an element without being a separate addressable entity.
+- **Mixins**: `dsys:IDistributionFlowElement`,
+  `dsys:IDistributionControlElement`, `dsys:IDistributionSensorElement` are
+  implemented where appropriate.
+
+### UPM → BIS unit mapping
+
+The UPM uses a `MeasuredValue` struct for all dimensional quantities:
+```python
+class MeasuredValue:
+    value_si: Optional[float]   # canonical SI value (metres, newtons, etc.)
+    unit_si: str                # e.g. "m", "N"
+    source_value: Optional[float]  # original tool value before conversion
+    source_unit: Optional[str]     # e.g. "ft", "in", "lbs"
+```
+BIS properties have explicit named units. The connector is responsible for
+extracting `value_si` from `MeasuredValue` and converting to the BIS property's
+declared unit. The `source_value`/`source_unit` pair is preserved in the iModel
+as a custom attribute or extra property on the element so round-tripping to the
+source tool is lossless.
+
+### UPM freeform strings vs. true enumerations
+
+Not all UPM string fields are enumerations. This distinction matters for BIS
+property types and for connector mapping:
+
+- **True UPM `Literal` types** (match these values exactly in connectors):
+  `NescGrade` (B/C/C_WITH_CROSSINGS/N), `GO95Grade` (A/B/C/F),
+  `NescDistrict` (HEAVY/MEDIUM/LIGHT/WARM_ISLAND_UNDER_9000_FT/WARM_ISLAND_OVER_9000_FT),
+  `GO95Zone` (HEAVY/LIGHT), `InstallType` (install/replacement),
+  `TransformerCoolingClass` (ONAN/ONAF/ODAF),
+  `TransformerPhaseConfig` (single_phase/three_phase),
+  `FramingBreakdown.crossarm_structure` (single/double/mixed/unknown),
+  `ClearanceRelationship.dimension` (vertical/horizontal/radial/unknown),
+  `ClearanceFinding.severity` (info/warning/error/critical),
+  `InspectionSection.pole_test_result` and `.verdict` (pass/marginal/fail),
+  `EnvironmentalDesignContext.fire_threat_zone` (none/tier_2/tier_3).
+
+- **UPM freeform `Optional[str]` fields** (adapters write varied values; BIS
+  provides an enumeration derived from the union across all adapters; the
+  connector must map adapter-specific strings to the BIS enum):
+  `insulator_type`, `crossarm_type`, `equipment_type`, `attachment_type`,
+  `guy_type`, `soil_class`, `treatment_type`, `sound_test_result`,
+  `recommendation`.
+
+---
+
+## Schema Declaration
+
+```xml
+<ECSchema schemaName="ElectricDistribution" alias="edist" version="01.00.00"
+    xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2"
+    displayLabel="Electric Distribution"
+    description="BIS domain schema for overhead electric distribution
+    infrastructure including poles, attachments, conductors, and structural
+    analysis.">
+
+  <ECSchemaReference name="BisCore"                      version="01.00.25" alias="bis"/>
+  <ECSchemaReference name="Analytical"                   version="01.00.02" alias="anlyt"/>
+  <ECSchemaReference name="DistributionSystems"          version="01.00.02" alias="dsys"/>
+  <ECSchemaReference name="PowerSystemResourcesPhysical" version="01.00.02" alias="psrp"/>
+  <ECSchemaReference name="AecUnits"                     version="01.00.03" alias="AECU"/>
+  <ECSchemaReference name="Units"                        version="01.00.06" alias="u"/>
+  <ECSchemaReference name="Formats"                      version="01.00.00" alias="f"/>
+  <ECSchemaReference name="CoreCustomAttributes"         version="01.00.04" alias="CoreCA"/>
+  <ECSchemaReference name="BisCustomAttributes"          version="01.00.00" alias="bisCA"/>
+
+</ECSchema>
+```
+
+> **Version note:** Reference versions are aligned to `PowerSystemResourcesPhysical 01.00.02`
+> and validated against the current `iTwin/bis-schemas` repo with `SchemaValidationRunner`.
+
+---
+
+## Gap 1: Distribution Poles
+
+### UPM source concepts
+
+**Primary UPM models:** `PoleIdentity`, `PoleGeometry` in
+`domain/pole_model/models.py`.
+
+Species (western red cedar, douglas fir, southern yellow pine, steel, concrete,
+composite), class (1–10, H1–H6), manufactured height, setting depth, ground-line
+circumference, pole-top circumference, condition rating, install date, lean
+angle (not in UPM — see TODO), owner, map number, GPS coordinates, elevation,
+heading.
+
+### BIS classes
+
+#### `edist:DistributionPoleType` — catalog/spec record
+
+Subclass of `bis:PhysicalType`. Holds properties shared across all poles of the
+same species/class/height combination.
+
+| BIS Property | UPM Field | Type | Unit | Notes |
+|---|---|---|---|---|
+| `PoleClass` | `PoleGeometry.pole_class` | string | — | ANSI/NESC class (1, 2, H1, H2, etc.) |
+| `ManufacturedHeight` | `PoleGeometry.manufactured_height` | double | ft | Nominal height; UPM stores as MeasuredValue in metres |
+| `PoleMaterial` | (inferred from `pole_species`) | enum | — | `edist:PoleMaterial`; UPM has `pole_species` (freeform string) — Wood poles derive material from species; steel/concrete/composite from explicit species names |
+| `PoleSpecies` | `PoleGeometry.pole_species` | string | — | Freeform species string (WRC, DF, SYP, GL, Steel, Concrete) |
+| `NominalGroundlineStrength` | — | double | ft-lbs | ANSI O5.1 tabulated strength; not a UPM field — sourced from O5.1 table lookup by class+species |
+| `NominalTipCircumference` | `PoleGeometry.pole_top_circumference` | double | in | UPM uses circumference (not diameter); stores as MeasuredValue in metres |
+| `NominalGroundlineCircumference` | — | double | in | Derived from class+height+species per O5.1; not a direct UPM instance field |
+| `TreatmentType` | `InspectionSection.treatment_type` | string | — | Preservative treatment (CCA, Penta, copper_naphthenate); freeform in UPM |
+
+> **Structural note:** The original draft used `NominalTipDiameter` and
+> `NominalGroundlineDiameter` (inches, diameter). The UPM stores
+> `pole_top_circumference` and `ground_line_circumference` (metres,
+> circumference). BIS properties are renamed to circumference to match the UPM's
+> physical measurement convention; connectors convert from metres to inches.
+
+#### `edist:DistributionPole` — placed instance
+
+Subclass of `psrp:Structure` (shared power-system structural base). Implements `dsys:IDistributionElement`.
+
+| BIS Property | UPM Field | Type | Unit | Notes |
+|---|---|---|---|---|
+| `InstallDate` | — | dateTime | — | Not a direct UPM field; sourced from utility GIS on ingest |
+| `SetDepth` | `PoleGeometry.set_depth` | double | ft | UPM: `set_depth` (MeasuredValue, metres) |
+| `GroundlineCircumference` | `PoleGeometry.ground_line_circumference` | double | in | Measured field value; UPM stores in metres |
+| `PoleTipCircumference` | `PoleGeometry.pole_top_circumference` | double | in | Measured field value; UPM field name is `pole_top_circumference` |
+| `Elevation` | `PoleGeometry.elevation_m` | double | ft | WGS84 ellipsoid elevation; UPM stores in metres |
+| `HeadingDegrees` | `PoleGeometry.heading_deg` | double | degrees | Compass bearing of pole facing (0=N, 90=E) |
+| `GpsAccuracyMeters` | `PoleGeometry.gps_accuracy_m` | double | m | GPS horizontal uncertainty; stored in metres in both UPM and BIS |
+| `ConditionRating` | — | enum | — | `edist:PoleConditionRating`; not a direct UPM field — derived from inspection verdict |
+| `MapNumber` | `PoleIdentity.pole_id` | string | — | Utility GIS map label |
+| `StructureNumber` | `PoleIdentity.structure_id` | string | — | Utility asset ID |
+| `StructureName` | `PoleIdentity.structure_name` | string | — | Human-readable label |
+| `PoleOwner` | — | string | — | Owner of record; not in UPM PoleIdentity — sourced from GIS |
+| `JointUse` | — | boolean | — | Whether joint use attachments present; not in UPM |
+
+> **TODO:** `LeanAngle` and `LeanDirection` are in the original draft but are
+> **absent from the UPM** (`PoleGeometry` has no lean fields). These are
+> meaningful structural measurements (NESC Rule 217 limits lean to 2° from
+> vertical for new construction). Add them only as optional properties derived
+> from field survey; the connector cannot populate them from UPM data.
+
+> **TODO:** The UPM `PoleIdentity.source_ref` (`source_system`, `source_key`,
+> `source_path`) has no BIS counterpart yet. The connector framework's external
+> source ID map handles round-trip identity; no schema property needed, but the
+> mapping doc should call this out explicitly.
+
+#### Relationship: `edist:DistributionPoleIsOfType`
+
+Subclass of `bis:PhysicalElementIsOfType`.
+`edist:DistributionPole` → `edist:DistributionPoleType`.
+
+---
+
+## Gap 2: Pole Loading Analysis
+
+### UPM source concepts
+
+**Primary UPM models:** `domain/loading/grades.py`, `domain/loading/zones.py`,
+`domain/loading/load_case_builder.py`, `domain/loading/tensions.py`.
+
+Loading codes (NESC, GO95), construction grades (NESC B/C/C_WITH_CROSSINGS/N;
+GO95 A/B/C/F), loading districts (NESC: Heavy/Medium/Light/Warm Island; GO95:
+Heavy/Light), construction type (new/replacement), load case weather (wind speed,
+ice, temperature), allowable tensions.
+
+> **Structural note — no UPM loading result dataclass:** The UPM does not define
+> a persistent loading result model (there is no `UtilizationResult` or similar
+> dataclass in the `domain/` package). Loading results come from SPIDAcalc's
+> `analysisResults` JSON block (`actualRatio`, `allowedRatio`, `passes`) or
+> equivalent O-Calc / PLS-POLE output, which the connector reads directly from
+> the source tool. The `edist:PoleLoadingResult` aspect below is a BIS-only
+> design that the connector populates from the source tool's native output — it
+> has no UPM field-for-field mapping.
+
+### BIS classes
+
+#### `edist:LoadCaseDefinition` — reusable load case
+
+Subclass of `bis:DefinitionElement`.
+
+| Property | Type | UPM Source | Description |
+|---|---|---|---|
+| `AnalysisCode` | enum | `LoadingCode` ("nesc"/"go95") | `edist:AnalysisCode`; replaces the old conflated `AnalysisStandard` |
+| `NescGrade` | enum | `NescGrade` (Literal from grades.py) | `edist:NescGrade`; null when AnalysisCode is GO95 |
+| `GO95Grade` | enum | `GO95Grade` (Literal from grades.py) | `edist:GO95Grade`; null when AnalysisCode is NESC |
+| `NescDistrict` | enum | `NescDistrict` (Literal from zones.py) | `edist:NescDistrict`; null when AnalysisCode is GO95 |
+| `GO95Zone` | enum | `GO95Zone` (Literal from zones.py) | `edist:GO95Zone`; null when AnalysisCode is NESC |
+| `ConstructionType` | enum | `InstallType` ("install"/"replacement") | `edist:ConstructionType`; drives overload capacity factors |
+| `NescRevision` | string | load_case_builder constants | e.g. "NESC 2023", "NESC 2012-2017" |
+| `GO95Revision` | string | load_case_builder constants | e.g. "GO95 01-2020" |
+| `WindSpeed` | double | district/zone lookup | mph at conductor height |
+| `IceThickness` | double | district/zone lookup | inches radial |
+| `WindOnIce` | boolean | — | Wind-on-ice combination case |
+| `TemperatureLow` | double | district/zone lookup | °F |
+| `TemperatureHigh` | double | — | °F |
+| `OverloadCapacityFactor` | double | grades.py factors | Applied to allowable stress |
+| `WindLoadFactor` | double | — | LRFD wind load factor |
+| `Description` | string | — | Human-readable name |
+
+> **Structural note — AnalysisStandard split:** The original draft had a single
+> `edist:AnalysisStandard` enum with values `NESC_B`, `NESC_C`, `GO95`,
+> `RUS_Bulletin_1724`, `Custom`. This is wrong in two ways: (1) the UPM treats
+> analysis code (NESC vs. GO95) and construction grade (B, C, N; or A, B, C, F)
+> as orthogonal concepts with separate `Literal` types; (2) the NESC revision
+> ("NESC 2023") is a third independent axis. All three are now separate
+> properties. `RUS_1724E200` is moved to `AnalysisCode`; Custom remains.
+
+> **TODO:** Tension limits (NESC Rule 261H: initial loaded 60% RBS, initial
+> unloaded at 60°F 35% RBS, final unloaded 25% RBS; guy strand 90% at loading)
+> are not BIS properties — they are computed from the `NescGrade` and the wire's
+> catalog rated breaking strength. Document in the `rationale.md` mapping doc
+> that tension limits are not stored on `LoadCaseDefinition`.
+
+#### `edist:PoleLoadingAnalysis` — analytical element
+
+Subclass of `anlyt:AnalyticalElement`. Lives in an `AnalyticalModel`.
+One per pole per analysis run.
+
+| Property | Type | Source | Description |
+|---|---|---|---|
+| `AnalysisDate` | dateTime | — | When analysis was run |
+| `AnalysisSoftware` | string | — | SPIDAcalc, O-Calc Pro, PLS-POLE, EPC Studio |
+| `AnalysisSoftwareVersion` | string | — | |
+| `OverallPassFail` | boolean | SPIDA `passes` / OCalc pass/fail | True = pass |
+| `GoverningUtilizationRatio` | double | SPIDA `actualRatio/allowedRatio` | Highest ratio across all load cases |
+| `GoverningLoadCase` | string | — | Name of governing load case |
+| `GoverningLoadComponent` | string | — | Wire tension, wind, vertical, etc. |
+
+#### `edist:PoleLoadingResult` — per-case result aspect
+
+Subclass of `bis:ElementMultiAspect` on `edist:PoleLoadingAnalysis`.
+One aspect per load case. **BIS-only — not derived from a UPM dataclass.**
+Populated by the connector from SPIDAcalc `analysisResults`, OCalc per-case
+output, or PLS-POLE component utilization.
+
+| Property | Type | SPIDA Field | Description |
+|---|---|---|---|
+| `LoadCaseId` | string | load case name | References `LoadCaseDefinition` CodeValue |
+| `UtilizationRatio` | double | `actualRatio / allowedRatio` | 0.0–1.0+ |
+| `PassFail` | boolean | `passes` | |
+| `ActualMoment` | double | — | ft-lbs at groundline (moment-method tools) |
+| `AllowableMoment` | double | — | ft-lbs |
+| `GoverningComponent` | string | — | Which load direction governed |
+
+> **TODO:** PLS-POLE uses component-level stress ratios (pole shaft, guy, anchor)
+> rather than SPIDAcalc's single groundline-moment ratio. The `UtilizationRatio`
+> field captures the governing component, but PLS multi-component output may need
+> additional aspects or an array property. Resolve before schema 1.0 release.
+
+#### Relationship: `edist:PoleLoadingAnalysisAnalyzesPole`
+
+Subclass of `anlyt:AnalyticalElementAnalyzesElement`.
+`edist:PoleLoadingAnalysis` → `edist:DistributionPole`.
+
+---
+
+## Gap 3: Attachments
+
+### General pattern
+
+All direct pole attachments subclass `edist:PoleAttachment` → `psrp:AuxiliaryEquipment`.
+They are assembled to the pole via `bis:PhysicalElementAssemblesElements`. Each
+has an `AttachmentHeight` (ft above grade) derived from the UPM `attachment_height`
+MeasuredValue (metres in UPM).
+
+> **UPM parallel structure note:** The UPM maintains two parallel representations:
+> (1) typed collections (`crossarms`, `guys`, `anchors`, `equipment`) as first-class
+> lists on `PoleModel`, and (2) a flat `attachments: List[Attachment]` list where
+> each entry has `attachment_type` (freeform string like "crossarm", "insulator",
+> "guy", "equipment") for clearance and rendering lookups. BIS models only the
+> typed structure — the flat attachment list is a UPM internal view, not a separate
+> BIS class.
+
+#### `edist:PoleAttachment` — abstract base
+
+Subclass of `psrp:AuxiliaryEquipment`. Abstract. (Inherits the `dsys:IDistributionFlowElement` and `spi:IStructuralElement` mixins via `psrp:Equipment`.)
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `AttachmentHeight` | `attachment_height.value_si` (converted) | double | Height above grade (ft) |
+| `DirectionDegrees` | `direction_deg` | double | Compass bearing (0=N, 90=E) |
+| `InstallDate` | — | dateTime | Not in UPM; sourced from GIS |
+
+> **TODO:** Original draft had `MountHeight` and `Offset` as base attachment
+> properties. Renamed `MountHeight` → `AttachmentHeight` to match UPM field name.
+> `Offset` applies only to crossarms (UPM `Crossarm.offset`) — moved to
+> `edist:Crossarm`. Base class `Offset` removed.
+
+#### `edist:Crossarm`
+
+Subclass of `edist:PoleAttachment`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `CrossarmType` | `Crossarm.crossarm_type` | string | Freeform; e.g. "Wood - 8' Double" |
+| `Offset` | `Crossarm.offset` | double | Horizontal distance from pole center (ft) |
+| `ArmSide` | `Crossarm.side` | enum | `edist:CrossarmSide` — arm configuration (single/double) |
+| `ArmLength` | — | double | ft; not a direct UPM field — inferred from span geometry or crossarm catalog |
+| `ArmMaterial` | — | enum | `edist:CrossarmMaterial`; not in UPM — inferred from `crossarm_type` string |
+| `ArmSize` | — | string | e.g. "3.5x4.5"; not in UPM |
+| `BraceType` | — | string | None, Single, Double; not in UPM |
+
+> **Structural note:** UPM `Crossarm` nests its `insulators: List[Insulator]`
+> directly on the crossarm object. BIS represents this as assembly relationships:
+> `edist:Crossarm` assembles `edist:Insulator` children via
+> `bis:PhysicalElementAssemblesElements`. The UPM's crossarm-to-insulator
+> association is preserved via `edist:Insulator.CrossarmId` (external reference).
+
+> **TODO:** The UPM `Crossarm.metadata` dict (from adapters) may carry
+> `arm_count` (1=single, 2=sandwich/double). Map `arm_count` → `ArmSide`.
+> `FramingBreakdown.crossarm_structure` (single/double/mixed/unknown) is a
+> pole-level rollup, not the per-crossarm value.
+
+#### `edist:Insulator`
+
+Subclass of `edist:PoleAttachment`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `InsulatorType` | `Insulator.insulator_type` | enum | `edist:InsulatorType`; UPM freeform — see enum table |
+| `CrossarmId` | `Insulator.crossarm_id` | string | External reference to parent crossarm; null for pole-mounted |
+| `VerticalOffset` | `Insulator.vertical_offset` | double | Vertical offset from attachment height (ft) |
+| `HorizontalOffset` | `Insulator.horizontal_offset` | double | Horizontal offset from crossarm/pole center (ft) |
+| `VoltageRating` | — | double | kV; not in UPM — sourced from wire catalog |
+| `PhaseDesignation` | — | string | A, B, C, N; not in UPM |
+
+> **Structural note:** UPM `Insulator` contains `spans: List[Span]` — the
+> conductor spans leaving from this insulator position. BIS models spans as
+> `edist:OverheadConductor` elements (standalone), linked to the insulator by
+> relationship rather than containment. This avoids the UPM's nested structure
+> and makes conductors independently queryable. The trade-off: the BIS connector
+> must explicitly create the insulator-to-conductor link; the UPM embeds it.
+
+#### `edist:SpanGuy` — pole-to-pole guy wire
+
+**New class — absent from original draft.**
+Subclass of `edist:PoleAttachment`. Represents a guy wire running from this
+pole to a backup stub or another anchoring structure (NOT down to a ground
+anchor). SPIDA models these as paired structures; each end has a `SpanGuy`
+entry sharing the same `ExternalId`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `ExternalId` | `SpanGuy.external_id` | string | Shared ID across paired poles for renderer reconstruction |
+| `Distance` | `SpanGuy.distance` | double | Horizontal wire length (ft) |
+| `GuySize` | `SpanGuy.size` | string | Freeform; e.g. "3/8 EHS" |
+
+#### `edist:GuyWire` — ground-anchored guy
+
+Subclass of `edist:PoleAttachment`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `AnchorId` | `Guy.anchor_id` | string | External reference to the anchor |
+| `GuyType` | `Guy.guy_type` | string | Freeform; e.g. "Down Guy" |
+| `GuySize` | (from metadata) | string | e.g. "3/8 EHS", "7/16 HS" |
+| `GuyGrade` | (from metadata) | enum | `edist:GuyGrade` |
+| `GuyStrand` | (from metadata) | string | e.g. "7x" |
+| `LeadDistance` | (from metadata) | double | ft horizontal to anchor |
+| `DownAngle` | (from metadata) | double | degrees from horizontal |
+| `PreloadedTension` | (from metadata) | double | lbs |
+| `AllowableTension` | (from metadata) | double | lbs |
+
+> **Structural note:** UPM `Guy` is intentionally sparse — it has only
+> `guy_id`, `guy_type`, `attachment_height`, and `anchor_id`. The detailed
+> properties (`GuySize`, `GuyGrade`, etc.) live in `Guy.metadata` as passed
+> through from the source tool. BIS promotes them to first-class properties
+> because structural analysis requires them. The connector must extract these
+> from `metadata`. Mark these BIS properties as optional to tolerate UPM poles
+> where the metadata is absent.
+
+#### `edist:AnchorAssembly`
+
+Subclass of `psrp:Foundation` (ground-embedded support). Associated to the pole, not a subtype of
+`PoleAttachment` (anchors are ground-mounted, not pole-mounted).
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `AnchorType` | — | enum | `edist:AnchorType`; not in UPM — sourced from anchor catalog or metadata |
+| `EmbedDepth` | — | double | ft; not in UPM `Anchor` model |
+| `SoilClass` | — | string | Not in UPM `Anchor` model |
+
+> **TODO:** UPM `Anchor` has only `anchor_id`, `distance` (ft), `direction_deg`,
+> `height` (stub pole height), and `guy_ids` (list of connected guys). It does
+> NOT have `AnchorRating`, `EmbedDepth`, or `SoilClass`. These properties in
+> the original draft have no UPM source — they must come from the anchor catalog
+> or a separate soil data input. Remove `AnchorRating` from the BIS class until
+> a UPM or connector source is identified. `SoilClass` for grounding analysis
+> belongs on `edist:GroundingConfiguration` (Gap 6), not on the anchor.
+
+#### Relationship: `edist:GuyWireConnectsToAnchor`
+
+New relationship. `edist:GuyWire` → `edist:AnchorAssembly`.
+
+#### `edist:OverheadConductor`
+
+Subclass of `psrp:Equipment` (inherits `dsys:IDistributionFlowElement`).
+Represents a conductor span between two poles. Populated from UPM `Span` objects
+(which are nested under `Insulator.spans` in the UPM).
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `WireId` | `Span.wire_id` | string | Wire label (e.g. "Phase A", "Neutral N") |
+| `WireCode` | `Span.size` | string | Conductor size label (ACSR 336, 2/0 ACSR, #2 CU) |
+| `ConductorUsageGroup` | `Attachment.attachment_type` or span metadata | enum | `edist:ConductorUsageGroup`; UPM stores as freeform usage group |
+| `NominalVoltage` | `Attachment.voltage_v` | double | kV |
+| `SpanLength` | `Span.length` | double | ft horizontal |
+| `AttachmentHeightNear` | parent `Insulator.attachment_height` | double | ft at near pole |
+| `AttachmentHeightFar` | (far-pole insulator) | double | ft at far pole |
+| `RotationDegrees` | `Span.rotation_deg` | double | Compass bearing from near pole |
+| `EndpointType` | `Span.endpoint_type` | string | PREVIOUS_POLE, OTHER_POLE, etc. |
+| `IsInsulated` | — | boolean | Not in UPM |
+| `CoverType` | — | string | Tree wire, bare, spacer; not in UPM |
+| `TensionGroup` | `Span.metadata.tension_type` | string | "full" or "slack" |
+
+> **Structural note:** The UPM nests spans under insulators
+> (`Insulator.spans: List[Span]`). BIS models each span as a standalone
+> `edist:OverheadConductor` element linked to its source insulator by a
+> relationship. This makes conductors independently addressable in the iModel
+> (required for clearance checks and iTwin visualization) at the cost of
+> requiring explicit relationship creation in the connector.
+
+#### `edist:DistributionTransformer`
+
+Subclass of `edist:PoleAttachment`. Implements `dsys:IDistributionFlowElement`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `RatedKva` | `TransformerNameplate.rated_kva` | double | kVA |
+| `CoolingClass` | `TransformerNameplate.cooling_class` | enum | `edist:TransformerCoolingClass` (ONAN/ONAF/ODAF) |
+| `PrimaryVoltageKv` | `TransformerNameplate.primary_voltage_kv` | double | kV |
+| `SecondaryVoltageV` | `TransformerNameplate.secondary_voltage_v` | double | V |
+| `PhaseConfig` | `TransformerNameplate.phase_config` | enum | `edist:TransformerPhaseConfig` (SinglePhase/ThreePhase) |
+| `ConnectionType` | `TransformerNameplate.connection_type` | string | Freeform; e.g. "Delta-Wye" |
+| `LossRatioR` | `TransformerNameplate.loss_ratio_R` | double | PCC/PNL ratio for IEEE C57.91 thermal model |
+| `ActualLoadKva` | `TransformerNameplate.actual_load_kva` | double | Measured / SCADA load at time of analysis |
+| `RatedTopOilRiseC` | `TransformerNameplate.rated_top_oil_rise_c` | double | °C; IEEE C57.91 thermal parameter |
+| `RatedHottestSpotRiseC` | `TransformerNameplate.rated_hottest_spot_rise_c` | double | °C; IEEE C57.91 thermal parameter |
+| `EquipmentSize` | `Equipment.equipment_size` | string | Freeform size label |
+| `BottomHeight` | `Equipment.bottom_height` | double | ft; lower edge height above grade |
+| `SerialNumber` | — | string | Not in UPM |
+| `MountType` | — | enum | Overhead, Padmount, SubSurface; not in UPM |
+
+> **Note:** Original draft was missing all `TransformerNameplate` fields. The
+> UPM's `TransformerNameplate` is the source for IEEE C57.91 thermal loading
+> analysis — these fields are required for the transformer thermal analyzer.
+
+#### `edist:PoleEquipment` — general pole-mounted equipment
+
+Subclass of `edist:PoleAttachment`. Used for non-transformer equipment: street
+lights, capacitors, regulators, reclosers, switches, cutouts, arresters, risers,
+termination brackets, and communication equipment. The `EquipmentType` enum
+(below) classifies the item; a future release may add typed subclasses for each.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `EquipmentType` | `Equipment.equipment_type` | enum | `edist:EquipmentType`; UPM freeform |
+| `EquipmentSize` | `Equipment.equipment_size` | string | Freeform size label |
+| `BottomHeight` | `Equipment.bottom_height` | double | ft; lower edge height above grade |
+
+> **Note:** Equipment types seen across UPM adapters (SPIDA, OCalc, PLS):
+> `TRANSFORMER`, `STREET_LIGHT`, `CUTOUT_ARRESTOR`, `RISER`,
+> `TERMINATION_BRACKET`, `CAPACITOR`, `REGULATOR`, `RECLOSER`, `SWITCH`,
+> `COMMUNICATION`, `CATV`, `TELCO`, `FIBER`. Original draft modeled only
+> `DistributionTransformer`; all others were missing. `RISER` and
+> `TERMINATION_BRACKET` are SPIDA-specific (underground-to-overhead transition).
+
+---
+
+## Gap 4: Clearance Zones and Conductor Sag Geometry
+
+### UPM source concepts
+
+**Primary UPM models:** `ClearanceSection`, `ClearanceCheck`, `ClearanceFinding`,
+`ClearanceSummary`, `ClearanceProfileRef`, `ClearanceRelationship`,
+`ClearanceContext` in `domain/pole_model/models.py`; clearance section builder
+in `domain/pole_model/adapters/clearance.py`.
+
+Clearance profile (rule set and version), per-pair attachment clearance checks
+(required, actual, delta, pass/fail), table classification (Table 1 = conductor-
+to-ground/crossing; Table 2 = conductor-to-conductor for GO95), severity findings,
+pole-level clearance summary.
+
+> **Structural note — profile-based vs. type-based model:** The original draft
+> modeled clearance with a `ClearanceType` enum classifying checks by physical
+> relationship (ToGrade, ToCrossing, ToBulding, etc.). The UPM uses a
+> profile-based approach: each check references a `ClearanceProfileRef`
+> (rule_profile, rule_version) and a `table_id` (GO95 "Table 1"/"Table 2"; NESC
+> Table 232-1, Table 235-5, Table 235-6). Attachment pair voltage classes drive
+> the required clearance lookup, not an enum type. The BIS classes below blend
+> both approaches: the profile and table_id from the UPM for connector fidelity,
+> and a clearance-type classification for human readability.
+
+### BIS classes
+
+#### `edist:ClearanceRequirement` — reusable profile definition
+
+Subclass of `bis:DefinitionElement`.
+
+| Property | Type | UPM Field | Description |
+|---|---|---|---|
+| `RuleProfile` | string | `ClearanceProfileRef.rule_profile` | e.g. "CPUC_GO95", "NESC_2023" |
+| `RuleVersion` | string | `ClearanceProfileRef.rule_version` | e.g. "01-2020" |
+| `TableId` | string | `ClearanceCheck.table_id` | e.g. "Table 1", "Table 232-1" |
+| `ApplicableCode` | enum | — | `edist:AnalysisCode` |
+| `StandardSection` | string | — | e.g. "NESC Rule 232" |
+| `RequiredClearance` | double | `ClearanceCheck.required.value_si` (converted) | ft |
+| `ConditionClass` | string | — | Normal, Loaded, Extreme |
+
+#### `edist:ClearanceCheck` — per-attachment-pair check
+
+Subclass of `anlyt:AnalyticalElement`. One per attachment pair per analysis.
+
+| Property | Type | UPM Field | Description |
+|---|---|---|---|
+| `CheckDate` | dateTime | — | |
+| `ProfileRef` | string | `ClearanceCheck.profile.rule_profile` | Which rule set was applied |
+| `TableId` | string | `ClearanceCheck.table_id` | "Table 1", "Table 2", "Table 232-1", etc. |
+| `ClearanceTypeId` | int | `ClearanceCheck.clearance_type_id` | Numeric clearance type from rule table |
+| `Dimension` | enum | `ClearanceRelationship.dimension` | `edist:ClearanceDimension` (Vertical/Horizontal/Radial/Unknown) |
+| `SameSupport` | boolean | `ClearanceRelationship.same_support` | Whether subject and object are on the same pole |
+| `SubjectAttachmentId` | string | `ClearanceRelationship.subject_attachment_id` | |
+| `ObjectAttachmentId` | string | `ClearanceRelationship.object_attachment_id` | |
+| `SubjectVoltageV` | double | `ClearanceCheck.subject_voltage_v` | V |
+| `ObjectVoltageV` | double | `ClearanceCheck.object_voltage_v` | V |
+| `RequiredClearance` | double | `ClearanceCheck.required.value_si` (converted) | ft |
+| `ActualClearance` | double | `ClearanceCheck.actual.value_si` (converted) | ft |
+| `ClearanceDelta` | double | `ClearanceCheck.delta.value_si` (converted) | ft; positive = margin, negative = violation |
+| `Passed` | boolean | `ClearanceCheck.passed` | |
+| `Message` | string | `ClearanceCheck.message` | |
+| `OverallPassFail` | boolean | — | Aggregate for the span/check set |
+| `MinimumClearanceFound` | double | — | ft — worst case found in this analysis |
+
+#### `edist:ClearanceViolation` — finding record
+
+Subclass of `bis:InformationContentElement`. One per violation found.
+
+| Property | Type | UPM Field | Description |
+|---|---|---|---|
+| `Severity` | enum | `ClearanceFinding.severity` | `edist:ClearanceSeverity` (Info/Warning/Error/Critical) |
+| `Category` | string | `ClearanceFinding.category` | |
+| `RequiredClearance` | double | — | ft |
+| `ActualClearance` | double | — | ft |
+| `DeficiencyAmount` | double | `ClearanceCheck.delta` | ft (negative = violation) |
+| `LocationDescription` | string | — | |
+| `StandardSection` | string | — | |
+
+#### `edist:ClearanceSummary` — pole-level rollup
+
+Subclass of `bis:ElementMultiAspect` on `edist:DistributionPole`. Captures the
+UPM `ClearanceSummary` block directly.
+
+| Property | Type | UPM Field | Description |
+|---|---|---|---|
+| `Status` | string | `ClearanceSummary.status` | "pass", "fail", "unknown" |
+| `TotalIssues` | int | `ClearanceSummary.total_issues` | |
+| `Table1Issues` | int | `ClearanceSummary.table_1_issues` | Conductor-to-ground/crossing |
+| `Table2Issues` | int | `ClearanceSummary.table_2_issues` | Conductor-to-conductor |
+| `CriticalIssues` | int | `ClearanceSummary.critical_issues` | |
+| `MinorIssues` | int | `ClearanceSummary.minor_issues` | |
+
+#### `edist:ConductorSagCondition` — multi-aspect on OverheadConductor
+
+Subclass of `bis:ElementMultiAspect`. Captures sag at multiple
+temperature/load conditions on a single conductor element.
+
+| Property | Type | Description |
+|---|---|---|
+| `Condition` | enum | `edist:ConductorSagConditionType` |
+| `Temperature` | double | °F |
+| `MidspanSag` | double | ft |
+| `HorizontalTension` | double | lbs |
+| `VerticalClearanceAtMidspan` | double | ft to grade |
+
+---
+
+## Gap 5: Field Inspection Results
+
+### UPM source concepts
+
+**Primary UPM models:** `InspectionSection` in `domain/pole_model/models.py`;
+`InspectionRecord` in `domain/inspection/pge_ptt.py`.
+
+Inspection program, date, inspector, pole test result (pass/marginal/fail),
+sound test result (freeform), borehole result (freeform), groundline decay
+percent, residual strength percent, shell thickness, treatment history,
+condition factor (circumference-derived), PG&E PTT-specific measured
+circumferences, visual findings, recommendation, overall verdict.
+
+### BIS classes
+
+#### `edist:PoleInspection` — inspection record
+
+Subclass of `bis:InformationRecordElement`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `InspectionDate` | `InspectionSection.last_inspection_date` | dateTime | ISO date |
+| `Inspector` | `InspectionSection.inspector` | string | Inspector name |
+| `InspectionProgram` | `InspectionSection.program` | string | e.g. "Annual Pole Test & Treat" |
+| `InspectionMethod` | — | enum | `edist:InspectionMethod`; UPM does not prescribe a method enum — infer from program name or default to Intrusive for PTT records |
+| `PoleTestResult` | `InspectionSection.pole_test_result` | enum | `edist:InspectionVerdict` (Pass/Marginal/Fail) — matches UPM Literal |
+| `SoundTestResult` | `InspectionSection.sound_test_result` | string | Freeform; e.g. "no_decay", "hollow_at_groundline" |
+| `BoreholeTestResult` | `InspectionSection.borehole_test_result` | string | Freeform |
+| `GroundlineDecayPct` | `InspectionSection.groundline_decay_pct` | double | % of original circumference lost to decay |
+| `ResidualStrengthPct` | `InspectionSection.residual_strength_pct` | double | Post-decay strength as % of original |
+| `ShellThicknessIn` | `InspectionSection.shell_thickness_in` | double | Inches; from boring measurement |
+| `TreatedBool` | `InspectionSection.treated_bool` | boolean | Whether pole has been chemically treated |
+| `TreatmentType` | `InspectionSection.treatment_type` | string | Freeform; e.g. "CCA-C", "copper_naphthenate" |
+| `LastTreatmentDate` | `InspectionSection.last_treatment_date` | dateTime | |
+| `ConditionFactor` | `InspectionRecord.condition_factor` | double | (effective_circ/orig_circ)^3; remaining strength fraction |
+| `OrigCircumferenceIn` | `InspectionRecord.orig_circ_in` | double | As-installed groundline circumference (capacity baseline) |
+| `CurrentCircumferenceIn` | `InspectionRecord.current_circ_in` | double | Current external measured circumference |
+| `EffectiveCircumferenceIn` | `InspectionRecord.effective_circ_in` | double | Sound-wood equivalent-solid circumference (decay removed) |
+| `GlShellAvgIn` | `InspectionRecord.gl_shell_avg` | double | Groundline shell average from boring |
+| `WoodStrengthPct` | `InspectionRecord.wood_strength_pct` | double | Utility-computed % of original strength remaining |
+| `VisualFindings` | `InspectionSection.visual_findings` | string | Freeform narrative |
+| `Recommendation` | `InspectionSection.recommendation` | string | Freeform; e.g. "Re-inspect in 5 yrs", "Replace" |
+| `Verdict` | `InspectionSection.verdict` | enum | `edist:InspectionVerdict` (Pass/Marginal/Fail) — matches UPM Literal |
+| `InspectionStandard` | — | string | ANSI O5.1, RUS, Utility custom; not in UPM |
+| `NextInspectionDate` | — | dateTime | Not in UPM |
+| `Notes` | — | string | Supplemental notes; not in UPM |
+
+> **Enum correction:** Original draft had `InspectionOverallRating` with values
+> Satisfactory/Marginal/Unsatisfactory/Condemned. UPM uses
+> `Literal["pass", "marginal", "fail"]` for both `pole_test_result` and
+> `verdict`. BIS enum `edist:InspectionVerdict` matches UPM: Pass, Marginal,
+> Fail. The original "Condemned" state maps to Fail (no separate UPM value).
+
+#### `edist:InspectionFinding` — individual finding aspect
+
+Subclass of `bis:ElementMultiAspect` on `edist:PoleInspection`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `FindingType` | — | enum | `edist:FindingType`; no direct UPM enum — UPM uses freeform `visual_findings` |
+| `Severity` | `ClearanceFinding.severity` | enum | `edist:FindingSeverity` (Info/Warning/Error/Critical) — matches UPM Literal |
+| `HeightLocation` | — | double | ft above grade where found |
+| `Description` | — | string | |
+| `PhotoReference` | — | string | URI to attached photo |
+
+> **Enum correction:** Original draft had `FindingSeverity` values
+> Minor/Moderate/Severe/Critical. UPM `ClearanceFinding.severity` uses
+> `Literal["info", "warning", "error", "critical"]`. BIS enum corrected to:
+> Info, Warning, Error, Critical.
+
+#### Relationship: `edist:PoleInspectionInspectsPole`
+
+Subclass of `bis:ElementRefersToElements`.
+`edist:PoleInspection` → `edist:DistributionPole`.
+
+---
+
+## Gap 6: Grounding Configuration
+
+**New gap — absent from original draft.**
+
+### UPM source concepts
+
+**UPM model:** `Grounding` in `domain/pole_model/models.py`.
+
+Per-pole grounding rod configuration for IEEE 142 resistance calculation.
+`rod_count + rod_length_ft + rod_diameter_in + soil_resistivity_ohm_m` are
+required to compute resistance analytically; `measured_resistance_ohm` supersedes
+the calculation when a fall-of-potential test has been performed.
+
+### BIS classes
+
+#### `edist:GroundingConfiguration` — grounding data aspect
+
+Subclass of `bis:ElementMultiAspect` on `edist:DistributionPole`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `RodCount` | `Grounding.rod_count` | int | Number of ground rods |
+| `RodLengthFt` | `Grounding.rod_length_ft` | double | Length per rod (ft) |
+| `RodDiameterIn` | `Grounding.rod_diameter_in` | double | Diameter per rod (inches) |
+| `RodSpacingFt` | `Grounding.rod_spacing_ft` | double | Spacing between rods in multi-rod arrays (ft) |
+| `SoilResistivityOhmM` | `Grounding.soil_resistivity_ohm_m` | double | Soil resistivity (Ω·m) |
+| `SoilClass` | `Grounding.soil_class` | string | Freeform soil classification |
+| `MeasuredResistanceOhm` | `Grounding.measured_resistance_ohm` | double | Fall-of-potential test result (Ω); overrides analytical estimate |
+
+---
+
+## Gap 7: Environmental Design Context
+
+**New gap — absent from original draft.**
+
+### UPM source concepts
+
+**UPM model:** `EnvironmentalDesignContext` in `domain/pole_model/models.py`.
+
+Per-pole design environmental conditions consumed by IEEE 738 ampacity analysis,
+IEEE C57.91 transformer thermal analysis, and conductor sag-tension change-of-state.
+Sourced from the loading area definition for the pole's location, or pinned
+per-pole when site-specific.
+
+### BIS classes
+
+#### `edist:EnvironmentalDesignContext` — design environment aspect
+
+Subclass of `bis:ElementMultiAspect` on `edist:DistributionPole`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `AmbientTempDesignF` | `EnvironmentalDesignContext.ambient_temp_design_f` | double | Design ambient temperature (°F) for IEEE 738 |
+| `WindDesignFps` | `EnvironmentalDesignContext.wind_design_fps` | double | Design wind speed (ft/s) for IEEE 738 |
+| `SolarFluxWPerFt2` | `EnvironmentalDesignContext.solar_flux_w_per_ft2` | double | Solar irradiance (W/ft²) for IEEE 738 |
+| `IceRadialIn` | `EnvironmentalDesignContext.ice_radial_in` | double | Radial ice accretion (inches) for sag-tension |
+| `FireThreatZone` | `EnvironmentalDesignContext.fire_threat_zone` | enum | `edist:FireThreatZone` (None/Tier2/Tier3); UPM Literal `"none"/"tier_2"/"tier_3"` |
+
+---
+
+## Gap 8: Vegetation Clearance Context
+
+**New gap — absent from original draft.**
+
+### UPM source concepts
+
+**UPM model:** `VegetationContext` in `domain/pole_model/models.py`.
+
+Per-pole vegetation clearance state. Sourced from inspection, AMI, or LiDAR
+scan; populated when the utility runs a tree-trim survey on the pole.
+
+### BIS classes
+
+#### `edist:VegetationContext` — vegetation clearance aspect
+
+Subclass of `bis:ElementMultiAspect` on `edist:DistributionPole`.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `CurrentClearanceIn` | `VegetationContext.current_clearance_in` | double | Current tree-to-conductor clearance (inches) |
+| `VegetationInspectionDate` | `VegetationContext.last_inspection_date` | dateTime | Date of last tree-trim survey |
+| `DominantConductorInsulationType` | `VegetationContext.dominant_conductor_insulation_type` | string | Freeform; e.g. "bare", "tree_wire" |
+
+---
+
+## Gap 9: Avian Protection Context
+
+**New gap — absent from original draft.**
+
+### UPM source concepts
+
+**UPM model:** `AvianContext` in `domain/pole_model/models.py`.
+
+Per-pole avian-zone membership and IEEE 1656 mitigation tracking. Captures zone
+classification, wildlife/bushing covers installed, and retrofit completion state.
+
+### BIS classes
+
+#### `edist:AvianZone` — zone definition element
+
+Subclass of `bis:DefinitionElement`. Lives in a `DefinitionModel`. Represents a
+named avian protection zone (utility-designated or regulatory). Poles reference
+zones via relationship, so zone membership is queryable without string parsing.
+
+| BIS Property | Type | Description |
+|---|---|---|
+| `ZoneId` | string | Utility or regulatory zone identifier (e.g. "PGE_AVIAN_ZONE_5") |
+| `ZoneName` | string | Human-readable name |
+| `Authority` | string | Designating body (e.g. "PG&E", "CPUC") |
+
+#### `edist:PoleIsInAvianZone` — zone membership relationship
+
+Subclass of `bis:ElementRefersToElements`. Many-to-many: a pole belongs to
+multiple zones; a zone contains many poles.
+
+- **Source**: `edist:DistributionPole` (0..*)
+- **Target**: `edist:AvianZone` (0..*)
+
+**Connector mapping:** For each string in `AvianContext.in_avian_zones`, the
+connector upserts an `edist:AvianZone` element by `ZoneId` in the definition
+model, then inserts one `PoleIsInAvianZone` relationship per entry.
+
+#### `edist:AvianProtectionContext` — avian mitigation aspect
+
+Subclass of `bis:ElementMultiAspect` on `edist:DistributionPole`. Carries the
+per-pole mitigation state; zone membership is on the relationship above.
+
+| BIS Property | UPM Field | Type | Description |
+|---|---|---|---|
+| `WildlifeCoverPresent` | `AvianContext.wildlife_cover_present` | boolean | |
+| `BushingCoverPresent` | `AvianContext.bushing_cover_present` | boolean | |
+| `LastAvianInspectionDate` | `AvianContext.last_avian_inspection_date` | dateTime | |
+| `AvianRetrofitComplete` | `AvianContext.avian_retrofit_complete` | boolean | IEEE 1656 retrofit fully installed |
+
+---
+
+## Gap 10: Service Network References
+
+**New gap — absent from original draft.**
+
+### UPM source concepts
+
+**UPM model:** `ServiceNetworkRef` in `domain/pole_model/models.py`.
+
+Forward reference from a pole to a Universal Service Model network sourced by a
+transformer on this pole. Keeps the pole-side and services-side models loosely
+coupled — the actual network lives in its own document, joined by `network_id`.
+
+### BIS classes
+
+#### Relationship: `edist:PoleServicesNetwork`
+
+New relationship. `edist:DistributionPole` → target (TBD — depends on how the
+Universal Service Model is modeled in BIS).
+
+| UPM Field | Type | Description |
+|---|---|---|
+| `ServiceNetworkRef.network_id` | string | Key to the downstream service network |
+| `ServiceNetworkRef.transformer_equipment_id` | string | Which transformer sources this network |
+| `ServiceNetworkRef.service_count` | int | Number of services on the network |
+
+> **TODO:** The Universal Service Model is not yet a BIS schema. Represent
+> `ServiceNetworkRef` as a string property `ServiceNetworkId` on
+> `edist:DistributionTransformer` as a placeholder, and upgrade to a first-class
+> relationship when the services schema is available. Note `transformer_equipment_id`
+> and `service_count` as custom attributes on the interim property.
+
+---
+
+## Supporting Enumerations
+
+Author as `ECEnumeration` in the schema. Values are given in BIS (PascalCase)
+format; the UPM source Literal value (where one exists) is shown for connector
+mapping.
+
+### Unchanged from original draft (values correct)
+
+| Enumeration | Values |
+|---|---|
+| `edist:PoleMaterial` | Wood, Steel, Concrete, Composite, Fiberglass |
+| `edist:PoleConditionRating` | Good, Fair, Poor, Critical |
+| `edist:CrossarmMaterial` | Wood, Steel, Fiberglass |
+| `edist:AnchorType` | ScrewAuger, Expanding, Concrete, Rock, StubPole, Deadman |
+| `edist:InspectionMethod` | Visual, Sounding, Boring, ChemicalTest, Ultrasonic, PoleTreat |
+| `edist:FindingType` | SurfaceRot, InteriorRot, Crack, Woodpecker, PhysicalDamage, LeaningExcessive, HardwareDamaged, AttachmentLoose, Other |
+| `edist:ConductorSagConditionType` | Initial, Final, Loaded, FullIce, Extreme |
+| `edist:GuyGrade` | EHS, HS, SiloGuy, SoftDrawCopper |
+
+### Corrected or renamed enumerations
+
+| Enumeration | Old values | Corrected values | Reason |
+|---|---|---|---|
+| `edist:InsulatorType` | PinType, PostType, SuspensionType, DeadEndType, StrainType | **Pin, Deadend, Clamp, Bracket, Unknown** | UPM freeform field; union across SPIDA (`_infer_insulator_type`), OCalc, and PLS-POLE adapters all converge on these values. SPIDA: Deadend/Clamp/Bracket/Pin/Unknown; PLS: Pin/Deadend. Connector maps adapter strings to this enum. |
+| `edist:ConductorUsageGroup` | (was `ConductorType`: Primary, Secondary, Neutral, CommunicationSupport, Guy) | **Primary, Secondary, Neutral, PrimaryNeutral, Streetlight, Communication, CommunicationBundle, CommunicationService, SecondaryDrop, StaticWire, GroundWire** | Renamed from `ConductorType` to match UPM "usage group" concept. Values extended to match `_USAGE_GROUP_FALLBACK_VOLTAGE` dict in `clearance.py`. `Guy` removed (not a wire usage group). |
+| `edist:InspectionVerdict` | (was `InspectionOverallRating`: Satisfactory, Marginal, Unsatisfactory, Condemned) | **Pass, Marginal, Fail** | UPM `Literal["pass", "marginal", "fail"]` on both `pole_test_result` and `verdict`. "Condemned" has no UPM value; maps to Fail. |
+| `edist:FindingSeverity` | Minor, Moderate, Severe, Critical | **Info, Warning, Error, Critical** | UPM `Literal["info", "warning", "error", "critical"]` on `ClearanceFinding.severity`. Minor/Moderate/Severe do not exist in the UPM. |
+| `edist:CrossarmSide` | (not in original draft) | **Single, Double, Mixed, Unknown** | New enum; derived from UPM `FramingBreakdown.crossarm_structure` Literal (`"single"/"double"/"mixed"/"unknown"`). |
+| `edist:ClearanceDimension` | (not in original draft) | **Vertical, Horizontal, Radial, Unknown** | New enum; matches UPM `ClearanceRelationship.dimension` Literal (`"vertical"/"horizontal"/"radial"/"unknown"`). |
+| `edist:ClearanceSeverity` | (was `FindingSeverity` used for clearance) | **Info, Warning, Error, Critical** | Same values as `FindingSeverity`; can share the enum or be separate for schema clarity. |
+| ~~`edist:RecommendedAction`~~ | ~~None, Monitor, Reinforce, Replace, Emergency~~ | **Removed — superseded by freeform string** | UPM `InspectionSection.recommendation` is `Optional[str]` (e.g. "Re-inspect in 5 yrs", "Replace"). A fixed enum would drop real-world values. Model as a plain string property on `PoleSpatialElementAspect`. |
+
+### New enumerations (not in original draft)
+
+| Enumeration | Values | UPM Source |
+|---|---|---|
+| `edist:AnalysisCode` | **NESC, GO95, RUS1724E200, Custom** | Replaces conflated `AnalysisStandard`; from `LoadingCode = Literal["nesc", "go95"]` in grades.py |
+| `edist:NescGrade` | **B, C, C_WITH_CROSSINGS, N** | True UPM Literal from `grades.py`: `NescGrade = Literal["B", "C", "C_WITH_CROSSINGS", "N"]` |
+| `edist:GO95Grade` | **A, B, C, F** | True UPM Literal from `grades.py`: `GO95Grade = Literal["A", "B", "C", "F"]` |
+| `edist:NescDistrict` | **Heavy, Medium, Light, WarmIslandUnder9000Ft, WarmIslandOver9000Ft** | True UPM Literal from `zones.py`; exact values: HEAVY/MEDIUM/LIGHT/WARM_ISLAND_UNDER_9000_FT/WARM_ISLAND_OVER_9000_FT |
+| `edist:GO95Zone` | **Heavy, Light** | True UPM Literal from `zones.py`: GO95Zone = Literal["HEAVY", "LIGHT"] |
+| `edist:ConstructionType` | **Install, Replacement** | UPM `InstallType = Literal["install", "replacement"]` in grades.py. **Note:** `load_case_builder.py` uses `"NEW"`/`"REPLACEMENT"` (different vocabulary, same concept). Connector must map both: `"install"` → Install, `"NEW"` → Install; `"replacement"` → Replacement, `"REPLACEMENT"` → Replacement. |
+| `edist:TransformerCoolingClass` | **ONAN, ONAF, ODAF** | True UPM Literal from `TransformerNameplate.cooling_class` |
+| `edist:TransformerPhaseConfig` | **SinglePhase, ThreePhase** | True UPM Literal from `TransformerNameplate.phase_config` (`"single_phase"/"three_phase"`) |
+| `edist:EquipmentType` | **Transformer, StreetLight, CutoutArrestor, Riser, TerminationBracket, Capacitor, Regulator, Recloser, Switch, Arrester, Communication, Catv, Telco, Fiber, Equipment** | UPM freeform; union across SPIDA, OCalc, PLS adapters |
+| `edist:FireThreatZone` | **None, Tier2, Tier3** | True UPM Literal from `EnvironmentalDesignContext.fire_threat_zone` (`"none"/"tier_2"/"tier_3"`) |
+
+---
+
+## Source Tool Format Notes
+
+These notes document the source-tool data models the schema's property set and
+enumeration values were derived from.
+
+### SPIDAcalc (Bentley Systems)
+- **Format:** JSON project files (`.spida` extension, JSON internally)
+- **Structure:** A project contains locations; each location has a label,
+  coordinates, and one or more designs (existing, proposed, remedy). Each design
+  has a pole and a list of wires, equipment, and guys.
+- **Key objects:** `pole` (species, class, height, owner), `wire` (clientItem
+  wire code, attachmentHeight, tensionGroup), `equipment` (transformers,
+  streetlights), `guy` (attachmentHeight, direction, leadDistance, clientItem)
+- **Analysis results:** Stored per-design as `analysisResults` containing
+  per-load-case summaries with `actualRatio`, `allowedRatio`, `unit`, `passes`
+- **Insulator types inferred** by `_infer_insulator_type` from clientItem name:
+  Deadend, Clamp, Bracket, Pin, Unknown (freeform — not a SPIDA enum)
+- **Equipment types** from adapter: `TERMINATION_BRACKET`, `RISER`,
+  `TRANSFORMER`, `STREET_LIGHT`, `CUTOUT_ARRESTOR`; pairing logic resolves
+  RISER + TERMINATION_BRACKET as primary riser entry points
+- **SpanGuy:** Modeled as paired structures sharing `external_id`; each pole
+  carries one `SpanGuy` entry pointing at the partner's attachment height
+- **Coordinate system:** WGS84 lat/lon on the location; relative offsets within
+  the design
+- **MCP access:** EPC Studio has a live SPIDAcalc MCP server
+- **Ownership note:** SPIDAcalc is a Bentley Systems product.
+
+### PLS-POLE / PLS-CADD (Bentley Systems)
+- **Format:** `.pole` files (PLS-POLE standalone) or embedded in `.lco` line
+  files (PLS-CADD). Text-based structured format.
+- **Key objects:** `POLE_SECTION` (diameter top/bottom, length, material),
+  `WIRE_POINT` (attachment coordinates, wire label), `GUY` (attachment height,
+  lead, direction, guy size), `LOAD_CASE` (wind, ice, temperature per NESC/GO95)
+- **Analysis results:** Utilization ratio per component (pole, guy, anchor)
+  per load case. PLS uses component-level stress vs. SPIDAcalc's groundline
+  moment — BIS schema must accommodate both (see `PoleLoadingResult` TODO).
+- **Insulator types from adapter:** PinInsulator → `"Pin"`, StrainInsulator → `"Deadend"`
+- **Equipment category map:** `{"transformer": "TRANSFORMER", "streetlight": "STREET_LIGHT"}`
+- **Ownership note:** PLS-POLE/PLS-CADD is a Bentley Systems product.
+
+### O-Calc Pro (Osmose Utilities Services)
+- **Format:** Proprietary `.ocalc` files (SQLite database internally) and PPLX XML export
+- **Key objects:** Pole properties map closely to ANSI O5.1 (species, class,
+  height, circumferences). Wire attachments include height, tension class,
+  wire size (English units throughout). Guys include lead, direction, grade.
+- **Analysis results:** Per-load-case pass/fail and utilization ratio
+- **Equipment types inferred** by `_infer_equipment_type`: TRANSFORMER,
+  STREET_LIGHT, CUTOUT_ARRESTOR, RISER (from description text matching)
+- **Span direction:** CoordinateA in radians (CCW from East); convert to compass
+  via `(90 - deg) % 360`. All UPM direction_deg fields use compass convention.
+- **Span tension types:** "Slack" or "Static" (Static → "full" in UPM)
+- **Ownership note:** Osmose Utilities Services is an independent company.
+
+### UPM (Universal Pole Model)
+- **Format:** Python/Pydantic models, serializable to JSON
+- **Role:** Canonical internal representation all three external formats translate
+  into before analysis. Primary reference for the BIS schema property set.
+
+---
+
+## Connector Integration Notes
+
+When building a UPM → iModel connector using `@itwin/connector-framework`:
+
+- `InitializeJob`: Import `ElectricDistribution.ecschema.xml` into the briefcase
+- `OpenSourceData`: Read UPM JSON project file
+- `ImportDomainSchema`: Register the `edist` schema
+- `UpdateExistingData`: Map UPM entities to BIS classes:
+  - `PoleModel.identity` + `PoleModel.geometry` → `edist:DistributionPole`
+  - `PoleModel.crossarms` → `edist:Crossarm` (nested insulators → `edist:Insulator` children)
+  - `PoleModel.guys` → `edist:GuyWire`; `PoleModel.span_guys` → `edist:SpanGuy`
+  - `PoleModel.anchors` → `edist:AnchorAssembly`
+  - `PoleModel.equipment` where `equipment_type == "TRANSFORMER"` → `edist:DistributionTransformer`
+  - `PoleModel.equipment` (all others) → `edist:PoleEquipment`
+  - `Insulator.spans` → `edist:OverheadConductor` (flattened from nested structure)
+  - Loading results (from source tool `analysisResults`) → `edist:PoleLoadingAnalysis` + `edist:PoleLoadingResult` aspects
+  - `PoleModel.clearance` → `edist:ClearanceCheck` elements + `edist:ClearanceSummary` aspect
+  - `PoleModel.inspection` → `edist:PoleInspection`
+  - `PoleModel.grounding` → `edist:GroundingConfiguration` aspect
+  - `PoleModel.environment` → `edist:EnvironmentalDesignContext` aspect
+  - `PoleModel.vegetation` → `edist:VegetationContext` aspect
+  - `PoleModel.avian` → `edist:AvianProtectionContext` aspect
+  - `PoleModel.service_networks` → `ServiceNetworkId` on `edist:DistributionTransformer` (interim)
+- **MeasuredValue conversion:** Extract `value_si` from each UPM `MeasuredValue`;
+  convert to BIS property unit. Preserve `source_value`/`source_unit` as custom
+  attributes for round-trip losslessness.
+- **Provenance:** Store UPM `source_ref.source_key` in the connector's external
+  source ID map so changesets are incremental (not full re-sync on every run).
+- **Geometry:** Convert pole `latitude`/`longitude` to iModel coordinate system;
+  generate catenary curves for `edist:OverheadConductor` from span length and sag data.
+
+---
+
+## References
+
+- BIS Schemas repo: `github.com/iTwin/bis-schemas`
+- Write a Connector guide: `itwinjs.org/learning/writeaconnector`
+- DistributionSystems schema: `itwinjs.org/bis/domains/distributionsystems.ecschema`
+- BIS Organization: `itwinjs.org/bis/guide/intro/bis-organization`
+- BIS Schema Release Process: `github.com/iTwin/bis-schemas/blob/master/docs/schema-release-process.md`
+- ANSI O5.1: American National Standard for Wood Poles
+- NESC C2-2023: National Electrical Safety Code (Rule 242, Rule 250B, Rule 261H)
+- GO-95 Rule 42, Rule 43, Rule 44: California PUC General Order 95
+- IEEE 738: Standard for Calculating the Current-Temperature Relationship of Bare
+  Overhead Conductors (ampacity)
+- IEEE C57.91: Guide for Loading Mineral-Oil-Immersed Transformers (thermal model)
+- IEEE 142: Grounding of Industrial and Commercial Power Systems
+- IEEE 1656: Guide for Testing the Electrical Performance of Insulating Cover-Up
+  Equipment (avian protection)
+- RUS Bulletin 1724E-200: Design Manual for High Voltage Transmission Lines
+
+---
+
+## Changelog — UPM Audit (2026-06-19)
+
+This section records what changed from the original draft after cross-referencing
+against the UPM source in `domain/`.
+
+### Property name corrections
+
+| Class | Old property | New property | UPM field |
+|---|---|---|---|
+| `DistributionPoleType` | `PoleHeight` | `ManufacturedHeight` | `PoleGeometry.manufactured_height` |
+| `DistributionPole` | `SettingDepth` | `SetDepth` | `PoleGeometry.set_depth` |
+| `DistributionPole` | `TipCircumference` | `PoleTipCircumference` | `PoleGeometry.pole_top_circumference` |
+| `DistributionPoleType` | `NominalTipDiameter` | `NominalTipCircumference` | UPM stores circumference not diameter |
+| `DistributionPoleType` | `NominalGroundlineDiameter` | `NominalGroundlineCircumference` | UPM stores circumference not diameter |
+| `PoleAttachment` | `MountHeight` | `AttachmentHeight` | matches UPM `attachment_height` field |
+| `DistributionTransformer` | `Phase` | `PhaseConfig` | `TransformerNameplate.phase_config` |
+| `DistributionTransformer` | `KVARating` | `RatedKva` | `TransformerNameplate.rated_kva` |
+| `DistributionTransformer` | `PrimaryVoltage` | `PrimaryVoltageKv` | `TransformerNameplate.primary_voltage_kv` |
+| `DistributionTransformer` | `SecondaryVoltage` | `SecondaryVoltageV` | `TransformerNameplate.secondary_voltage_v` |
+| `PoleInspection` | `OverallRating` | `Verdict` | `InspectionSection.verdict` |
+| `PoleInspection` | `InspectionDate` (via `dateTime`) | `InspectionDate` | `InspectionSection.last_inspection_date` |
+
+### Missing fields added
+
+| Class | New property | UPM source |
+|---|---|---|
+| `DistributionPole` | `Elevation` | `PoleGeometry.elevation_m` |
+| `DistributionPole` | `HeadingDegrees` | `PoleGeometry.heading_deg` |
+| `DistributionPole` | `GpsAccuracyMeters` | `PoleGeometry.gps_accuracy_m` |
+| `DistributionPole` | `StructureName` | `PoleIdentity.structure_name` |
+| `Insulator` | `VerticalOffset` | `Insulator.vertical_offset` |
+| `Insulator` | `HorizontalOffset` | `Insulator.horizontal_offset` |
+| `Insulator` | `CrossarmId` | `Insulator.crossarm_id` |
+| `Crossarm` | `ArmSide` | `Crossarm.side` / `FramingBreakdown.crossarm_structure` |
+| `OverheadConductor` | `WireId`, `RotationDegrees`, `EndpointType`, `TensionGroup` | `Span` fields |
+| `DistributionTransformer` | `CoolingClass` | `TransformerNameplate.cooling_class` |
+| `DistributionTransformer` | `ConnectionType` | `TransformerNameplate.connection_type` |
+| `DistributionTransformer` | `LossRatioR` | `TransformerNameplate.loss_ratio_R` |
+| `DistributionTransformer` | `ActualLoadKva` | `TransformerNameplate.actual_load_kva` |
+| `DistributionTransformer` | `RatedTopOilRiseC` | `TransformerNameplate.rated_top_oil_rise_c` |
+| `DistributionTransformer` | `RatedHottestSpotRiseC` | `TransformerNameplate.rated_hottest_spot_rise_c` |
+| `DistributionTransformer` | `BottomHeight` | `Equipment.bottom_height` |
+| `ClearanceCheck` | `TableId`, `ClearanceTypeId`, `Dimension`, `SameSupport`, `SubjectAttachmentId`, `ObjectAttachmentId`, `SubjectVoltageV`, `ObjectVoltageV`, `ClearanceDelta` | `ClearanceCheck` + `ClearanceRelationship` fields |
+| `PoleInspection` | `InspectionProgram`, `SoundTestResult`, `BoreholeTestResult`, `GroundlineDecayPct`, `ResidualStrengthPct`, `ShellThicknessIn`, `TreatedBool`, `TreatmentType`, `LastTreatmentDate`, `ConditionFactor`, `OrigCircumferenceIn`, `CurrentCircumferenceIn`, `EffectiveCircumferenceIn`, `GlShellAvgIn`, `WoodStrengthPct` | `InspectionSection` + `InspectionRecord` (pge_ptt.py) |
+| `LoadCaseDefinition` | `NescGrade`, `GO95Grade`, `NescDistrict`, `GO95Zone`, `ConstructionType`, `NescRevision`, `GO95Revision` | grades.py + zones.py Literals |
+
+### New classes added
+
+| Class | Reason |
+|---|---|
+| `edist:SpanGuy` | UPM has `SpanGuy` (pole-to-pole guy); absent from original draft |
+| `edist:PoleEquipment` | General equipment class; original draft only had `DistributionTransformer` |
+| `edist:ClearanceSummary` | UPM `ClearanceSummary` block; pole-level rollup |
+
+### New gaps added
+
+| Gap | Description |
+|---|---|
+| Gap 6 | Grounding configuration (IEEE 142) |
+| Gap 7 | Environmental design context (IEEE 738, C57.91) |
+| Gap 8 | Vegetation clearance context |
+| Gap 9 | Avian protection context (IEEE 1656) |
+| Gap 10 | Service network references |
+
+### Enum corrections
+
+| Enum | Change |
+|---|---|
+| `AnalysisStandard` → split | `AnalysisCode` + `NescGrade` + `GO95Grade` (standard and grade are orthogonal axes) |
+| `InsulatorType` | PinType/PostType/SuspensionType/DeadEndType/StrainType → **Pin/Deadend/Clamp/Bracket/Unknown** (union across all adapters) |
+| `ConductorType` → `ConductorUsageGroup` | Extended to full UPM usage group set; Guy removed |
+| `InspectionOverallRating` → `InspectionVerdict` | Satisfactory/Marginal/Unsatisfactory/Condemned → **Pass/Marginal/Fail** (matches UPM Literal) |
+| `FindingSeverity` | Minor/Moderate/Severe/Critical → **Info/Warning/Error/Critical** (matches UPM Literal) |
+| New: `NescDistrict` | HEAVY/MEDIUM/LIGHT/WARM_ISLAND_UNDER_9000_FT/WARM_ISLAND_OVER_9000_FT (from zones.py) |
+| New: `GO95Zone` | HEAVY/LIGHT (from zones.py) |
+| New: `ConstructionType` | Install/Replacement (from grades.py `InstallType`). Connector maps BOTH `"install"`/`"replacement"` (grades.py) AND `"NEW"`/`"REPLACEMENT"` (load_case_builder.py) to this enum. |
+| Removed: ~~`RecommendedAction`~~ | Original: None/Monitor/Reinforce/Replace/Emergency. **Removed** — UPM `InspectionSection.recommendation` is `Optional[str]` (freeform). Replaced by a plain string property; enum values would truncate real utility text. |
+| New: `TransformerCoolingClass` | ONAN/ONAF/ODAF (from TransformerNameplate Literal) |
+| New: `TransformerPhaseConfig` | SinglePhase/ThreePhase |
+| New: `CrossarmSide` | Single/Double/Mixed/Unknown (from FramingBreakdown Literal) |
+| New: `ClearanceDimension` | Vertical/Horizontal/Radial/Unknown (from ClearanceRelationship Literal) |
+| New: `EquipmentType` | Union of equipment_type strings across SPIDA/OCalc/PLS adapters |
+| New: `FireThreatZone` | None/Tier2/Tier3 (from EnvironmentalDesignContext Literal) |
+
+### TODO callouts added
+
+| Location | TODO |
+|---|---|
+| Gap 1 | LeanAngle/LeanDirection — not in UPM; field-survey-only |
+| Gap 1 | `PoleIdentity.source_ref` — no BIS property; handled by connector external source ID map |
+| Gap 2 | Tension limits (Rule 261H) — computed, not stored; document in rationale.md |
+| Gap 2 | PLS-POLE multi-component utilization — may need additional aspects |
+| Gap 3 | `AnchorRating` removed — no UPM source; `SoilClass` moved to grounding |
+| Gap 3 | `GuyWire` detailed properties from `metadata` — confirm adapter extraction |
+| Gap 9 | ~~`AvianContext.in_avian_zones: List[str]`~~ — **resolved**: `edist:AvianZone` definition element + `edist:PoleIsInAvianZone` relationship (option b). Connector upserts zone by ZoneId, inserts one relationship per entry. |
+| Gap 10 | `ServiceNetworkRef` — placeholder `ServiceNetworkId` string until services schema exists |

--- a/Domains/2-DisciplinePhysical/ElectricDistribution/design.md
+++ b/Domains/2-DisciplinePhysical/ElectricDistribution/design.md
@@ -34,10 +34,12 @@ BIS schemas are organized into layers. This schema belongs at layer
 It references schemas from:
 
 - `2-DisciplinePhysical`: `PowerSystemResourcesPhysical` (alias `psrp`) — the
-  **shared power-system base schema** this domain extends. Distribution physical
-  classes derive from `psrp:Structure` / `psrp:Equipment` / `psrp:AuxiliaryEquipment`
-  / `psrp:Foundation` so they share the same bases as the substation+ domain
-  (per iTwin/bis-schemas PR #733 review).
+  **shared power-system schema** this domain extends. Distribution classes derive
+  from their specific psrp classes (`Pole`, `Conductor`, `Transformer`,
+  `Insulator`, `GuyWire`, `SpanGuy`, `AnchorCage`, `CableSupports`,
+  `AuxiliaryEquipment`, `PolePhysicalType`) so they reuse the power-system domain
+  hierarchy shared with the substation+ domain rather than re-deriving from
+  `bis:PhysicalElement` (per iTwin/bis-schemas PR #733 review).
 - `0-Core`: `BisCore` — `psrp` bases ultimately subclass `bis:PhysicalElement`
 - `0-Core`: `Analytical` — for loading analysis elements
 - `1-Common`: `DistributionSystems` (alias `dsys`) — flow/control mixin source
@@ -175,7 +177,7 @@ same species/class/height combination.
 
 #### `edist:DistributionPole` — placed instance
 
-Subclass of `psrp:Structure` (shared power-system structural base). Implements `dsys:IDistributionElement`.
+Subclass of `psrp:Pole` (`Pole → OverheadStructure → Structure`). Implements `dsys:IDistributionElement`.
 
 | BIS Property | UPM Field | Type | Unit | Notes |
 |---|---|---|---|---|
@@ -318,7 +320,7 @@ Subclass of `anlyt:AnalyticalElementAnalyzesElement`.
 
 ### General pattern
 
-All direct pole attachments subclass `edist:PoleAttachment` → `psrp:AuxiliaryEquipment`.
+All direct pole attachments derive from their specific `psrp` class and apply the `edist:PoleAttachment` mixin.
 They are assembled to the pole via `bis:PhysicalElementAssemblesElements`. Each
 has an `AttachmentHeight` (ft above grade) derived from the UPM `attachment_height`
 MeasuredValue (metres in UPM).
@@ -333,7 +335,13 @@ MeasuredValue (metres in UPM).
 
 #### `edist:PoleAttachment` — abstract base
 
-Subclass of `psrp:AuxiliaryEquipment`. Abstract. (Inherits the `dsys:IDistributionFlowElement` and `spi:IStructuralElement` mixins via `psrp:Equipment`.)
+A **mixin** (`IsMixin`, applies to `bis:PhysicalElement`) carrying the shared
+attachment properties (AttachmentHeight, DirectionDegrees, InstallDate); it is
+the target of `DistributionPoleAssemblesAttachments`. Each attachment class
+derives from its specific psrp base (e.g. `Crossarm → CableSupports`,
+`Insulator → Insulator`, `GuyWire → GuyWire`, `Transformer → Transformer`) **and**
+applies this mixin, since the attachments span both the `Structure` and
+`Equipment` psrp branches and no longer share a single entity base.
 
 | BIS Property | UPM Field | Type | Description |
 |---|---|---|---|
@@ -431,7 +439,7 @@ Subclass of `edist:PoleAttachment`.
 
 #### `edist:AnchorAssembly`
 
-Subclass of `psrp:Foundation` (ground-embedded support). Associated to the pole, not a subtype of
+Subclass of `psrp:AnchorCage` (`AnchorCage → UndergroundStructure → Structure`). Associated to the pole, not a subtype of
 `PoleAttachment` (anchors are ground-mounted, not pole-mounted).
 
 | BIS Property | UPM Field | Type | Description |
@@ -454,7 +462,7 @@ New relationship. `edist:GuyWire` → `edist:AnchorAssembly`.
 
 #### `edist:OverheadConductor`
 
-Subclass of `psrp:Equipment` (inherits `dsys:IDistributionFlowElement`).
+Subclass of `psrp:Conductor` (`Conductor → Equipment`; inherits `dsys:IDistributionFlowElement`).
 Represents a conductor span between two poles. Populated from UPM `Span` objects
 (which are nested under `Insulator.spans` in the UPM).
 

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -8032,5 +8032,20 @@
       "approved": "Yes",
       "localizations": []
     }
+  ],
+  "ElectricDistribution": [
+    {
+      "name": "ElectricDistribution",
+      "path": "Domains\\2-DisciplinePhysical\\ElectricDistribution\\ElectricDistribution.ecschema.xml",
+      "released": false,
+      "version": "01.00.00",
+      "comment": "Working Copy",
+      "localizations": [],
+      "sha1": "",
+      "author": "",
+      "approved": "No",
+      "date": "Unknown",
+      "dynamic": "No"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

This PR proposes a new BIS **2-DisciplinePhysical** domain schema for overhead electric distribution infrastructure.

- **Schema name:** `ElectricDistribution` · alias `edist` · version `01.00.00`
- **Schema path:** `Domains/2-DisciplinePhysical/ElectricDistribution/ElectricDistribution.ecschema.xml`
- **Validation:** Passes `SchemaValidationRunner` with zero violations

### Schema Contents

| Category | Count | Classes |
|---|---|---|
| PhysicalElement | 10 | DistributionPole, Crossarm, Insulator, OverheadConductor, DistributionTransformer, PoleEquipment, SpanGuy, GuyWire, AnchorAssembly, PoleAttachment (abstract) |
| ElementAspect | 8 | GroundingConfiguration, EnvironmentalDesignContext, VegetationContext, AvianProtectionContext, ClearanceSummary (Unique); PoleLoadingResult, InspectionFinding, ConductorSagCondition (Multi) |
| AnalyticalElement | 2 | PoleLoadingAnalysis, ClearanceCheck |
| InformationRecordElement | 2 | PoleInspection, ClearanceViolation |
| DefinitionElement | 3 | AvianZone, LoadCaseDefinition, ClearanceRequirement |
| PhysicalType | 1 | DistributionPoleType |
| ECEnumeration | 25 | PoleMaterial, NescDistrict, GO95Zone, ConductorUsageGroup, and 21 others |
| ECRelationshipClass | 14 | Type-instance, assembly, analytical, aspect ownership, and reference relationships |
| Custom KOQ | 2 | EDIST_RESISTANCE (`u:OHM`), EDIST_RESISTIVITY (`u:OHM_M`) |

### Design Rationale

- `DistributionPole` implements `dsys:IDistributionElement` (not `IDistributionFlowElement`) — a pole is structural support, not a flow conduit
- Five aspects are `ElementUniqueAspect` (one per pole: grounding, environmental, vegetation, avian protection, clearance summary); three are `ElementMultiAspect` (many per host: loading results, inspection findings, sag conditions)
- `AvianZone` modeled as `bis:DefinitionElement` with a `PoleIsInAvianZone` many-to-many relationship, supporting upsert-by-ZoneId from connector imports
- `anlyt:AnalyticalSimulatesSpatialElement` used as the base for analytical relationships (confirmed against Analytical schema)
- `ClearanceViolation` and `PoleInspection` use `bis:InformationRecordElement` (`bis:InformationContentElement` carries `NotSubclassableInReferencingSchemas`)

### Ground Truth

Property names are aligned 1-to-1 with the Universal Pole Model (UPM), a proprietary Pydantic domain model validated against the data models of **SPIDAcalc**, **PLS-POLE / PLS-CADD**, and **O-Calc Pro** — the three dominant overhead distribution analysis tools. The UPM is covered by 825+ domain-validated tests spanning real-world pole configurations across NESC and GO-95 jurisdictions.

### Schema References

| Schema | Version |
|---|---|
| BisCore | 01.00.15 |
| Analytical | 01.00.02 |
| DistributionSystems | 01.00.03 |
| AecUnits | 01.00.03 |
| Units | 01.00.06 |
| Formats | 01.00.00 |
| CoreCustomAttributes | 01.00.03 |
| BisCustomAttributes | 01.00.00 |

BisCore 01.00.15 is required by Analytical 01.00.02. Units 01.00.06 is the minimum released version containing `u:OHM_M` (ELECTRICAL_RESISTIVITY).

---

Proposed by Julius Guay IV (Bentley Systems, Application Engineer, Solutions Engineering) · [linkedin.com/in/juliusguay](https://www.linkedin.com/in/juliusguay/)