### PR TITLE
[OpenSite] Set Min and Max Values for Properties

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -311,13 +311,13 @@
     <ECEntityClass typeName="DrivewayEndVertex" modifier="Sealed" displayLabel="Driveway End Vertex" description="The first and last Vertex of a DrivewayPath.">
         <BaseClass>PathEndVertex</BaseClass>
 
-        <ECProperty propertyName="CuldesacRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Radius" description="Radius of cul-de-sac." />
+        <ECProperty propertyName="CuldesacRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Radius" description="Radius of cul-de-sac." />
         <ECProperty propertyName="CuldesacOffset" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Offset" description="Offset of cul-de-sac, negative for left." />
-        <ECProperty propertyName="CuldesacROWRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Radius" description="Cul-de-sac right of way entrance radius." />
-        <ECProperty propertyName="CuldesacROWReturnRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Return Radius" description="Cul-de-sac right of way exit radius." />
+        <ECProperty propertyName="CuldesacROWRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Radius" description="Cul-de-sac right of way entrance radius." />
+        <ECProperty propertyName="CuldesacROWReturnRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Return Radius" description="Cul-de-sac right of way exit radius." />
 
-        <ECProperty propertyName="EntranceFlareRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Entrance Radius" description="Sets the size of the flared entrance radius. Exit will be defined by the drive side of the road." />
-        <ECProperty propertyName="ExitFlareRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Exit Radius" description="Sets the size of the flared exit radius.  Entrance will be defined by the drive side of the road." />
+        <ECProperty propertyName="EntranceFlareRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Entrance Radius" description="Sets the size of the flared entrance radius. Exit will be defined by the drive side of the road." />
+        <ECProperty propertyName="ExitFlareRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Exit Radius" description="Sets the size of the flared exit radius.  Entrance will be defined by the drive side of the road." />
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayMidVertex" modifier="Sealed" displayLabel="Driveway Mid Vertex" description="Vertex of a DrivewayPath that is attached to two DrivewayPathEdge instances.">
@@ -349,10 +349,10 @@
         </ECProperty>
 
         <ECProperty propertyName="KnuckleType" typeName="DrivewayMidVertexKnuckleType" category="DrivewayMidVertex_Knuckle" displayLabel="Type" description="Knuckle type." />
-        <ECProperty propertyName="KnuckleRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Radius" description="Knuckle radius." />
+        <ECProperty propertyName="KnuckleRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Radius" description="Knuckle radius." />
         <ECProperty propertyName="KnuckleOffset" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Offset" description="Knuckle offset." />
-        <ECProperty propertyName="CurbReturnRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Radius" description="Curb return radius." />
-        <ECProperty propertyName="CurbReturnLength" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Length" description="Curb return length." />
+        <ECProperty propertyName="CurbReturnRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Radius" description="Curb return radius." />
+        <ECProperty propertyName="CurbReturnLength" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Length" description="Curb return length." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingOverride" modifier="Abstract" displayLabel="Parking Override">
@@ -395,8 +395,8 @@
         <BaseClass>BayOverride</BaseClass>
 
         <ECProperty propertyName="SideOfBay" typeName="BaySide" category="ParkingBayOverride_Bay" displayLabel="Side of Bay" description="Side of the bay to be overridden." />
-        <ECProperty propertyName="Angle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingBayOverride_Bay" displayLabel="Row Angle" description="The new angle of the Bay." />
-        <ECProperty propertyName="Depth" minimumValue="-30.48" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingBayOverride_Bay" displayLabel="Row Depth" description="The new depth of the Bay." />
+        <ECProperty propertyName="Angle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingBayOverride_Bay" displayLabel="Row Angle" description="The new angle of the Bay." />
+        <ECProperty propertyName="Depth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingBayOverride_Bay" displayLabel="Row Depth" description="The new depth of the Bay." />
     </ECEntityClass>
 
     <ECEntityClass typeName="SpaceOverride" modifier="Abstract" displayLabel="Space Override">
@@ -433,8 +433,8 @@
         <ECProperty propertyName="ParkingNumber" minimumValue="0" maximumValue="1000" typeName="int" category="ParkingSpaceVertex_Parking" displayLabel="Number of Spaces" description="Number of spaces to be overridden by a parking vertex." />
         <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:LENGTH" displayLabel="Space Width" description="Width to be used for a parking vertex override." />
         <ECProperty propertyName="ParkingSurfaceType" typeName="SurfaceType" category="ParkingSpaceVertex_Parking" displayLabel="Surface Type" description="Surface type defined by a parking vertex override." />
-        <ECProperty propertyName="ParkingMinSlope" minimumValue="0" maximumValue="10" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope defined by a parking vertex override." />
-        <ECProperty propertyName="ParkingMaxSlope" minimumValue="0" maximumValue="10" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope defined by a parking vertex override." />
+        <ECProperty propertyName="ParkingMinSlope" minimumValue="-10" maximumValue="10" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope defined by a parking vertex override." />
+        <ECProperty propertyName="ParkingMaxSlope" minimumValue="-10" maximumValue="10" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope defined by a parking vertex override." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingBayVertex" modifier="Sealed" displayLabel="Parking Bay Vertex" description="Defines a location point to override an entire parking bay settings.">
@@ -443,8 +443,8 @@
         <ECProperty propertyName="BayMedianWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Median Width" description="Median width defined by a bay override." />
         <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Parking Depth Primary" description="Defines the bay override parking depth for primary side." />
         <ECProperty propertyName="ParkingDepthOther" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Parking Depth Secondary" description="Defines the bay override parking depth for secondary side." />
-        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Primary" description="Defines the bay override parking angle for primary side." />
-        <ECProperty propertyName="ParkingAngleOther" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Secondary" description="Defines the bay override parking angle for secondary side." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Primary" description="Defines the bay override parking angle for primary side." />
+        <ECProperty propertyName="ParkingAngleOther" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Secondary" description="Defines the bay override parking angle for secondary side." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingAisleVertex" modifier="Sealed" displayLabel="Parking Aisle Vertex" description="Defines a location point to override a parking aisle settings.">
@@ -566,7 +566,7 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="SurfaceDepth" minimumValue="-30.48" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="CenterlinePathEdge_Grading" displayLabel="Surface Depth" description="Surface material depth for path." >
+        <ECProperty propertyName="SurfaceDepth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="CenterlinePathEdge_Grading" displayLabel="Surface Depth" description="Surface material depth for path." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -655,7 +655,7 @@
         </ECProperty>
 
         <ECProperty propertyName="SidewalkWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="SidewalkPathFin_Sidewalk" displayLabel="Sidewalk Width" description="Sidewalk width for this side of the sidewalk." />
-        <ECProperty propertyName="CrossSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="SidewalkPathFin_Sidewalk" displayLabel="Cross Slope" description="Cross slope for this side of the sidewalk." />
+        <ECProperty propertyName="CrossSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="SidewalkPathFin_Sidewalk" displayLabel="Cross Slope" description="Cross slope for this side of the sidewalk." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingDirectionPathEdge" modifier="Sealed" displayLabel="Parking Direction Edge" description="Parking direction path edge.">
@@ -1064,9 +1064,9 @@
         </ECProperty>
         <ECProperty propertyName="RunoffCoefficient" minimumValue="0" maximumValue="1" typeName="double" category="ShapedArea_Surface" displayLabel="Runoff Coefficient" description="Runoff coefficient for area." />
 
-        <ECProperty propertyName="FixedSlope" minimumValue="0" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed design slope for area." />
-        <ECProperty propertyName="MinSlope" minimumValue="0" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum design slope for area." />
-        <ECProperty propertyName="MaxSlope" minimumValue="0" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum design slope for area." />
+        <ECProperty propertyName="FixedSlope" minimumValue="-10" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed design slope for area." />
+        <ECProperty propertyName="MinSlope" minimumValue="-10" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum design slope for area." />
+        <ECProperty propertyName="MaxSlope" minimumValue="-10" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum design slope for area." />
         <ECProperty propertyName="MinZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Min. Elevation" description="Minimum design elevation for area." />
         <ECProperty propertyName="MaxZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Max. Elevation" description="Maximum design elevation for area." />
     </ECEntityClass>
@@ -1130,7 +1130,7 @@
         <ECProperty propertyName="DoCentralParking" typeName="boolean" category="LayoutParkingArea_Parking" displayLabel="Add Central Parking" description="Add central parking." />
         <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:LENGTH"  displayLabel="Width" description="Parking space width." />
         <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:LENGTH"  displayLabel="Depth" description="Parking space depth." />
-        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:ANGLE"  displayLabel="Angle" description="Parking space angle." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:ANGLE"  displayLabel="Angle" description="Parking space angle." />
         <ECProperty propertyName="ParkingSpaces" typeName="int" category="LayoutParkingArea_Parking" displayLabel="Parking Spaces" description="Number of spaces.">
 		    <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
@@ -1164,8 +1164,8 @@
 
         <ECProperty propertyName="BayCurbRadius" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_ParkingBay" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Radius" description="Parking bay curb radius." />
 
-        <ECProperty propertyName="MinSlopeParkingLot" minimumValue="0" maximumValue="10" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Design Slope" description="Minimum design slope for parking lot." />
-        <ECProperty propertyName="MaxSlopeParkingLot" minimumValue="0" maximumValue="10" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Design Slope" description="Maximum design slope for parking lot." />
+        <ECProperty propertyName="MinSlopeParkingLot" minimumValue="-10" maximumValue="10" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Design Slope" description="Minimum design slope for parking lot." />
+        <ECProperty propertyName="MaxSlopeParkingLot" minimumValue="-10" maximumValue="10" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Design Slope" description="Maximum design slope for parking lot." />
         <ECProperty propertyName="SurfaceTypeParkingLot" typeName="SurfaceType" category="LayoutParkingArea_ParkingGrading" displayLabel="Surface Type" description="Surface type or material for parking lot." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
@@ -1196,7 +1196,7 @@
 
         <ECProperty propertyName="Height" minimumValue="-304.8" maximumValue="9144" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Riser Top Elevation" description="Riser Top Elevation." />
         <ECProperty propertyName="TopHeight" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Dry Storage Height" description="Dry Storage Height." />
-		<ECProperty propertyName="WallSlope" minimumValue="0" maximumValue="10" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:SLOPE" displayLabel="Side Slope" description=" Side Slope." />
+		<ECProperty propertyName="WallSlope" minimumValue="-10" maximumValue="10" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:SLOPE" displayLabel="Side Slope" description=" Side Slope." />
         <ECProperty propertyName="WallWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Berm Width" description="Depth of the pond." />
 		<ECProperty propertyName="Depth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Riser Height" description="Riser Height." />
 		<ECProperty propertyName="SizePond" typeName="boolean" category="LayoutPondArea_Pond" displayLabel="Size Pond" description="Size the pond using the target surface or volume." />
@@ -1285,9 +1285,9 @@
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="GradingArea_Surface" displayLabel="Surface Type" description="Surface type or material for grading area." />
         <ECProperty propertyName="SurfaceDepth" minimumValue="0" maximumValue="30.48" typeName="double" category="GradingArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth for grading area." />
 
-        <ECProperty propertyName="FixedSlope" minimumValue="0" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed slope constraint on grading area." />
-        <ECProperty propertyName="MinSlope" minimumValue="0" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope constraint on grading area." />
-        <ECProperty propertyName="MaxSlope" minimumValue="0" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope constraint on grading area." />
+        <ECProperty propertyName="FixedSlope" minimumValue="-10" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed slope constraint on grading area." />
+        <ECProperty propertyName="MinSlope" minimumValue="-10" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope constraint on grading area." />
+        <ECProperty propertyName="MaxSlope" minimumValue="-10" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope constraint on grading area." />
         <ECProperty propertyName="MinZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Min. Elevation" description="Minimum elevation change constraint on grading area." />
         <ECProperty propertyName="MaxZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Max. Elevation" description="Maximum elevation change constraint on grading area." />
     </ECEntityClass>
@@ -1334,7 +1334,7 @@
 
         <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingRowPath_Parking" displayLabel="Width" description="Parking width for row." />
         <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingRowPath_Parking" displayLabel="Depth" description="Parking depth for row." />
-        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingRowPath_Parking" displayLabel="Angle" description="Parking angle for row." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingRowPath_Parking" displayLabel="Angle" description="Parking angle for row." />
     </ECEntityClass>
 
     <ECEntityClass typeName="GradingPath" modifier="Abstract" displayLabel="Grading Path" description="Grading path.">
@@ -1379,7 +1379,7 @@
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
         <ECProperty propertyName="Spacing" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Spacing" description="Space between the hatch lines." />
-        <ECProperty propertyName="Angle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" displayLabel="Angle" description="Angle of the hatch lines." />
+        <ECProperty propertyName="Angle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" kindOfQuantity="cvu:ANGLE" displayLabel="Angle" description="Angle of the hatch lines." />
         <ECProperty propertyName="Width" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Width" description="Width of the hatch lines." />
     </ECEntityClass>
 
@@ -1455,7 +1455,7 @@
 
         <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Parking Width" description="Parking space width." />
         <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Parking Depth" description="Parking space depth." />
-        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeParkingAspect_Parking" displayLabel="Parking Angle" description="Parking space angle." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeParkingAspect_Parking" displayLabel="Parking Angle" description="Parking space angle." />
         <ECProperty propertyName="MaxParkingOffset" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Max. Parking Offset" />
         <ECProperty propertyName="IgnoreProblems" typeName="boolean" category="EdgeParkingAspect_Parking" displayLabel="Ignore Problems" />
         <ECProperty propertyName="ParksPerIsland" minimumValue="0" maximumValue="1000" typeName="int" category="EdgeParkingAspect_Parking" displayLabel="Count Per Island" description="Parking space count between islands." />
@@ -1518,7 +1518,7 @@
 
         <ECProperty propertyName="OnSideParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Width" description="Onside parking space width for this side of driveway." />
         <ECProperty propertyName="OnSideParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Depth" description="Onside parking space depth for this side of driveway." />
-        <ECProperty propertyName="OnSideParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Angle" description="Onside parking space angle for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingAngle" minimumValue="-3.141592653589793" maximumValue="3.141592653589793" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Angle" description="Onside parking space angle for this side of driveway." />
         <ECProperty propertyName="OnSideParksPerIsland" minimumValue="0" maximumValue="1000" typeName="int" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parks Per Island" description="Onside parking space count per island on this side of driveway." />
         <ECProperty propertyName="OnSideIslandWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Island Width" description="Onside parking island width for this side of driveway." />
         <ECProperty propertyName="OnSideIslandCurbRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Curb Radius" description="Onside parking island curb radius for this side of driveway." />
@@ -1531,7 +1531,7 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="OnSideParkingSurfaceDepth" minimumValue="-30.48" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Depth" description="Onside parking material depth for this side of driveway." >
+        <ECProperty propertyName="OnSideParkingSurfaceDepth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Depth" description="Onside parking material depth for this side of driveway." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -1540,8 +1540,8 @@
             </ECCustomAttributes>
         </ECProperty>
         <ECNavigationProperty propertyName="LayeredStructureType" relationshipName="EdgeOnSideParkingAspectUsesLayeredStructureType" direction="Forward" category="EdgeOnSideParkingAspect_Grading" displayLabel="Layered Structure Type" />
-        <ECProperty propertyName="OnSideParkingMinSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Min. Slope" description="Onside parking minimum design slope for this side of driveway." />
-        <ECProperty propertyName="OnSideParkingMaxSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Max. Slope" description="Onside parking maximum design slope for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingMinSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Min. Slope" description="Onside parking minimum design slope for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingMaxSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Max. Slope" description="Onside parking maximum design slope for this side of driveway." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="DrivewayPathFinOwnsOnSideParkingAspect" modifier="Sealed" strength="embedding">
@@ -1576,8 +1576,8 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="MinSidewalkSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Min. Slope" description="Minimum allowable sidewalk slope." />
-        <ECProperty propertyName="MaxSidewalkSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Max. Slope" description="Maximum allowable sidewalk slope." />
+        <ECProperty propertyName="MinSidewalkSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Min. Slope" description="Minimum allowable sidewalk slope." />
+        <ECProperty propertyName="MaxSidewalkSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Max. Slope" description="Maximum allowable sidewalk slope." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="BuildingEdgeOwnsSidewalkAspect" modifier="Sealed" strength="embedding">
@@ -1892,10 +1892,10 @@
         <BaseClass>BaseSurfaceControlVertex</BaseClass>
 
         <ECProperty propertyName="VertexType" typeName="SurfaceControlVertexType" description="Specifies the type of control vertex used." displayLabel="Control Vertex Type" category="SurfaceControl"/>
-        <ECProperty propertyName="Slope" minimumValue="0" maximumValue="10" typeName="double" description="Slope of the line emanating from this vertex position." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="SlopeBehind" minimumValue="0" maximumValue="10" typeName="double" description="Slope behind the line emanating from this vertex position." displayLabel="Slope Behind" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="MinSlope" minimumValue="0" maximumValue="10" typeName="double" description="Minimum slope constraint." displayLabel="Min. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="MaxSlope" minimumValue="0" maximumValue="10" typeName="double" description="Maximum slope constraint." displayLabel="Max. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="Slope" minimumValue="-10" maximumValue="10" typeName="double" description="Slope of the line emanating from this vertex position." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="SlopeBehind" minimumValue="-10" maximumValue="10" typeName="double" description="Slope behind the line emanating from this vertex position." displayLabel="Slope Behind" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="MinSlope" minimumValue="-10" maximumValue="10" typeName="double" description="Minimum slope constraint." displayLabel="Min. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="MaxSlope" minimumValue="-10" maximumValue="10" typeName="double" description="Maximum slope constraint." displayLabel="Max. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
         <ECProperty propertyName="Direction" typeName="point2d" description="Direction of the line emanating from this vertex position that constrains the elevation interpolation." displayLabel="Direction" category="SurfaceControl"/>
         <ECProperty propertyName="Mirrored" typeName="boolean" description="True if the direction constraint should represent two lines emanating from the position, forming a V shape, or false if it should be a single line passing through the position." displayLabel="Mirrored" category="SurfaceControl"/>
         <ECProperty propertyName="ClampDistance" minimumValue="0" maximumValue="304.8" typeName="double" description="Distance at which to clamp slope calculations, turning elevation into a piecewise function where it stays constant beyond this distance." displayLabel="Clamp Distance" category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
@@ -2012,15 +2012,15 @@
     <ECEntityClass typeName="SurfaceControlVertexSlopeRule" description="Constrains two surface control vertices to lie on the same line defined by the slope between them." displayLabel="Surface Control Vertex Slope Rule" modifier="Sealed">
         <BaseClass>SurfaceControlVertexRule</BaseClass>
 
-        <ECProperty propertyName="ControlVertexSlope" minimumValue="0" maximumValue="10" typeName="double" description="Slope defined by a control vertex override." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="ControlVertexSlope" minimumValue="-10" maximumValue="10" typeName="double" description="Slope defined by a control vertex override." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
     </ECEntityClass>
 
     <ECEntityClass typeName="SurfaceControlDitchRule" description="Models a ditch-like parametric template that is applied to a control path." displayLabel="Surface Control Ditch Rule" modifier="Sealed" >
         <BaseClass>SurfaceControlRule</BaseClass>
 
         <ECProperty propertyName="Interval" typeName="double" description="Drop interval along the path." category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
-        <ECProperty propertyName="Slope" minimumValue="0" maximumValue="10" typeName="double" description="Slope of the line emanating from the path on the right-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="LeftSlope" typeName="double" description="Slope of the line emanating from the path on the left-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="Slope" minimumValue="-10" maximumValue="10" typeName="double" description="Slope of the line emanating from the path on the right-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="LeftSlope" minimumValue="-10" maximumValue="10" typeName="double" description="Slope of the line emanating from the path on the left-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
         <ECProperty propertyName="Offset" typeName="double" description="Offset from the right-side of the path to attenuate the influence of the ditch elevation." category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
         <ECProperty propertyName="LeftOffset" typeName="double" description="Offset from the left-side of the path to attenuate the influence of the ditch elevation." category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
         <ECProperty propertyName="Mirrored" typeName="boolean" description="True if the right-side constraints should be mirrored on the left side, forming a V-shape. False if they can vary independently." displayLabel="Mirrored" category="SurfaceControl"/>
@@ -2047,7 +2047,7 @@
                 <Description>SurfaceControlLowPoint is no longer used for surface control, use SurfaceSlopedControlVertex instead.</Description>
             </Deprecated>
         </ECCustomAttributes>
-        <ECProperty propertyName="ControlSlope" typeName="double" description="Slope defined by a control low point override." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="ControlSlope" minimumValue="-10" maximumValue="10" typeName="double" description="Slope defined by a control low point override." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
         <ECProperty propertyName="MaximumControlRadius" typeName="double" description="Max radius defined by a control low point override." displayLabel="Radius" category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
     </ECEntityClass>
 

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -311,13 +311,13 @@
     <ECEntityClass typeName="DrivewayEndVertex" modifier="Sealed" displayLabel="Driveway End Vertex" description="The first and last Vertex of a DrivewayPath.">
         <BaseClass>PathEndVertex</BaseClass>
 
-        <ECProperty propertyName="CuldesacRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Radius" description="Radius of cul-de-sac." />
-        <ECProperty propertyName="CuldesacOffset" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Offset" description="Offset of cul-de-sac, negative for left." />
-        <ECProperty propertyName="CuldesacROWRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Radius" description="Cul-de-sac right of way entrance radius." />
-        <ECProperty propertyName="CuldesacROWReturnRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Return Radius" description="Cul-de-sac right of way exit radius." />
+        <ECProperty propertyName="CuldesacRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Radius" description="Radius of cul-de-sac." />
+        <ECProperty propertyName="CuldesacOffset" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="Offset" description="Offset of cul-de-sac, negative for left." />
+        <ECProperty propertyName="CuldesacROWRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Radius" description="Cul-de-sac right of way entrance radius." />
+        <ECProperty propertyName="CuldesacROWReturnRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_CulDeSac" displayLabel="ROW Return Radius" description="Cul-de-sac right of way exit radius." />
 
-        <ECProperty propertyName="EntranceFlareRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Entrance Radius" description="Sets the size of the flared entrance radius. Exit will be defined by the drive side of the road." />
-        <ECProperty propertyName="ExitFlareRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Exit Radius" description="Sets the size of the flared exit radius.  Entrance will be defined by the drive side of the road." />
+        <ECProperty propertyName="EntranceFlareRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Entrance Radius" description="Sets the size of the flared entrance radius. Exit will be defined by the drive side of the road." />
+        <ECProperty propertyName="ExitFlareRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayEndVertex_Flares" displayLabel="Exit Radius" description="Sets the size of the flared exit radius.  Entrance will be defined by the drive side of the road." />
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayMidVertex" modifier="Sealed" displayLabel="Driveway Mid Vertex" description="Vertex of a DrivewayPath that is attached to two DrivewayPathEdge instances.">
@@ -349,10 +349,10 @@
         </ECProperty>
 
         <ECProperty propertyName="KnuckleType" typeName="DrivewayMidVertexKnuckleType" category="DrivewayMidVertex_Knuckle" displayLabel="Type" description="Knuckle type." />
-        <ECProperty propertyName="KnuckleRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Radius" description="Knuckle radius." />
-        <ECProperty propertyName="KnuckleOffset" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Offset" description="Knuckle offset." />
-        <ECProperty propertyName="CurbReturnRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Radius" description="Curb return radius." />
-        <ECProperty propertyName="CurbReturnLength" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Length" description="Curb return length." />
+        <ECProperty propertyName="KnuckleRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Radius" description="Knuckle radius." />
+        <ECProperty propertyName="KnuckleOffset" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Knuckle Offset" description="Knuckle offset." />
+        <ECProperty propertyName="CurbReturnRadius" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Radius" description="Curb return radius." />
+        <ECProperty propertyName="CurbReturnLength" minimumValue="-304.8" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayMidVertex_Knuckle" displayLabel="Curb Return Length" description="Curb return length." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingOverride" modifier="Abstract" displayLabel="Parking Override">
@@ -370,7 +370,7 @@
                     'C' refers to the center aisle that runs along the parking direction path
         -->
         <ECProperty propertyName="AisleId" typeName="string" category="ParkingAisleOverride_Aisle" displayLabel="Aisle" description="The Id of the Aisle to be overridden." />
-        <ECProperty propertyName="Width" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingAisleOverride_Aisle" displayLabel="Aisle Width" description="The new width of the Aisle." />
+        <ECProperty propertyName="Width" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingAisleOverride_Aisle" displayLabel="Aisle Width" description="The new width of the Aisle." />
     </ECEntityClass>
 
     <ECEntityClass typeName="BayOverride" modifier="Abstract" displayLabel="Bay Override">
@@ -388,24 +388,24 @@
     <ECEntityClass typeName="BayCentralOverride" modifier="Sealed" displayLabel="Bay Central Override">
         <BaseClass>BayOverride</BaseClass>
 
-        <ECProperty propertyName="MedianWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingBayOverride_Bay" displayLabel="Median Width" description="The new median width of the Bay." />
+        <ECProperty propertyName="MedianWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingBayOverride_Bay" displayLabel="Median Width" description="The new median width of the Bay." />
     </ECEntityClass>
 
     <ECEntityClass typeName="BaySideOverride" modifier="Sealed" displayLabel="Bay Side Override">
         <BaseClass>BayOverride</BaseClass>
 
         <ECProperty propertyName="SideOfBay" typeName="BaySide" category="ParkingBayOverride_Bay" displayLabel="Side of Bay" description="Side of the bay to be overridden." />
-        <ECProperty propertyName="Angle" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingBayOverride_Bay" displayLabel="Row Angle" description="The new angle of the Bay." />
-        <ECProperty propertyName="Depth" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingBayOverride_Bay" displayLabel="Row Depth" description="The new depth of the Bay." />
+        <ECProperty propertyName="Angle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingBayOverride_Bay" displayLabel="Row Angle" description="The new angle of the Bay." />
+        <ECProperty propertyName="Depth" minimumValue="-30.48" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingBayOverride_Bay" displayLabel="Row Depth" description="The new depth of the Bay." />
     </ECEntityClass>
 
     <ECEntityClass typeName="SpaceOverride" modifier="Abstract" displayLabel="Space Override">
         <BaseClass>ParkingOverride</BaseClass>
 
-        <ECProperty propertyName="RowIndex" typeName="int" category="ParkingSpaceOverride_Row" displayLabel="Row Index" description="The index of the row to be overridden." />
-        <ECProperty propertyName="SpaceIndex" typeName="int" category="ParkingSpaceOverride_Space" displayLabel="Space Index" description="The index of the space to be overridden." />
+        <ECProperty propertyName="RowIndex" minimumValue="0" maximumValue="1000" typeName="int" category="ParkingSpaceOverride_Row" displayLabel="Row Index" description="The index of the row to be overridden." />
+        <ECProperty propertyName="SpaceIndex" minimumValue="0" maximumValue="1000" typeName="int" category="ParkingSpaceOverride_Space" displayLabel="Space Index" description="The index of the space to be overridden." />
 
-        <ECProperty propertyName="Width" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingSpaceOverride_Space" displayLabel="Space Width" description="The new width of the space." />
+        <ECProperty propertyName="Width" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingSpaceOverride_Space" displayLabel="Space Width" description="The new width of the space." />
 
         <ECNavigationProperty propertyName="SurfaceMarkingType" relationshipName="SpaceOverrideUsesSurfaceMarkingType" direction="Forward" displayLabel="Surface Marking Type" description="The surface marking type applied to the space." />
     </ECEntityClass>
@@ -430,21 +430,21 @@
     <ECEntityClass typeName="ParkingSpaceVertex" modifier="Sealed" displayLabel="Parking Space Vertex" description="Defines a location point which overrides parking space settings.">
         <BaseClass>ParkingVertex</BaseClass>
 
-        <ECProperty propertyName="ParkingNumber" typeName="int" category="ParkingSpaceVertex_Parking" displayLabel="Number of Spaces" description="Number of spaces to be overridden by a parking vertex." />
-        <ECProperty propertyName="ParkingWidth" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:LENGTH" displayLabel="Space Width" description="Width to be used for a parking vertex override." />
+        <ECProperty propertyName="ParkingNumber" minimumValue="0" maximumValue="1000" typeName="int" category="ParkingSpaceVertex_Parking" displayLabel="Number of Spaces" description="Number of spaces to be overridden by a parking vertex." />
+        <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:LENGTH" displayLabel="Space Width" description="Width to be used for a parking vertex override." />
         <ECProperty propertyName="ParkingSurfaceType" typeName="SurfaceType" category="ParkingSpaceVertex_Parking" displayLabel="Surface Type" description="Surface type defined by a parking vertex override." />
-        <ECProperty propertyName="ParkingMinSlope" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope defined by a parking vertex override." />
-        <ECProperty propertyName="ParkingMaxSlope" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope defined by a parking vertex override." />
+        <ECProperty propertyName="ParkingMinSlope" minimumValue="0" maximumValue="10" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope defined by a parking vertex override." />
+        <ECProperty propertyName="ParkingMaxSlope" minimumValue="0" maximumValue="10" typeName="double" category="ParkingSpaceVertex_Parking" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope defined by a parking vertex override." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingBayVertex" modifier="Sealed" displayLabel="Parking Bay Vertex" description="Defines a location point to override an entire parking bay settings.">
         <BaseClass>ParkingVertex</BaseClass>
 
-        <ECProperty propertyName="BayMedianWidth" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Median Width" description="Median width defined by a bay override." />
-        <ECProperty propertyName="ParkingDepth" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Parking Depth Primary" description="Defines the bay override parking depth for primary side." />
-        <ECProperty propertyName="ParkingDepthOther" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Parking Depth Secondary" description="Defines the bay override parking depth for secondary side." />
-        <ECProperty propertyName="ParkingAngle" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Primary" description="Defines the bay override parking angle for primary side." />
-        <ECProperty propertyName="ParkingAngleOther" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Secondary" description="Defines the bay override parking angle for secondary side." />
+        <ECProperty propertyName="BayMedianWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Median Width" description="Median width defined by a bay override." />
+        <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Parking Depth Primary" description="Defines the bay override parking depth for primary side." />
+        <ECProperty propertyName="ParkingDepthOther" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:LENGTH" displayLabel="Parking Depth Secondary" description="Defines the bay override parking depth for secondary side." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Primary" description="Defines the bay override parking angle for primary side." />
+        <ECProperty propertyName="ParkingAngleOther" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" category="ParkingBayVertex_Bay" kindOfQuantity="cvu:ANGLE" displayLabel="Parking Angle Secondary" description="Defines the bay override parking angle for secondary side." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingAisleVertex" modifier="Sealed" displayLabel="Parking Aisle Vertex" description="Defines a location point to override a parking aisle settings.">
@@ -456,7 +456,7 @@
     <ECEntityClass typeName="ParkingIslandVertex" modifier="Sealed" displayLabel="Parking Island Vertex" description="Defines a location point to override a parking island settings.">
         <BaseClass>ParkingVertex</BaseClass>
 
-        <ECProperty propertyName="IslandWidth" typeName="double" category="ParkingIslandVertex_Island" kindOfQuantity="cvu:LENGTH" displayLabel="Island Width" description="Defines the island override for it's width." />
+        <ECProperty propertyName="IslandWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="ParkingIslandVertex_Island" kindOfQuantity="cvu:LENGTH" displayLabel="Island Width" description="Defines the island override for it's width." />
     </ECEntityClass>
 
     <ECEntityClass typeName="Edge" modifier="Abstract" displayLabel="Edge">
@@ -515,7 +515,7 @@
     <ECEntityClass typeName="BuildingEdge" modifier="Sealed" displayLabel="Building Pad Edge">
         <BaseClass>ShapedEdge</BaseClass>
 
-        <ECProperty propertyName="SlopeAway" typeName="double" kindOfQuantity="cvu:SLOPE" category="BuildingEdge_SlopeAway" displayLabel="Slope Away" description="Slope away from edge for grading." />
+        <ECProperty propertyName="SlopeAway" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="BuildingEdge_SlopeAway" displayLabel="Slope Away" description="Slope away from edge for grading." />
         <ECProperty propertyName="SlopeAwayDistance" typeName="double" kindOfQuantity="cvu:LENGTH" category="BuildingEdge_SlopeAway" displayLabel="Slope Away Distance" description="Distance of the slope away from edge for grading." />
         <ECProperty propertyName="FixedHeightDifference" typeName="double" kindOfQuantity="cvu:LENGTH" category="ShapedEdge_LinkHeight" displayLabel="Fixed Height Difference" description="Height of an edge." />
     </ECEntityClass>
@@ -542,7 +542,7 @@
 
     <ECEntityClass typeName="PadEdge" modifier="Sealed" displayLabel="Pad Edge">
         <BaseClass>ShapedEdge</BaseClass>
-        <ECProperty propertyName="FixedHeightDifference" typeName="double" kindOfQuantity="cvu:LENGTH" category="ShapedEdge_LinkHeight" displayLabel="Fixed Height Difference" description="Height of an edge." />
+        <ECProperty propertyName="FixedHeightDifference" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" category="ShapedEdge_LinkHeight" displayLabel="Fixed Height Difference" description="Height of an edge." />
     </ECEntityClass>
 
     <ECEntityClass typeName="LayoutParkingEdge" modifier="Sealed" displayLabel="Layout Parking Edge" description="Parking lot">
@@ -556,8 +556,8 @@
     <ECEntityClass typeName="CenterlinePathEdge" modifier="None" displayLabel="Centerline Path Edge" description="Centerline of a path.">
         <BaseClass>PathEdge</BaseClass>
 
-        <ECProperty propertyName="MinDriveSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="CenterlinePathEdge_Grading" displayLabel="Min. Slope" description="Minimum path slope for design." />
-        <ECProperty propertyName="MaxDriveSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="CenterlinePathEdge_Grading" displayLabel="Max. Slope" description="Maximum path slope for design." />
+        <ECProperty propertyName="MinDriveSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="CenterlinePathEdge_Grading" displayLabel="Min. Slope" description="Minimum path slope for design." />
+        <ECProperty propertyName="MaxDriveSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="CenterlinePathEdge_Grading" displayLabel="Max. Slope" description="Maximum path slope for design." />
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="CenterlinePathEdge_Grading" displayLabel="Surface Type" description="Surface material type for path." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
@@ -566,7 +566,7 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="SurfaceDepth" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="CenterlinePathEdge_Grading" displayLabel="Surface Depth" description="Surface material depth for path." >
+        <ECProperty propertyName="SurfaceDepth" minimumValue="-30.48" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="CenterlinePathEdge_Grading" displayLabel="Surface Depth" description="Surface material depth for path." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -574,10 +574,10 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="MinZ" typeName="double" kindOfQuantity="cvu:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Min. Elevation" description="Minimum design elevation for path." />
-        <ECProperty propertyName="MaxZ" typeName="double" kindOfQuantity="cvu:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Max. Elevation" description="Maximum design elevation for path." />
+        <ECProperty propertyName="MinZ" minimumValue="-304.8" maximumValue="9144" typeName="double" kindOfQuantity="cvu:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Min. Elevation" description="Minimum design elevation for path." />
+        <ECProperty propertyName="MaxZ" minimumValue="-304.8" maximumValue="9144" typeName="double" kindOfQuantity="cvu:LENGTH" category="CenterlinePathEdge_Grading" displayLabel="Max. Elevation" description="Maximum design elevation for path." />
 
-        <ECProperty propertyName="RunoffC" typeName="double" category="CenterlinePathEdge_Drainage" displayLabel="Runoff Coefficient" description="Runoff coefficient for path." />
+        <ECProperty propertyName="RunoffC" minimumValue="0" maximumValue="1" typeName="double" category="CenterlinePathEdge_Drainage" displayLabel="Runoff Coefficient" description="Runoff coefficient for path." />
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayPathEdge" modifier="Sealed" displayLabel="Driveway Edge" description="Centerline of a driveway.">
@@ -592,12 +592,12 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="MedianWidth" typeName="double" kindOfQuantity="cvu:LENGTH"  category="DrivewayPathEdge_Median" displayLabel="Width" description="Median width for path." />
+        <ECProperty propertyName="MedianWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH"  category="DrivewayPathEdge_Median" displayLabel="Width" description="Median width for path." />
         <ECNavigationProperty propertyName="MedianLayeredStructureType" relationshipName="DrivewayPathEdgeUsesMedianLayeredStructureType" direction="Forward" category="DrivewayPathEdge_Median" displayLabel="Median Layered Structure" description="Layers (courses) of median." />
 
         <ECProperty propertyName="CrowningType" typeName="CrownType" category="DrivewayPathEdge_Crowning" displayLabel="Crown Type" description="Type of crown design for path." />
-        <ECProperty propertyName="KValueSag" typeName="double" category="DrivewayPathEdge_Crowning" displayLabel="Sag K Value" description="Design K-Value for sag vertical curves." />
-        <ECProperty propertyName="KValueSummit" typeName="double" category="DrivewayPathEdge_Crowning" displayLabel="Crest K Value" description="Design K-Value for crest vertical curves." />
+        <ECProperty propertyName="KValueSag" minimumValue="0" maximumValue="1000" typeName="double" category="DrivewayPathEdge_Crowning" displayLabel="Sag K Value" description="Design K-Value for sag vertical curves." />
+        <ECProperty propertyName="KValueSummit" minimumValue="0" maximumValue="1000" typeName="double" category="DrivewayPathEdge_Crowning" displayLabel="Crest K Value" description="Design K-Value for crest vertical curves." />
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayPathFin" modifier="Sealed" displayLabel="Driveway Fin" description="One of two sides to a Driveway Path Edge.">
@@ -613,13 +613,13 @@
             </ECCustomAttributes>
         </ECProperty>
 
-        <ECProperty propertyName="CrossSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="DrivewayPathFin_Road" displayLabel="Cross Slope" description="Cross slope for this side of driveway." />
-        <ECProperty propertyName="DrivewayWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayPathFin_Road" displayLabel="Driveway Width" description="Driveway width on this side." />
+        <ECProperty propertyName="CrossSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="DrivewayPathFin_Road" displayLabel="Cross Slope" description="Cross slope for this side of driveway." />
+        <ECProperty propertyName="DrivewayWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayPathFin_Road" displayLabel="Driveway Width" description="Driveway width on this side." />
 
-        <ECProperty propertyName="ShoulderWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayPathFin_Shoulder" displayLabel="Shoulder Width" description="Width of shoulder on this side of driveway." />
-        <ECProperty propertyName="ShoulderSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="DrivewayPathFin_Shoulder" displayLabel="Shoulder Slope" description="Slope of shoulder on this side of driveway." />
-        <ECProperty propertyName="DitchOffset" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayPathFin_Shoulder" displayLabel="Ditch Offset" description="Offset to ditch on this side of driveway." />
-        <ECProperty propertyName="DitchSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="DrivewayPathFin_Shoulder" displayLabel="Ditch Slope" description="Ditch slope for this side of driveway." />
+        <ECProperty propertyName="ShoulderWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayPathFin_Shoulder" displayLabel="Shoulder Width" description="Width of shoulder on this side of driveway." />
+        <ECProperty propertyName="ShoulderSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="DrivewayPathFin_Shoulder" displayLabel="Shoulder Slope" description="Slope of shoulder on this side of driveway." />
+        <ECProperty propertyName="DitchOffset" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="DrivewayPathFin_Shoulder" displayLabel="Ditch Offset" description="Offset to ditch on this side of driveway." />
+        <ECProperty propertyName="DitchSlope" minimumValue="-10" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="DrivewayPathFin_Shoulder" displayLabel="Ditch Slope" description="Ditch slope for this side of driveway." />
     </ECEntityClass>
 
     <ECEntityClass typeName="DrivewayTransition" modifier="Sealed" displayLabel="Transition">
@@ -631,9 +631,9 @@
             </ECCustomAttributes>
         </ECProperty>
 
-        <ECProperty propertyName="sideTransitionOffset" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Transition Offset" description="Length of the offset."/>
-        <ECProperty propertyName="sideTransitionRadius1" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Transition Inner Radius" description="Radius of the arc before the transition."/>
-        <ECProperty propertyName="sideTransitionRadius2" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Transition Outer Radius" description="Radius of the arc after the transition."/>
+        <ECProperty propertyName="sideTransitionOffset" minimumValue="0" maximumValue="9144" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Transition Offset" description="Length of the offset."/>
+        <ECProperty propertyName="sideTransitionRadius1" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Transition Inner Radius" description="Radius of the arc before the transition."/>
+        <ECProperty propertyName="sideTransitionRadius2" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Transition Outer Radius" description="Radius of the arc after the transition."/>
     </ECEntityClass>
 
     <ECEntityClass typeName="SidewalkPathEdge" modifier="Sealed" displayLabel="Sidewalk Edge" description="Sidewalk path edge.">
@@ -654,8 +654,8 @@
             </ECCustomAttributes>
         </ECProperty>
 
-        <ECProperty propertyName="SidewalkWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="SidewalkPathFin_Sidewalk" displayLabel="Sidewalk Width" description="Sidewalk width for this side of the sidewalk." />
-        <ECProperty propertyName="CrossSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="SidewalkPathFin_Sidewalk" displayLabel="Cross Slope" description="Cross slope for this side of the sidewalk." />
+        <ECProperty propertyName="SidewalkWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="SidewalkPathFin_Sidewalk" displayLabel="Sidewalk Width" description="Sidewalk width for this side of the sidewalk." />
+        <ECProperty propertyName="CrossSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="SidewalkPathFin_Sidewalk" displayLabel="Cross Slope" description="Cross slope for this side of the sidewalk." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParkingDirectionPathEdge" modifier="Sealed" displayLabel="Parking Direction Edge" description="Parking direction path edge.">
@@ -1034,7 +1034,7 @@
 
     <ECEntityClass typeName="RetainingWallArea" displayLabel="Retaining Wall" description="Retaining Wall">
         <BaseClass>Area</BaseClass>
-		<ECProperty propertyName="Width" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Width" description="Width of the retaining wall." />
+		<ECProperty propertyName="Width" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Width" description="Width of the retaining wall." />
         <ECNavigationProperty propertyName="RetainingWallType" relationshipName="RetainingWallAreaUsesRetainingWallType" direction="Forward" displayLabel="Retaining Wall Type" />
     </ECEntityClass>
 
@@ -1044,7 +1044,7 @@
 
         <ECProperty propertyName="DoGrade" typeName="boolean" category="ShapedArea_Optimizer" displayLabel="Grading" description="Add area grading data to grading optimizer." />
 
-        <ECProperty propertyName="Topsoil" typeName="double" category="ShapedArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Topsoil" description="Depth of topsoil." />
+        <ECProperty propertyName="Topsoil" minimumValue="0" maximumValue="30.48" typeName="double" category="ShapedArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Topsoil" description="Depth of topsoil." />
         <ECNavigationProperty propertyName="LayeredStructureType" relationshipName="ShapedAreaUsesLayeredStructureType" direction="Forward" category="ShapedArea_Surface" displayLabel="Layered Structure" />
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="ShapedArea_Surface" displayLabel="Surface Type" description="Type definition of area." >
             <ECCustomAttributes>
@@ -1054,7 +1054,7 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="SurfaceDepth" typeName="double" category="ShapedArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Material depth of area." >
+        <ECProperty propertyName="SurfaceDepth" minimumValue="0" maximumValue="30.48" typeName="double" category="ShapedArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Material depth of area." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -1062,13 +1062,13 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="RunoffCoefficient" typeName="double" category="ShapedArea_Surface" displayLabel="Runoff Coefficient" description="Runoff coefficient for area." />
+        <ECProperty propertyName="RunoffCoefficient" minimumValue="0" maximumValue="1" typeName="double" category="ShapedArea_Surface" displayLabel="Runoff Coefficient" description="Runoff coefficient for area." />
 
-        <ECProperty propertyName="FixedSlope" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed design slope for area." />
-        <ECProperty propertyName="MinSlope" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum design slope for area." />
-        <ECProperty propertyName="MaxSlope" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum design slope for area." />
-        <ECProperty propertyName="MinZ" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Min. Elevation" description="Minimum design elevation for area." />
-        <ECProperty propertyName="MaxZ" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Max. Elevation" description="Maximum design elevation for area." />
+        <ECProperty propertyName="FixedSlope" minimumValue="0" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed design slope for area." />
+        <ECProperty propertyName="MinSlope" minimumValue="0" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum design slope for area." />
+        <ECProperty propertyName="MaxSlope" minimumValue="0" maximumValue="10" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum design slope for area." />
+        <ECProperty propertyName="MinZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Min. Elevation" description="Minimum design elevation for area." />
+        <ECProperty propertyName="MaxZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="ShapedArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Max. Elevation" description="Maximum design elevation for area." />
     </ECEntityClass>
 
     <ECEntityClass typeName="PropertyArea" modifier="Sealed" displayLabel="Grading Limits" description="Grading Limits">
@@ -1128,9 +1128,9 @@
         </ECProperty>
 
         <ECProperty propertyName="DoCentralParking" typeName="boolean" category="LayoutParkingArea_Parking" displayLabel="Add Central Parking" description="Add central parking." />
-        <ECProperty propertyName="ParkingWidth" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:LENGTH"  displayLabel="Width" description="Parking space width." />
-        <ECProperty propertyName="ParkingDepth" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:LENGTH"  displayLabel="Depth" description="Parking space depth." />
-        <ECProperty propertyName="ParkingAngle" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:ANGLE"  displayLabel="Angle" description="Parking space angle." />
+        <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:LENGTH"  displayLabel="Width" description="Parking space width." />
+        <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:LENGTH"  displayLabel="Depth" description="Parking space depth." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" category="LayoutParkingArea_Parking" kindOfQuantity="cvu:ANGLE"  displayLabel="Angle" description="Parking space angle." />
         <ECProperty propertyName="ParkingSpaces" typeName="int" category="LayoutParkingArea_Parking" displayLabel="Parking Spaces" description="Number of spaces.">
 		    <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
@@ -1148,10 +1148,10 @@
             </ECCustomAttributes>
         </ECProperty>
 
-        <ECProperty propertyName="AisleWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParkingArea_ParkingAisle" displayLabel="Width" description="Parking aisle width." />
+        <ECProperty propertyName="AisleWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParkingArea_ParkingAisle" displayLabel="Width" description="Parking aisle width." />
 
-        <ECProperty propertyName="ParkingPerIsland" typeName="int" category="LayoutParkingArea_ParkingIsland" displayLabel="Count Per Island" description="Number of parking spaces between islands." />
-        <ECProperty propertyName="MinIslandWidth" typeName="double" category="LayoutParkingArea_ParkingIsland" kindOfQuantity="cvu:LENGTH"  displayLabel="Minimum Width" description="Minimum parking island width." />
+        <ECProperty propertyName="ParkingPerIsland" minimumValue="0" maximumValue="1000" typeName="int" category="LayoutParkingArea_ParkingIsland" displayLabel="Count Per Island" description="Number of parking spaces between islands." />
+        <ECProperty propertyName="MinIslandWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_ParkingIsland" kindOfQuantity="cvu:LENGTH"  displayLabel="Minimum Width" description="Minimum parking island width." />
         <ECProperty propertyName="IslandType" typeName="IslandType" category="LayoutParkingArea_ParkingIsland" displayLabel="Type" description="Island type or material." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
@@ -1160,12 +1160,12 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="IslandCurbRadius" typeName="double" category="LayoutParkingArea_ParkingIsland" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Radius" description="Island curb radius." />
+        <ECProperty propertyName="IslandCurbRadius" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_ParkingIsland" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Radius" description="Island curb radius." />
 
-        <ECProperty propertyName="BayCurbRadius" typeName="double" category="LayoutParkingArea_ParkingBay" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Radius" description="Parking bay curb radius." />
+        <ECProperty propertyName="BayCurbRadius" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutParkingArea_ParkingBay" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Radius" description="Parking bay curb radius." />
 
-        <ECProperty propertyName="MinSlopeParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Design Slope" description="Minimum design slope for parking lot." />
-        <ECProperty propertyName="MaxSlopeParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Design Slope" description="Maximum design slope for parking lot." />
+        <ECProperty propertyName="MinSlopeParkingLot" minimumValue="0" maximumValue="10" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Design Slope" description="Minimum design slope for parking lot." />
+        <ECProperty propertyName="MaxSlopeParkingLot" minimumValue="0" maximumValue="10" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Design Slope" description="Maximum design slope for parking lot." />
         <ECProperty propertyName="SurfaceTypeParkingLot" typeName="SurfaceType" category="LayoutParkingArea_ParkingGrading" displayLabel="Surface Type" description="Surface type or material for parking lot." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
@@ -1174,7 +1174,7 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="SurfaceDepthParkingLot" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth." >
+        <ECProperty propertyName="SurfaceDepthParkingLot" minimumValue="0" maximumValue="30.48" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -1183,7 +1183,7 @@
             </ECCustomAttributes>
         </ECProperty>
         <ECProperty propertyName="SurfaceTypeParkingSpaces" typeName="SurfaceType" category="LayoutParkingArea_ParkingGrading" displayLabel="Space Surface Type" description="Surface type or material for specific parking spaces." />
-        <ECProperty propertyName="SurfaceDepthParkingSpaces" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Space Surface Depth" description="Surface or material depth for specific parking spaces." />
+        <ECProperty propertyName="SurfaceDepthParkingSpaces" minimumValue="0" maximumValue="30.48" typeName="double" category="LayoutParkingArea_ParkingGrading" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Space Surface Depth" description="Surface or material depth for specific parking spaces." />
 
         <ECNavigationProperty propertyName="IslandCurbType" relationshipName="LayoutParkingAreaUsesIslandCurbType" direction="Forward" displayLabel="Island Curb Type" />
         <ECNavigationProperty propertyName="ParkingCurbType" relationshipName="LayoutParkingAreaUsesCurbType" direction="Forward" displayLabel="Curb Type" />
@@ -1194,14 +1194,14 @@
     <ECEntityClass typeName="LayoutPondArea" modifier="Sealed" displayLabel="Pond" description="Layout pond area.">
         <BaseClass>LayoutArea</BaseClass>
 
-        <ECProperty propertyName="Height" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Riser Top Elevation" description="Riser Top Elevation." />
-        <ECProperty propertyName="TopHeight" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Dry Storage Height" description="Dry Storage Height." />
-		<ECProperty propertyName="WallSlope" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:SLOPE" displayLabel="Side Slope" description=" Side Slope." />
-        <ECProperty propertyName="WallWidth" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Berm Width" description="Depth of the pond." />
-		<ECProperty propertyName="Depth" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Riser Height" description="Riser Height." />
+        <ECProperty propertyName="Height" minimumValue="-304.8" maximumValue="9144" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Riser Top Elevation" description="Riser Top Elevation." />
+        <ECProperty propertyName="TopHeight" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Dry Storage Height" description="Dry Storage Height." />
+		<ECProperty propertyName="WallSlope" minimumValue="0" maximumValue="10" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:SLOPE" displayLabel="Side Slope" description=" Side Slope." />
+        <ECProperty propertyName="WallWidth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Berm Width" description="Depth of the pond." />
+		<ECProperty propertyName="Depth" minimumValue="0" maximumValue="304.8" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:LENGTH" displayLabel="Riser Height" description="Riser Height." />
 		<ECProperty propertyName="SizePond" typeName="boolean" category="LayoutPondArea_Pond" displayLabel="Size Pond" description="Size the pond using the target surface or volume." />
 		<ECProperty propertyName="TargetSurface" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:AREA" displayLabel="Target Surface" description="Target surface." />
-		<ECProperty propertyName="TargetVolume" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:VOLUME" displayLabel="Target Volume" description="Target volume." />
+		<ECProperty propertyName="TargetVolume" minimumValue="0" maximumValue="141584.23296" typeName="double" category="LayoutPondArea_Pond" kindOfQuantity="cvu:VOLUME" displayLabel="Target Volume" description="Target volume." />
     </ECEntityClass>
 
     <ECEntityClass typeName="LayoutParcelingArea" modifier="Sealed" displayLabel="Layout Parceling Area" description="Layout parceling area.">
@@ -1213,26 +1213,26 @@
             </ECCustomAttributes>
         </ECProperty>
 
-        <ECProperty propertyName="MinParcelSurface" typeName="double" kindOfQuantity="cvu:AREA" category="LayoutParcelingArea_ParcelLayout" displayLabel="Min. Parcel Surface" description="Minimum parcel surface area." />
-        <ECProperty propertyName="MaxParcelDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Max. Parcel Depth" description="Maximum parcel depth." />
-        <ECProperty propertyName="MinParcelFrontage" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Min. Parcel Frontage" description="Minimum parcel frontage." />
-        <ECProperty propertyName="ParcelFrontageOffset" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Frontage Offset" description="Frontage offset." />
-        <ECProperty propertyName="BackYardDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Back Yard Depth" description="Back yard depth." />
+        <ECProperty propertyName="MinParcelSurface" minimumValue="0" maximumValue="92903.04" typeName="double" kindOfQuantity="cvu:AREA" category="LayoutParcelingArea_ParcelLayout" displayLabel="Min. Parcel Surface" description="Minimum parcel surface area." />
+        <ECProperty propertyName="MaxParcelDepth" minimumValue="0" maximumValue="3048" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Max. Parcel Depth" description="Maximum parcel depth." />
+        <ECProperty propertyName="MinParcelFrontage" minimumValue="0" maximumValue="3048" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Min. Parcel Frontage" description="Minimum parcel frontage." />
+        <ECProperty propertyName="ParcelFrontageOffset" minimumValue="0" maximumValue="3048" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Frontage Offset" description="Frontage offset." />
+        <ECProperty propertyName="BackYardDepth" minimumValue="0" maximumValue="3048" typeName="double" kindOfQuantity="cvu:LENGTH" category="LayoutParcelingArea_ParcelLayout" displayLabel="Back Yard Depth" description="Back yard depth." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParcelBuildingAspect" modifier="Sealed" displayLabel="Building Aspect">
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
         <ECProperty propertyName="BuildingWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelBuildingAspect_BuildingLayout" displayLabel="Building Width" description="Width of the building on the parcel." />
-        <ECProperty propertyName="BuildingDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelBuildingAspect_BuildingLayout" displayLabel="Building Depth" description="Depth of the building on the parcel." />
+        <ECProperty propertyName="BuildingDepth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelBuildingAspect_BuildingLayout" displayLabel="Building Depth" description="Depth of the building on the parcel." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ParcelSetbacksAspect" modifier="Sealed" displayLabel="Setbacks">
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
-        <ECProperty propertyName="FrontSetback" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelSetbacksAspect_Setbacks" displayLabel="Front" description="Front setback distance." />
-        <ECProperty propertyName="SideSetback" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelSetbacksAspect_Setbacks" displayLabel="Side" description="Side setback distance." />
-        <ECProperty propertyName="BackSetback" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelSetbacksAspect_Setbacks" displayLabel="Back" description="Back setback distance." />
+        <ECProperty propertyName="FrontSetback" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelSetbacksAspect_Setbacks" displayLabel="Front" description="Front setback distance." />
+        <ECProperty propertyName="SideSetback" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelSetbacksAspect_Setbacks" displayLabel="Side" description="Side setback distance." />
+        <ECProperty propertyName="BackSetback" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParcelSetbacksAspect_Setbacks" displayLabel="Back" description="Back setback distance." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="LayoutParcelingAreaOwnsParcelBuildingAspect" modifier="Sealed" strength="embedding">
@@ -1281,15 +1281,15 @@
             </ECCustomAttributes>
         </ECProperty>
 
-        <ECProperty propertyName="Topsoil" typeName="double" category="GradingArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Topsoil" description="Topsoil depth for grading area." />
+        <ECProperty propertyName="Topsoil" minimumValue="0" maximumValue="30.48" typeName="double" category="GradingArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Topsoil" description="Topsoil depth for grading area." />
         <ECProperty propertyName="SurfaceType" typeName="SurfaceType" category="GradingArea_Surface" displayLabel="Surface Type" description="Surface type or material for grading area." />
-        <ECProperty propertyName="SurfaceDepth" typeName="double" category="GradingArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth for grading area." />
+        <ECProperty propertyName="SurfaceDepth" minimumValue="0" maximumValue="30.48" typeName="double" category="GradingArea_Surface" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Surface Depth" description="Surface or material depth for grading area." />
 
-        <ECProperty propertyName="FixedSlope" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed slope constraint on grading area." />
-        <ECProperty propertyName="MinSlope" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope constraint on grading area." />
-        <ECProperty propertyName="MaxSlope" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope constraint on grading area." />
-        <ECProperty propertyName="MinZ" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Min. Elevation" description="Minimum elevation change constraint on grading area." />
-        <ECProperty propertyName="MaxZ" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Max. Elevation" description="Maximum elevation change constraint on grading area." />
+        <ECProperty propertyName="FixedSlope" minimumValue="0" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Fixed Slope" description="Fixed slope constraint on grading area." />
+        <ECProperty propertyName="MinSlope" minimumValue="0" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Min. Slope" description="Minimum slope constraint on grading area." />
+        <ECProperty propertyName="MaxSlope" minimumValue="0" maximumValue="10" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:SLOPE" displayLabel="Max. Slope" description="Maximum slope constraint on grading area." />
+        <ECProperty propertyName="MinZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Min. Elevation" description="Minimum elevation change constraint on grading area." />
+        <ECProperty propertyName="MaxZ" minimumValue="-304.8" maximumValue="9144" typeName="double" category="GradingArea_Constraints" kindOfQuantity="cvu:LENGTH" displayLabel="Max. Elevation" description="Maximum elevation change constraint on grading area." />
     </ECEntityClass>
 
     <ECEntityClass typeName="GradingLimitArea" modifier="Sealed" displayLabel="Grading Constraints" description="Grading constraints area.">
@@ -1332,9 +1332,9 @@
     <ECEntityClass typeName="ParkingRowPath" modifier="Sealed" displayLabel="Parking Row" description="Parking row path.">
         <BaseClass>LayoutPath</BaseClass>
 
-        <ECProperty propertyName="ParkingWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingRowPath_Parking" displayLabel="Width" description="Parking width for row." />
-        <ECProperty propertyName="ParkingDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingRowPath_Parking" displayLabel="Depth" description="Parking depth for row." />
-        <ECProperty propertyName="ParkingAngle" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingRowPath_Parking" displayLabel="Angle" description="Parking angle for row." />
+        <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingRowPath_Parking" displayLabel="Width" description="Parking width for row." />
+        <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="ParkingRowPath_Parking" displayLabel="Depth" description="Parking depth for row." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="ParkingRowPath_Parking" displayLabel="Angle" description="Parking angle for row." />
     </ECEntityClass>
 
     <ECEntityClass typeName="GradingPath" modifier="Abstract" displayLabel="Grading Path" description="Grading path.">
@@ -1347,7 +1347,7 @@
 
     <ECEntityClass typeName="PedestrianPath" modifier="Sealed" displayLabel="Pedestrian path" description="Pedestrian path.">
         <BaseClass>LayoutPath</BaseClass>
-		<ECProperty propertyName="Width" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Width" description="Width of the pedestrian path." />
+		<ECProperty propertyName="Width" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Width" description="Width of the pedestrian path." />
     </ECEntityClass>
 
     <ECEntityClass typeName="CachedLinear" modifier="Sealed" displayLabel="Cached Linear" description="Cached 3D Linear geometry.">
@@ -1371,30 +1371,30 @@
     <ECEntityClass typeName="ContourLinesAspect" modifier="Sealed" displayLabel="Contour Lines" description="Terrain contour lines" >
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
-        <ECProperty propertyName="MinorStep" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Minor Step" description="Minor steps interval size" />
-        <ECProperty propertyName="MajorStepMultiple" typeName="int" displayLabel="Major Step Interval" description="Number of minor intervals between two major steps" />
+        <ECProperty propertyName="MinorStep" minimumValue="0" maximumValue="60.96" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Minor Step" description="Minor steps interval size" />
+        <ECProperty propertyName="MajorStepMultiple" minimumValue="0" maximumValue="200" typeName="int" displayLabel="Major Step Interval" description="Number of minor intervals between two major steps" />
     </ECEntityClass>
 
     <ECEntityClass typeName="HatchingAspect" modifier="Sealed" displayLabel="Hatching">
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
-        <ECProperty propertyName="Spacing" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Spacing" description="Space between the hatch lines." />
-        <ECProperty propertyName="Angle" typeName="double" kindOfQuantity="cvu:ANGLE" displayLabel="Angle" description="Angle of the hatch lines." />
-        <ECProperty propertyName="Width" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Width" description="Width of the hatch lines." />
+        <ECProperty propertyName="Spacing" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Spacing" description="Space between the hatch lines." />
+        <ECProperty propertyName="Angle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" displayLabel="Angle" description="Angle of the hatch lines." />
+        <ECProperty propertyName="Width" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Width" description="Width of the hatch lines." />
     </ECEntityClass>
 
     <ECEntityClass typeName="RetainingWallType" displayLabel="Retaining Wall Type" description="Defines a shared set of properties whose values vary per-type of RetainingWall rather than per-instance.">
         <BaseClass>cvphys:RetainingWallType</BaseClass>
 
-        <ECProperty propertyName="FrontWallSetback" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Front Wall Setback" description="Width of front wall setback." />
-        <ECProperty propertyName="BackWallSetback" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Back Wall Setback" description="Width of back wall setback." />
-        <ECProperty propertyName="ExposedWallHeight" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Exposed Wall Height" description="Height of exposed wall." />
-        <ECProperty propertyName="CoverDepth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Cover Depth" description="Depth of cover." />
-        <ECProperty propertyName="ToeWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Toe Width" description="Width of toe." />
-        <ECProperty propertyName="HeelWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Heel Width" description="Width of heel." />
-        <ECProperty propertyName="FootingThickness" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Footing Thickness" description="Thickness of footing." />
-        <ECProperty propertyName="KeyWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Key Width" description="Width of key." />
-        <ECProperty propertyName="KeyHeight" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Key Height" description="Height of key." />
+        <ECProperty propertyName="FrontWallSetback" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Front Wall Setback" description="Width of front wall setback." />
+        <ECProperty propertyName="BackWallSetback" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Back Wall Setback" description="Width of back wall setback." />
+        <ECProperty propertyName="ExposedWallHeight" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Exposed Wall Height" description="Height of exposed wall." />
+        <ECProperty propertyName="CoverDepth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Cover Depth" description="Depth of cover." />
+        <ECProperty propertyName="ToeWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Toe Width" description="Width of toe." />
+        <ECProperty propertyName="HeelWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Heel Width" description="Width of heel." />
+        <ECProperty propertyName="FootingThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Footing Thickness" description="Thickness of footing." />
+        <ECProperty propertyName="KeyWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Key Width" description="Width of key." />
+        <ECProperty propertyName="KeyHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Key Height" description="Height of key." />
     </ECEntityClass>
 
     <ECEntityClass typeName="LayeredStructure" displayLabel="Layered Structure" description="LayeredStructure for use in OpenSite+. A bis:PhysicalElement that assembles multiple layers.">
@@ -1419,15 +1419,15 @@
     <ECEntityClass typeName="CurbType" displayLabel="Curb Type" description="Defines a shared set of properties whose values vary per-type of Curb rather than per-instance.">
         <BaseClass>cvphys:CurbType</BaseClass>
 
-        <ECProperty propertyName="PanWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Pan Width" description="Width of curb pan." />
-        <ECProperty propertyName="PanThickness" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Pan Thickness" description="Thickness of curb pan." />
-        <ECProperty propertyName="StoneExtension" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Stone Extension" description="Width of stone extension." />
-        <ECProperty propertyName="StoneThickness" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Stone Thickness" description="Thickness of stone extension." />
-        <ECProperty propertyName="CurbHeight" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Height" description="Height of curb." />
-        <ECProperty propertyName="CurbTopWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Top Width" description="Width of curb top." />
-        <ECProperty propertyName="CurbBottomWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Bottom Width" description="Width of curb bottom." />
-        <ECProperty propertyName="MiterWidth" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Miter Width" description="Width of curb miter." />
-        <ECProperty propertyName="MiterHeight" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Miter Height" description="Height of curb miter." />
+        <ECProperty propertyName="PanWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Pan Width" description="Width of curb pan." />
+        <ECProperty propertyName="PanThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Pan Thickness" description="Thickness of curb pan." />
+        <ECProperty propertyName="StoneExtension" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Stone Extension" description="Width of stone extension." />
+        <ECProperty propertyName="StoneThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Stone Thickness" description="Thickness of stone extension." />
+        <ECProperty propertyName="CurbHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Height" description="Height of curb." />
+        <ECProperty propertyName="CurbTopWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Top Width" description="Width of curb top." />
+        <ECProperty propertyName="CurbBottomWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Bottom Width" description="Width of curb bottom." />
+        <ECProperty propertyName="MiterWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Miter Width" description="Width of curb miter." />
+        <ECProperty propertyName="MiterHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Miter Height" description="Height of curb miter." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="WireOwnsContourLinesAspect" modifier="Sealed" strength="embedding">
@@ -1453,14 +1453,14 @@
     <ECEntityClass typeName="EdgeParkingAspect" modifier="Sealed" displayLabel="Parking">
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
-        <ECProperty propertyName="ParkingWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Parking Width" description="Parking space width." />
-        <ECProperty propertyName="ParkingDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Parking Depth" description="Parking space depth." />
-        <ECProperty propertyName="ParkingAngle" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeParkingAspect_Parking" displayLabel="Parking Angle" description="Parking space angle." />
-        <ECProperty propertyName="MaxParkingOffset" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Max. Parking Offset" />
+        <ECProperty propertyName="ParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Parking Width" description="Parking space width." />
+        <ECProperty propertyName="ParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Parking Depth" description="Parking space depth." />
+        <ECProperty propertyName="ParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeParkingAspect_Parking" displayLabel="Parking Angle" description="Parking space angle." />
+        <ECProperty propertyName="MaxParkingOffset" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Max. Parking Offset" />
         <ECProperty propertyName="IgnoreProblems" typeName="boolean" category="EdgeParkingAspect_Parking" displayLabel="Ignore Problems" />
-        <ECProperty propertyName="ParksPerIsland" typeName="int" category="EdgeParkingAspect_Parking" displayLabel="Count Per Island" description="Parking space count between islands." />
-        <ECProperty propertyName="IslandWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Island Width" description="Width of parking islands." />
-        <ECProperty propertyName="IslandCurbRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Island Curb Radius" description="Curb radius for parking islands." />
+        <ECProperty propertyName="ParksPerIsland" minimumValue="0" maximumValue="1000" typeName="int" category="EdgeParkingAspect_Parking" displayLabel="Count Per Island" description="Parking space count between islands." />
+        <ECProperty propertyName="IslandWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Island Width" description="Width of parking islands." />
+        <ECProperty propertyName="IslandCurbRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeParkingAspect_Parking" displayLabel="Island Curb Radius" description="Curb radius for parking islands." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="PropertyEdgeOwnsParkingAspect" modifier="Sealed" strength="embedding">
@@ -1516,12 +1516,12 @@
     <ECEntityClass typeName="EdgeOnSideParkingAspect" modifier="Sealed" displayLabel="Onside Parking">
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
-        <ECProperty propertyName="OnSideParkingWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Width" description="Onside parking space width for this side of driveway." />
-        <ECProperty propertyName="OnSideParkingDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Depth" description="Onside parking space depth for this side of driveway." />
-        <ECProperty propertyName="OnSideParkingAngle" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Angle" description="Onside parking space angle for this side of driveway." />
-        <ECProperty propertyName="OnSideParksPerIsland" typeName="int" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parks Per Island" description="Onside parking space count per island on this side of driveway." />
-        <ECProperty propertyName="OnSideIslandWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Island Width" description="Onside parking island width for this side of driveway." />
-        <ECProperty propertyName="OnSideIslandCurbRadius" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Curb Radius" description="Onside parking island curb radius for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Width" description="Onside parking space width for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingDepth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Depth" description="Onside parking space depth for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingAngle" minimumValue="-1.5707963267948966" maximumValue="1.5707963267948966" typeName="double" kindOfQuantity="cvu:ANGLE" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parking Angle" description="Onside parking space angle for this side of driveway." />
+        <ECProperty propertyName="OnSideParksPerIsland" minimumValue="0" maximumValue="1000" typeName="int" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Parks Per Island" description="Onside parking space count per island on this side of driveway." />
+        <ECProperty propertyName="OnSideIslandWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Island Width" description="Onside parking island width for this side of driveway." />
+        <ECProperty propertyName="OnSideIslandCurbRadius" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeOnSideParkingAspect_Parking" displayLabel="Onside Curb Radius" description="Onside parking island curb radius for this side of driveway." />
 
         <ECProperty propertyName="OnSideParkingSurfaceType" typeName="SurfaceType" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Type" description="Onside parking surface type for this side of driveway." >
             <ECCustomAttributes>
@@ -1531,7 +1531,7 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="OnSideParkingSurfaceDepth" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Depth" description="Onside parking material depth for this side of driveway." >
+        <ECProperty propertyName="OnSideParkingSurfaceDepth" minimumValue="-30.48" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Surface Depth" description="Onside parking material depth for this side of driveway." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -1540,8 +1540,8 @@
             </ECCustomAttributes>
         </ECProperty>
         <ECNavigationProperty propertyName="LayeredStructureType" relationshipName="EdgeOnSideParkingAspectUsesLayeredStructureType" direction="Forward" category="EdgeOnSideParkingAspect_Grading" displayLabel="Layered Structure Type" />
-        <ECProperty propertyName="OnSideParkingMinSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Min. Slope" description="Onside parking minimum design slope for this side of driveway." />
-        <ECProperty propertyName="OnSideParkingMaxSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Max. Slope" description="Onside parking maximum design slope for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingMinSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Min. Slope" description="Onside parking minimum design slope for this side of driveway." />
+        <ECProperty propertyName="OnSideParkingMaxSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeOnSideParkingAspect_Grading" displayLabel="Onside Parking Max. Slope" description="Onside parking maximum design slope for this side of driveway." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="DrivewayPathFinOwnsOnSideParkingAspect" modifier="Sealed" strength="embedding">
@@ -1566,9 +1566,9 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="SidewalkWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Width" description="Width of sidewalk." />
-        <ECProperty propertyName="SidewalkOffset" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Offset" description="Offset distance for sidewalk." />
-        <ECProperty propertyName="SidewalkDepth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Depth" description="Depth of sidewalk material." >
+        <ECProperty propertyName="SidewalkWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Width" description="Width of sidewalk." />
+        <ECProperty propertyName="SidewalkOffset" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Offset" description="Offset distance for sidewalk." />
+        <ECProperty propertyName="SidewalkDepth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Depth" description="Depth of sidewalk material." >
             <ECCustomAttributes>
                 <HiddenProperty xmlns="CoreCustomAttributes.01.00.03" />
                 <Deprecated xmlns="CoreCustomAttributes.01.00.03">
@@ -1576,8 +1576,8 @@
                 </Deprecated>
             </ECCustomAttributes>
         </ECProperty>
-        <ECProperty propertyName="MinSidewalkSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Min. Slope" description="Minimum allowable sidewalk slope." />
-        <ECProperty propertyName="MaxSidewalkSlope" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Max. Slope" description="Maximum allowable sidewalk slope." />
+        <ECProperty propertyName="MinSidewalkSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Min. Slope" description="Minimum allowable sidewalk slope." />
+        <ECProperty propertyName="MaxSidewalkSlope" minimumValue="0" maximumValue="10" typeName="double" kindOfQuantity="cvu:SLOPE" category="EdgeSidewalkAspect_Sidewalk" displayLabel="Max. Slope" description="Maximum allowable sidewalk slope." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="BuildingEdgeOwnsSidewalkAspect" modifier="Sealed" strength="embedding">
@@ -1706,7 +1706,7 @@
     <ECEntityClass typeName="EdgeAisleAspect" modifier="Sealed" displayLabel="Aisle">
         <BaseClass>bis:ElementUniqueAspect</BaseClass>
 
-        <ECProperty propertyName="AisleWidth" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeAisleAspect_Aisle" displayLabel="Aisle Width" description="Aisle width for parking." />
+        <ECProperty propertyName="AisleWidth" minimumValue="0" maximumValue="304.8" typeName="double" kindOfQuantity="cvu:LENGTH" category="EdgeAisleAspect_Aisle" displayLabel="Aisle Width" description="Aisle width for parking." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="PropertyEdgeOwnsAisleAspect" modifier="Sealed" strength="embedding">
@@ -1892,14 +1892,14 @@
         <BaseClass>BaseSurfaceControlVertex</BaseClass>
 
         <ECProperty propertyName="VertexType" typeName="SurfaceControlVertexType" description="Specifies the type of control vertex used." displayLabel="Control Vertex Type" category="SurfaceControl"/>
-        <ECProperty propertyName="Slope" typeName="double" description="Slope of the line emanating from this vertex position." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="SlopeBehind" typeName="double" description="Slope behind the line emanating from this vertex position." displayLabel="Slope Behind" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="MinSlope" typeName="double" description="Minimum slope constraint." displayLabel="Min. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
-        <ECProperty propertyName="MaxSlope" typeName="double" description="Maximum slope constraint." displayLabel="Max. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="Slope" minimumValue="0" maximumValue="10" typeName="double" description="Slope of the line emanating from this vertex position." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="SlopeBehind" minimumValue="0" maximumValue="10" typeName="double" description="Slope behind the line emanating from this vertex position." displayLabel="Slope Behind" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="MinSlope" minimumValue="0" maximumValue="10" typeName="double" description="Minimum slope constraint." displayLabel="Min. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="MaxSlope" minimumValue="0" maximumValue="10" typeName="double" description="Maximum slope constraint." displayLabel="Max. Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
         <ECProperty propertyName="Direction" typeName="point2d" description="Direction of the line emanating from this vertex position that constrains the elevation interpolation." displayLabel="Direction" category="SurfaceControl"/>
         <ECProperty propertyName="Mirrored" typeName="boolean" description="True if the direction constraint should represent two lines emanating from the position, forming a V shape, or false if it should be a single line passing through the position." displayLabel="Mirrored" category="SurfaceControl"/>
-        <ECProperty propertyName="ClampDistance" typeName="double" description="Distance at which to clamp slope calculations, turning elevation into a piecewise function where it stays constant beyond this distance." displayLabel="Clamp Distance" category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
-        <ECProperty propertyName="ClampDistanceBehind" typeName="double" description="Distance at which to clamp slope calculations in opposite direction, turning elevation into a piecewise function where it stays constant beyond this distance" displayLabel="Clamp Distance Behind" category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
+        <ECProperty propertyName="ClampDistance" minimumValue="0" maximumValue="304.8" typeName="double" description="Distance at which to clamp slope calculations, turning elevation into a piecewise function where it stays constant beyond this distance." displayLabel="Clamp Distance" category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
+        <ECProperty propertyName="ClampDistanceBehind" minimumValue="0" maximumValue="304.8" typeName="double" description="Distance at which to clamp slope calculations in opposite direction, turning elevation into a piecewise function where it stays constant beyond this distance" displayLabel="Clamp Distance Behind" category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
     </ECEntityClass>
 
     <ECEntityClass typeName="SurfaceControlPathVertex" description="A vertex that forms a control path, which emits control points along the path." displayLabel="Surface Control Path Vertex">
@@ -2012,14 +2012,14 @@
     <ECEntityClass typeName="SurfaceControlVertexSlopeRule" description="Constrains two surface control vertices to lie on the same line defined by the slope between them." displayLabel="Surface Control Vertex Slope Rule" modifier="Sealed">
         <BaseClass>SurfaceControlVertexRule</BaseClass>
 
-        <ECProperty propertyName="ControlVertexSlope" typeName="double" description="Slope defined by a control vertex override." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="ControlVertexSlope" minimumValue="0" maximumValue="10" typeName="double" description="Slope defined by a control vertex override." displayLabel="Slope" category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
     </ECEntityClass>
 
     <ECEntityClass typeName="SurfaceControlDitchRule" description="Models a ditch-like parametric template that is applied to a control path." displayLabel="Surface Control Ditch Rule" modifier="Sealed" >
         <BaseClass>SurfaceControlRule</BaseClass>
 
         <ECProperty propertyName="Interval" typeName="double" description="Drop interval along the path." category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
-        <ECProperty propertyName="Slope" typeName="double" description="Slope of the line emanating from the path on the right-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
+        <ECProperty propertyName="Slope" minimumValue="0" maximumValue="10" typeName="double" description="Slope of the line emanating from the path on the right-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
         <ECProperty propertyName="LeftSlope" typeName="double" description="Slope of the line emanating from the path on the left-side." category="SurfaceControl" kindOfQuantity="cvu:SLOPE"/>
         <ECProperty propertyName="Offset" typeName="double" description="Offset from the right-side of the path to attenuate the influence of the ditch elevation." category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>
         <ECProperty propertyName="LeftOffset" typeName="double" description="Offset from the left-side of the path to attenuate the influence of the ditch elevation." category="SurfaceControl" kindOfQuantity="cvu:LENGTH"/>


### PR DESCRIPTION
- Define some loose constraints for most property values in the OpenSite+ schema, to prevent values that don't make any sense
    - For instance, parking space depth on a parking lot cannot be a negative number