### PR TITLE
Add Pan Slope to OpenSite.CurbType and fix its KoQs

### DIFF
--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -1637,15 +1637,16 @@
     <ECEntityClass typeName="CurbType" displayLabel="Curb Type" description="Defines a shared set of properties whose values vary per-type of Curb rather than per-instance.">
         <BaseClass>cvphys:CurbType</BaseClass>
 
-        <ECProperty propertyName="PanWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Pan Width" description="Width of curb pan." />
-        <ECProperty propertyName="PanThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Pan Thickness" description="Thickness of curb pan." />
-        <ECProperty propertyName="StoneExtension" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Stone Extension" description="Width of stone extension." />
-        <ECProperty propertyName="StoneThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Stone Thickness" description="Thickness of stone extension." />
-        <ECProperty propertyName="CurbHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Height" description="Height of curb." />
-        <ECProperty propertyName="CurbTopWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Top Width" description="Width of curb top." />
-        <ECProperty propertyName="CurbBottomWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Curb Bottom Width" description="Width of curb bottom." />
-        <ECProperty propertyName="MiterWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Miter Width" description="Width of curb miter." />
-        <ECProperty propertyName="MiterHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH" displayLabel="Miter Height" description="Height of curb miter." />
+        <ECProperty propertyName="PanWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Pan Width" description="Width of curb pan." />
+        <ECProperty propertyName="PanThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Pan Thickness" description="Thickness of curb pan." />
+        <ECProperty propertyName="StoneExtension" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Stone Extension" description="Width of stone extension." />
+        <ECProperty propertyName="StoneThickness" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Stone Thickness" description="Thickness of stone extension." />
+        <ECProperty propertyName="CurbHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Curb Height" description="Height of curb." />
+        <ECProperty propertyName="CurbTopWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Curb Top Width" description="Width of curb top." />
+        <ECProperty propertyName="CurbBottomWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Curb Bottom Width" description="Width of curb bottom." />
+        <ECProperty propertyName="MiterWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Miter Width" description="Width of curb miter." />
+        <ECProperty propertyName="MiterHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Miter Height" description="Height of curb miter." />
+        <ECProperty propertyName="PanSlope" minimumValue="-.1" maximumValue=".1" typeName="double" kindOfQuantity="cvu:SLOPE" displayLabel="Pan Slope" description="Slope of curb pan." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="WireOwnsContourLinesAspect" modifier="Sealed" strength="embedding">

--- a/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
+++ b/Domains/4-Application/OpenSite/OpenSite.ecschema.xml
@@ -1646,7 +1646,7 @@
         <ECProperty propertyName="CurbBottomWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Curb Bottom Width" description="Width of curb bottom." />
         <ECProperty propertyName="MiterWidth" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Miter Width" description="Width of curb miter." />
         <ECProperty propertyName="MiterHeight" minimumValue="0" maximumValue="30.48" typeName="double" kindOfQuantity="cvu:LENGTH_SHORT" displayLabel="Miter Height" description="Height of curb miter." />
-        <ECProperty propertyName="PanSlope" minimumValue="-.1" maximumValue=".1" typeName="double" kindOfQuantity="cvu:SLOPE" displayLabel="Pan Slope" description="Slope of curb pan." />
+        <ECProperty propertyName="PanSlope" minimumValue="-0.1" maximumValue="0.1" typeName="double" kindOfQuantity="cvu:SLOPE" displayLabel="Pan Slope" description="Slope of curb pan." />
     </ECEntityClass>
 
     <ECRelationshipClass typeName="WireOwnsContourLinesAspect" modifier="Sealed" strength="embedding">


### PR DESCRIPTION
Added "Pan Slope" OpenSite.CurbType

Previously the other length properties were incorrectly set to Civil lengths and have been updated to short length.

This diagram demonstrates pan slope, as well as how lengths were previously being displayed as ft when they should be in inches.

<img width="1384" height="755" alt="image" src="https://github.com/user-attachments/assets/521c42f9-39a8-4f8d-a786-2f29233f1aca" />
