### PR TITLE
Resolve released baseline schema references against Released directories only when comparing schemas

### DIFF
--- a/tools/SchemaValidation/iModelSchemaValidation.js
+++ b/tools/SchemaValidation/iModelSchemaValidation.js
@@ -86,6 +86,8 @@ async function schemaUpgradeTest(ignoreList, output) {
   const testSchemas = getShortListedVersions(releasedSchemas.reverse(), wipSchemas, output);
 
   let schemaDirs = await generateSchemaDirectoryList(bisSchemaRepo);
+  // Released schemas must resolve their references against released directories only.
+  const releasedSchemaDirs = schemaDirs.slice();
   schemaDirs = schemaDirs.concat(wipSchemas.map((schemaPath) => path.dirname(schemaPath)));
 
   let imodel;
@@ -114,7 +116,7 @@ async function schemaUpgradeTest(ignoreList, output) {
       batchStarted = true;
     }
 
-    imodel = await importAndExportSchemaToIModel(schema, schemaDirs, batchStarted, imodel, output);
+    imodel = await importAndExportSchemaToIModel(schema, isWIP ? schemaDirs : releasedSchemaDirs, batchStarted, imodel, output);
     results[schemaName].push({name: schemaName, batch: key.readVersion, batchStarted, version: schemaVersion});
     console.log("-> ", chalk.green(`${schemaName}.${schemaVersion} successfully imported.`));
     writeLogsToFile(`-> ${schemaName}.${schemaVersion} successfully imported.\n\n`, output);


### PR DESCRIPTION
Similar to the fix made in https://github.com/iTwin/bis-schemas/pull/787, but for the iModelSchemaValidation command instead.

The [PR pipeline](https://github.com/iTwin/bis-schemas/pull/779) failed with the error:
```
2026-09-03T11:23:32.4589361Z Schema: D:/a/1/s/Domains/4-Application/Substation/Released/SubstationParts.01.00.05.ecschema.xml
2026-09-03T11:23:33.1079743Z Error (35055): The schema, PowerSystemResourcesPhysical.02.00.00, already exists within this cache.
2026-09-03T11:23:33.1081131Z     at SchemaCache.addSchemaSync (D:\a\1\s\node_modules\@itwin\ecschema-metadata\lib\cjs\Context.js:86:19)
2026-09-03T11:23:33.1082698Z     at SchemaContext.addSchemaSync (D:\a\1\s\node_modules\@itwin\ecschema-metadata\lib\cjs\Context.js:229:28)
2026-09-03T11:23:33.1089593Z     at StubSchemaXmlFileLocater.getSchemaSync (D:\a\1\s\node_modules\@itwin\ecschema-locaters\lib\cjs\StubSchemaXmlFileLocater.js:82:17)
2026-09-03T11:23:33.1094275Z     at SchemaContext.getSchemaSync (D:\a\1\s\node_modules\@itwin\ecschema-metadata\lib\cjs\Context.js:297:36)
2026-09-03T11:23:33.1095696Z     at StubSchemaXmlFileLocater.addSchemaReferences (D:\a\1\s\node_modules\@itwin\ecschema-locaters\lib\cjs\StubSchemaXmlFileLocater.js:123:49)
2026-09-03T11:23:33.1096933Z     at StubSchemaXmlFileLocater.getSchemaSync (D:\a\1\s\node_modules\@itwin\ecschema-locaters\lib\cjs\StubSchemaXmlFileLocater.js:83:14)
2026-09-03T11:23:33.1097662Z     at SchemaContext.getSchemaSync (D:\a\1\s\node_modules\@itwin\ecschema-metadata\lib\cjs\Context.js:297:36)
2026-09-03T11:23:33.1098389Z     at StubSchemaXmlFileLocater.addSchemaReferences (D:\a\1\s\node_modules\@itwin\ecschema-locaters\lib\cjs\StubSchemaXmlFileLocater.js:123:49)
2026-09-03T11:23:33.1099112Z     at StubSchemaXmlFileLocater.loadSchema (D:\a\1\s\node_modules\@itwin\ecschema-locaters\lib\cjs\StubSchemaXmlFileLocater.js:41:14)
2026-09-03T11:23:33.1100108Z     at importAndExportSchemaToIModel (D:\a\1\s\tools\SchemaValidation\iModelSchemaValidation.js:503:32) {
2026-09-03T11:23:33.1100686Z   errorNumber: 35055,
2026-09-03T11:23:33.1101171Z   _metaData: undefined
2026-09-03T11:23:33.1103943Z }
```