### PR TITLE
Add KOQ for Scale Bars

### DIFF
--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -50,8 +50,7 @@
     <ECEntityClass typeName="ScaleBarCallout" displayLabel="Scale Bar Callout" modifier="None"
         description="A bis:AnnotationElement2d that displays a scale bar on a sheet.">
         <BaseClass>bis:AnnotationElement2d</BaseClass>
-        <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
-        <ECProperty propertyName="Scale" typeName="double" displayLabel="Scale" kindOfQuantity="SCALE_VALUE" />
+        <ECProperty propertyName="Scale" typeName="double" displayLabel="Scale" kindOfQuantity="SCALE_VALUE" description="The scale factor the scale bar was created at." />
     </ECEntityClass>
 
     <ECEntityClass typeName="ScaleBarCalloutDefinition" displayLabel="Scale Bar Callout Definition" modifier="None"

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -9,6 +9,11 @@
     <ECSchemaReference name="BisCore" version="01.00.25" alias="bis" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA" />
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA" />
+    <ECSchemaReference name="Units" version="01.00.00" alias="u" />
+    <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
+
+    <KindOfQuantity typeName="ScaleValue" displayLabel="Scale Value" persistenceUnit="u:COEFFICIENT" relativeError="0.0" description="A kind of quantity for scale values." />
+    <KindOfQuantity typeName="ScaleBarLength" displayLabel="Scale Bar Length" persistenceUnit="u:M" presentationUnits="f:DefaultReal(2)[u:IN];f:DefaultReal(2)[u:MM]" relativeError="0.0" description="The physical length of a scale bar on a sheet." />
     
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -47,6 +52,7 @@
         description="A bis:AnnotationElement2d that displays a scale bar on a sheet.">
         <BaseClass>bis:AnnotationElement2d</BaseClass>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
+        <ECProperty propertyName="Scale" typeName="double" displayLabel="Scale" kindOfQuantity="ScaleValue" />
     </ECEntityClass>
 
     <ECEntityClass typeName="ScaleBarCalloutDefinition" displayLabel="Scale Bar Callout Definition" modifier="None"
@@ -54,6 +60,7 @@
         <BaseClass>bis:GraphicalType2d</BaseClass>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
         <ECProperty propertyName="Description" typeName="string" description="Description of the style" />
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" kindOfQuantity="ScaleBarLength" description="The physical length of the scale bar on the sheet." />
         <ECNavigationProperty propertyName="TextStyle" relationshipName="ScaleBarStyleUsesTextStyle" direction="Forward" displayLabel="Text Style" description="The bis:AnnotationTextStyle used by the ScaleBarCalloutDefinition."/>
     </ECEntityClass>
     

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -9,7 +9,7 @@
     <ECSchemaReference name="BisCore" version="01.00.25" alias="bis" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA" />
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA" />
-    <ECSchemaReference name="Units" version="01.00.00" alias="u" />
+    <ECSchemaReference name="Units" version="01.00.10" alias="u" />
     <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
 
     <KindOfQuantity typeName="ScaleValue" displayLabel="Scale Value" persistenceUnit="u:COEFFICIENT" relativeError="0.0" description="A kind of quantity for scale values." />

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -11,7 +11,6 @@
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA" />
     <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU" />
     <ECSchemaReference name="Units" version="01.00.10" alias="u" />
-    <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
 
     <KindOfQuantity typeName="SCALE_VALUE" displayLabel="Scale Value" persistenceUnit="u:M_PER_M" relativeError="0.0" description="A kind of quantity for scale values." />
     

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -9,11 +9,11 @@
     <ECSchemaReference name="BisCore" version="01.00.25" alias="bis" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA" />
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.04" alias="CoreCA" />
+    <ECSchemaReference name="AecUnits" version="01.00.03" alias="AECU" />
     <ECSchemaReference name="Units" version="01.00.10" alias="u" />
     <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
 
     <KindOfQuantity typeName="SCALE_VALUE" displayLabel="Scale Value" persistenceUnit="u:COEFFICIENT" relativeError="0.0" description="A kind of quantity for scale values." />
-    <KindOfQuantity typeName="SCALE_BAR_LENGTH" displayLabel="Scale Bar Length" persistenceUnit="u:M" presentationUnits="f:DefaultReal(2)[u:IN];f:DefaultReal(2)[u:MM]" relativeError="0.0" description="The physical length of a scale bar on a sheet." />
     
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -60,7 +60,7 @@
         <BaseClass>bis:GraphicalType2d</BaseClass>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
         <ECProperty propertyName="Description" typeName="string" description="Description of the style" />
-        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" kindOfQuantity="SCALE_BAR_LENGTH" description="The physical length of the scale bar on the sheet." />
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" kindOfQuantity="AECU:LENGTH_SHORT" description="The physical length of the scale bar on the sheet." />
         <ECNavigationProperty propertyName="TextStyle" relationshipName="ScaleBarStyleUsesTextStyle" direction="Forward" displayLabel="Text Style" description="The bis:AnnotationTextStyle used by the ScaleBarCalloutDefinition."/>
     </ECEntityClass>
     

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -12,8 +12,8 @@
     <ECSchemaReference name="Units" version="01.00.10" alias="u" />
     <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
 
-    <KindOfQuantity typeName="ScaleValue" displayLabel="Scale Value" persistenceUnit="u:COEFFICIENT" relativeError="0.0" description="A kind of quantity for scale values." />
-    <KindOfQuantity typeName="ScaleBarLength" displayLabel="Scale Bar Length" persistenceUnit="u:M" presentationUnits="f:DefaultReal(2)[u:IN];f:DefaultReal(2)[u:MM]" relativeError="0.0" description="The physical length of a scale bar on a sheet." />
+    <KindOfQuantity typeName="SCALE_VALUE" displayLabel="Scale Value" persistenceUnit="u:COEFFICIENT" relativeError="0.0" description="A kind of quantity for scale values." />
+    <KindOfQuantity typeName="SCALE_BAR_LENGTH" displayLabel="Scale Bar Length" persistenceUnit="u:M" presentationUnits="f:DefaultReal(2)[u:IN];f:DefaultReal(2)[u:MM]" relativeError="0.0" description="The physical length of a scale bar on a sheet." />
     
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
@@ -52,7 +52,7 @@
         description="A bis:AnnotationElement2d that displays a scale bar on a sheet.">
         <BaseClass>bis:AnnotationElement2d</BaseClass>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
-        <ECProperty propertyName="Scale" typeName="double" displayLabel="Scale" kindOfQuantity="ScaleValue" />
+        <ECProperty propertyName="Scale" typeName="double" displayLabel="Scale" kindOfQuantity="SCALE_VALUE" />
     </ECEntityClass>
 
     <ECEntityClass typeName="ScaleBarCalloutDefinition" displayLabel="Scale Bar Callout Definition" modifier="None"
@@ -60,7 +60,7 @@
         <BaseClass>bis:GraphicalType2d</BaseClass>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
         <ECProperty propertyName="Description" typeName="string" description="Description of the style" />
-        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" kindOfQuantity="ScaleBarLength" description="The physical length of the scale bar on the sheet." />
+        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" kindOfQuantity="SCALE_BAR_LENGTH" description="The physical length of the scale bar on the sheet." />
         <ECNavigationProperty propertyName="TextStyle" relationshipName="ScaleBarStyleUsesTextStyle" direction="Forward" displayLabel="Text Style" description="The bis:AnnotationTextStyle used by the ScaleBarCalloutDefinition."/>
     </ECEntityClass>
     

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -59,7 +59,6 @@
         <BaseClass>bis:GraphicalType2d</BaseClass>
         <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for a scale bar in a versioned JSON format." />
         <ECProperty propertyName="Description" typeName="string" description="Description of the style" />
-        <ECProperty propertyName="Length" typeName="double" displayLabel="Length" kindOfQuantity="AECU:LENGTH_SHORT" description="The physical length of the scale bar on the sheet." />
         <ECNavigationProperty propertyName="TextStyle" relationshipName="ScaleBarStyleUsesTextStyle" direction="Forward" displayLabel="Text Style" description="The bis:AnnotationTextStyle used by the ScaleBarCalloutDefinition."/>
     </ECEntityClass>
     

--- a/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
+++ b/Domains/4-Application/DrawingProduction/DrawingProduction.ecschema.xml
@@ -13,7 +13,7 @@
     <ECSchemaReference name="Units" version="01.00.10" alias="u" />
     <ECSchemaReference name="Formats" version="01.00.00" alias="f" />
 
-    <KindOfQuantity typeName="SCALE_VALUE" displayLabel="Scale Value" persistenceUnit="u:COEFFICIENT" relativeError="0.0" description="A kind of quantity for scale values." />
+    <KindOfQuantity typeName="SCALE_VALUE" displayLabel="Scale Value" persistenceUnit="u:M_PER_M" relativeError="0.0" description="A kind of quantity for scale values." />
     
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">


### PR DESCRIPTION
Added `KindOfQuantity` for `ScaleValue` and a `Length` property on `ScaleBarCalloutDefinition`.

All formatting of the scale value is done during runtime by building a FormatterSpec. This is because the `presentationUnits` does not currently support ratios. 