### PR TITLE
DgnConnector schema

### DIFF
--- a/Domains/4-Application/Connectors/DgnConnector/DgnConnector.ecschema.xml
+++ b/Domains/4-Application/Connectors/DgnConnector/DgnConnector.ecschema.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ==================================================================================
+|  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+|  * See LICENSE.md in the project root for license terms and full copyright notice.
+======================================================================================= -->
+<ECSchema schemaName="DgnConnector" alias="dgnconn" version="01.00.00" description="ECClasses that capture concepts specific to the Dgn format" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="BisCore" version="01.00.00" alias="bis" />
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.00" alias="CoreCA"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+
+    <ECCustomAttributes>
+        <DynamicSchema xmlns="CoreCustomAttributes.01.00.00"/>
+        <ProductionStatus xmlns="CoreCustomAttributes.01.00.00">
+            <SupportedUse>NotForProduction</SupportedUse>
+        </ProductionStatus>
+        <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
+            <Value>Application</Value>
+        </SchemaLayerInfo>
+    </ECCustomAttributes>
+
+    <ECCustomAttributeClass typeName="ItemTypeCalculatedProperty" appliesTo="AnyProperty" description="Metadata associated to a Calculated Property in an ItemType." modifier="Sealed">
+        <ECProperty propertyName="Expression" typeName="string" description="The expression used to calculate the associated Calculated Property in an ItemType." />
+    </ECCustomAttributeClass>
+</ECSchema>


### PR DESCRIPTION
Proposal for a schema to capture dgn-specific concepts that are not directly converted into BIS core but are still needed to be synchronized to iModels.