### PR TITLE
Add PlanDrawingRecipe to DPSS

### DIFF
--- a/Domains/4-Application/DrawingProduction/DrawingProductionForSubstation.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProductionForSubstation.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="DrawingProductionForSubstation" alias="dpfss" version="01.00.01"
+<ECSchema schemaName="DrawingProductionForSubstation" alias="dpfss" version="01.00.02"
     xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2"
     description="Drawing Production schema for Substation related concepts (Substation+).">
     <ECSchemaReference name="DrawingProduction" version="01.00.00" alias="dp" />

--- a/Domains/4-Application/DrawingProduction/Released/DrawingProductionForSubstation.01.00.01.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/Released/DrawingProductionForSubstation.01.00.01.ecschema.xml
@@ -12,7 +12,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -8083,7 +8083,7 @@
       "name": "DrawingProductionForSubstation",
       "path": "Domains\\4-Application\\DrawingProduction\\DrawingProductionForSubstation.ecschema.xml",
       "released": false,
-      "version": "01.00.00",
+      "version": "01.00.01",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",
@@ -8106,6 +8106,21 @@
       "dynamic": "No",
       "approved": "Yes",
       "localizations": []
+    },
+    {
+      "name": "DrawingProductionForSubstation",
+      "path": "Domains\\4-Application\\DrawingProduction\\Released\\DrawingProductionForSubstation.01.00.01.ecschema.xml",
+      "released": true,
+      "version": "01.00.01",
+      "localizations": [],
+      "comment": "Added PlanDrawingRecipe",
+      "verifier": "",
+      "sha1": "627f26292a564dca72c70321f19043fe64a687c5",
+      "verified": "Yes",
+      "author": "Will.Bentley",
+      "date": "7/22/2026",
+      "dynamic": "No",
+      "approved": "Yes"
     }
   ]
 }

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -8083,7 +8083,7 @@
       "name": "DrawingProductionForSubstation",
       "path": "Domains\\4-Application\\DrawingProduction\\DrawingProductionForSubstation.ecschema.xml",
       "released": false,
-      "version": "01.00.01",
+      "version": "01.00.02",
       "comment": "Working Copy",
       "sha1": "",
       "author": "",


### PR DESCRIPTION
Added `PlanDrawingRecipe` to DrawingProductionForSubstation. This was missed in 01.00.00.