### PR TITLE
Release OpenSite 24

### DIFF
--- a/Domains/4-Application/OpenSite/Released/OpenSite.01.00.24.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSite.01.00.24.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.25" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.24" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
@@ -16,7 +16,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6705,7 +6705,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.24",
+      "version": "01.00.25",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",
@@ -7043,6 +7043,21 @@
       "dynamic": "No",
       "approved": "Yes",
       "localizations": []
+    },
+    {
+      "name": "OpenSite",
+      "path": "Domains\\4-Application\\OpenSite\\Released\\OpenSite.01.00.24.ecschema.xml",
+      "released": true,
+      "version": "01.00.24",
+      "localizations": [],
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "4714eb725efc815814f86266de7a1e64f324cd05",
+      "verified": "Yes",
+      "author": "Danny.Lewis",
+      "date": "7/15/2026",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ],
   "OpenSiteDraft": [


### PR DESCRIPTION
Release OpenSite v24, which contains the following changes:
- Adds min/max values to most property values to help alleviate bad data
  - For instance, most length properties (parking depth, parking width, etc) now have a lower bound of 0, since a negative number simply doesn't make sense for these properties