### PR TITLE
Add new scale bar classes

### DIFF
--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -42,4 +42,14 @@
         description="A bis:GraphicalType2d that defines the properties of a NorthArrowCallout.">
         <BaseClass>bis:GraphicalType2d</BaseClass>
     </ECEntityClass>
+    
+    <ECEntityClass typeName="ScaleBarCallout" displayLabel="Scale Bar Callout" modifier="None"
+        description="A bis:AnnotationElement2d that displays a scale bar on a sheet.">
+        <BaseClass>bis:AnnotationElement2d</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="ScaleBarCalloutDefinition" displayLabel="Scale Bar Callout Definition" modifier="None"
+        description="A bis:GraphicalType2d that defines the properties of a ScaleBarCallout.">
+        <BaseClass>bis:GraphicalType2d</BaseClass>
+    </ECEntityClass>
 </ECSchema>

--- a/Domains/4-Application/DrawingProduction/Released/DrawingProduction.01.00.02.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/Released/DrawingProduction.01.00.02.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="DrawingProduction" alias="dp" version="01.00.03"
+<ECSchema schemaName="DrawingProduction" alias="dp" version="01.00.02"
     xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2"
     description="This schema contains Drawing Production concepts. They should be considered domain agnostic.">
     <ECSchemaReference name="BisCore" version="01.00.25" alias="bis" />
@@ -12,7 +12,7 @@
     
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -7948,7 +7948,7 @@
       "name": "DrawingProduction",
       "path": "Domains\\4-Application\\DrawingProduction\\DrawingProduction.ecschema.xml",
       "released": false,
-      "version": "01.00.02",
+      "version": "01.00.03",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -7986,6 +7986,21 @@
       "dynamic": "No",
       "approved": "Yes",
       "localizations": []
+    },
+    {
+      "name": "DrawingProduction",
+      "path": "Domains\\4-Application\\DrawingProduction\\Released\\DrawingProduction.01.00.02.ecschema.xml",
+      "released": true,
+      "version": "01.00.02",
+      "localizations": [],
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "6b224a0eb4314dd7acc24fd3337a6aad00788fc1",
+      "verified": "Yes",
+      "author": "Ryan.Litzke",
+      "date": "6/30/2026",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "DrawingProductionForSiteDesign": [


### PR DESCRIPTION
Introduces two new classes for DrawingProduction:

1. `ScaleBarCallout`: A bis:AnnotationElement2d that displays a scale bar on a sheet.
2. `ScaleBarCalloutDefinition`: A bis:GraphicalType2d that defines the properties of a ScaleBarCallout.