### PR TITLE
Resolve released baseline schema references against Released directories only when comparing schemas

### DIFF
--- a/tools/SchemaDifference/SchemaDifferenceRunner.js
+++ b/tools/SchemaDifference/SchemaDifferenceRunner.js
@@ -31,6 +31,8 @@ process.on("unhandledRejection", err => {
 async function compareSchemas() {
   const schemas = await getAllSchemas();
   const refPaths = getRefpaths(schemas)
+  // The released schema's reference closure must be resolved using only released schema directories.
+  const releasedRefPaths = getRefpaths(schemas, true);
   let hasErrors = false;
 
   const outputPath = getOutputPath();
@@ -57,10 +59,9 @@ async function compareSchemas() {
       continue;
     }
 
-    console.log(`Found latest ${schema.name} schema at ${releasedSchema.fullPath}.`)
-
+    console.log(`Found latest ${schema.name} schema at ${releasedSchema.fullPath}.`);
     
-    const options = new CompareOptions(releasedSchema.fullPath, schema.fullPath, refPaths, refPaths, outputPath);
+    const options = new CompareOptions(releasedSchema.fullPath, schema.fullPath, releasedRefPaths, refPaths, outputPath);
     const results = await SchemaComparison.compare(options);
     if (processResults(releasedSchema, schema, results))
       hasErrors = true;
@@ -104,9 +105,12 @@ function reportWarning(message) {
   console.log(chalk.yellow(`\"##vso[task.logissue type=warning]${message}\"`));
 }
 
-function getRefpaths(schemas) {
+function getRefpaths(schemas, releasedOnly = false) {
   const referencePaths = [];
   for (const schema of schemas) {
+    if (releasedOnly && !schema.released)
+      continue;
+
     const dir = path.dirname(schema.fullPath);
     if (referencePaths.includes(dir))
       continue;

--- a/tools/SchemaDifference/SchemaDifferenceRunner.js
+++ b/tools/SchemaDifference/SchemaDifferenceRunner.js
@@ -16,7 +16,7 @@ const SchemaComparison = require("@bentley/schema-comparer").SchemaComparison;
 const CompareOptions = require("@bentley/schema-comparer").CompareOptions;
 const ComparisonResultType = require("@bentley/schema-comparer").ComparisonResultType;
 
-// Add the name(s) of schemas that should be skipped from schema differencing.
+// Add the name(s) of schemas that should be skipped from schema differencing
 const excludedSchemaNames = [
 ];
 


### PR DESCRIPTION
The `compareSchemas` check passes the same merged reference-path list (all working **and** `Released/` schema directories) to both sides of every comparison.
As a result, the **released baseline** schema's reference closure can absorb the **working (versionless) schema files**.

This surfaced on a branch [PR](https://github.com/iTwin/bis-schemas/pull/779) where working Substation schemas were re-pointed to `PowerSystemResourcesPhysical 02.00.00`.
The released `1.0.5` baselines transitively required **both** PSRP `01.00.01` (direct reference) and PSRP `02.00.00` (via the
substituted working `SubstationPhysical 1.0.6`).
The deserializer's schema-cache lookup then bound the 2.0.0 XML to the cached 1.0.1 schema, failing six schema comparisons with the misleading error:

    Unable to locate SchemaItem PowerSystemResourcesPhysical.ElectricalPortConnection