### PR TITLE
[OpenSite] Release v01.00.27

### DIFF
--- a/Domains/4-Application/OpenSite/Released/OpenSite.01.00.27.ecschema.xml
+++ b/Domains/4-Application/OpenSite/Released/OpenSite.01.00.27.ecschema.xml
@@ -3,7 +3,7 @@
 |  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 |  * See LICENSE.md in the project root for license terms and full copyright notice.
 ======================================================================================= -->
-<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.28" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
+<ECSchema schemaName="OpenSite" alias="opnsite" version="01.00.27" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" displayLabel="OpenSite" description="OpenSite+ application schema.">
     <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA" />
     <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
     <ECSchemaReference name="BisCore" version="01.00.10" alias="bis" />
@@ -16,7 +16,7 @@
 
     <ECCustomAttributes>
         <ProductionStatus xmlns="CoreCustomAttributes.01.00.03">
-            <SupportedUse>NotForProduction</SupportedUse>
+            <SupportedUse>FieldTesting</SupportedUse>
         </ProductionStatus>
         <SchemaLayerInfo xmlns="BisCustomAttributes.01.00.00">
             <Value>Application</Value>

--- a/SchemaInventory.json
+++ b/SchemaInventory.json
@@ -6752,7 +6752,7 @@
       "name": "OpenSite",
       "path": "Domains\\4-Application\\OpenSite\\OpenSite.ecschema.xml",
       "released": false,
-      "version": "01.00.27",
+      "version": "01.00.28",
       "comment": "Working Copy",
       "sha1": "",
       "author": "Karolis.Zukauskas",
@@ -7133,6 +7133,21 @@
       "verified": "Yes",
       "author": "Felix.Girard",
       "date": "8/25/2026",
+      "dynamic": "No",
+      "approved": "Yes"
+    },
+    {
+      "name": "OpenSite",
+      "path": "Domains\\4-Application\\OpenSite\\Released\\OpenSite.01.00.27.ecschema.xml",
+      "released": true,
+      "version": "01.00.27",
+      "localizations": [],
+      "comment": "",
+      "verifier": "Diego.Diaz",
+      "sha1": "ce75b49ae530b118194276a7bdbcd55cd1f470f8",
+      "verified": "Yes",
+      "author": "Danny.Lewis",
+      "date": "9/8/2026",
       "dynamic": "No",
       "approved": "Yes"
     }


### PR DESCRIPTION
- Releases version 01.00.27 of the OpenSite schema
- Includes changes from the following PRs:
  - https://github.com/iTwin/bis-schemas/pull/773
  - https://github.com/iTwin/bis-schemas/pull/781
  - https://github.com/iTwin/bis-schemas/pull/790