### PR TITLE
Add LastElevationValue property to RelativeElevation class in SubstationInformation

### DIFF
--- a/Domains/4-Application/Substation/SubstationInformation.ecschema.xml
+++ b/Domains/4-Application/Substation/SubstationInformation.ecschema.xml
@@ -32,6 +32,6 @@
   <ECEntityClass typeName="RelativeElevation" displayLabel="Relative Elevation" description="An element that holds Relative Elevation information." modifier="None">
     <BaseClass>bis:InformationRecordElement</BaseClass>
     <ECProperty propertyName="ElevationPoint" typeName="Point3d" description="ElevationPoint."/>
-    <ECProperty propertyName="RelativeElevation" typeName="double" displayLabel="Relative Elevation" description="Last reveal height, in meters, used when placing foundations with the Fixed Reveal method."/>
+    <ECProperty propertyName="LastElevationValue" typeName="double" displayLabel="Last Elevation Value" description="Last reveal height, in meters, used when placing foundations with the Fixed Reveal method."/>
   </ECEntityClass>
 </ECSchema>

--- a/Domains/4-Application/Substation/SubstationInformation.ecschema.xml
+++ b/Domains/4-Application/Substation/SubstationInformation.ecschema.xml
@@ -31,6 +31,7 @@
   </ECEntityClass>
   <ECEntityClass typeName="RelativeElevation" displayLabel="Relative Elevation" description="An element that holds Relative Elevation information." modifier="None">
     <BaseClass>bis:InformationRecordElement</BaseClass>
-    <ECProperty propertyName="ElevationPoint" typeName="Point3d" description="ElevationPoint."/>    
+    <ECProperty propertyName="ElevationPoint" typeName="Point3d" description="ElevationPoint."/>
+    <ECProperty propertyName="RelativeElevation" typeName="double" displayLabel="Relative Elevation" description="Last reveal height, in meters, used when placing foundations with the Fixed Reveal method."/>
   </ECEntityClass>
 </ECSchema>


### PR DESCRIPTION
Adds a new `LastElevationValue` property to the `RelativeElevation` class in the `SubstationInformation` schema (WIP version `01.00.06`).
