### PR TITLE
Add new FormatSetDefinitionElement class  to BisCore

### DIFF
--- a/Domains/0-Core/BisCore.ecschema.xml
+++ b/Domains/0-Core/BisCore.ecschema.xml
@@ -2471,6 +2471,11 @@
         </Target>
     </ECRelationshipClass> 
 
+    <ECEntityClass typeName="FormatSetDefinitionElement" modifier="Sealed" displayLabel="Format Set Definition" description="A subclass of a bis:DefinitionElement that defines a formatSet.">
+        <BaseClass>DefinitionElement</BaseClass>
+        <ECProperty propertyName="Settings" typeName="string" extendedTypeName="Json" displayLabel="Settings" description="The settings for the format set in a versioned JSON format." />
+    </ECEntityClass>
+
     <ECEntityClass typeName="LineStyle" modifier="Sealed" displayLabel="Line Style">
         <BaseClass>DefinitionElement</BaseClass>
         <ECCustomAttributes>


### PR DESCRIPTION
Introduce a bis class to persist formatSet in an iModel.

Refer https://github.com/iTwin/drawing-production/issues/4337 for more details